### PR TITLE
feat: add preliminary parsing of parameters

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -190,9 +190,9 @@ func TestParseToolFile(t *testing.T) {
 					statement: |
 						SELECT * FROM SQL_STATEMENT;
 					parameters:
-						country:
-							type: string
-							description: some description
+						- name: country
+						  type: string
+						  description: some description
 			`,
 			wantSources: sources.Configs{
 				"my-pg-instance": sources.CloudSQLPgConfig{
@@ -211,8 +211,9 @@ func TestParseToolFile(t *testing.T) {
 					Source:      "my-pg-instance",
 					Description: "some description",
 					Statement:   "SELECT * FROM SQL_STATEMENT;\n",
-					Parameters: map[string]tools.Parameter{
-						"country": {
+					Parameters: []tools.Parameter{
+						{
+							Name:        "country",
 							Type:        "string",
 							Description: "some description",
 						},

--- a/internal/tools/cloud_sql_pg.go
+++ b/internal/tools/cloud_sql_pg.go
@@ -26,12 +26,12 @@ const CloudSQLPgSQLGenericKind string = "cloud-sql-postgres-generic"
 var _ Config = CloudSQLPgGenericConfig{}
 
 type CloudSQLPgGenericConfig struct {
-	Name        string               `yaml:"name"`
-	Kind        string               `yaml:"kind"`
-	Source      string               `yaml:"source"`
-	Description string               `yaml:"description"`
-	Statement   string               `yaml:"statement"`
-	Parameters  map[string]Parameter `yaml:"parameters"`
+	Name        string      `yaml:"name"`
+	Kind        string      `yaml:"kind"`
+	Source      string      `yaml:"source"`
+	Description string      `yaml:"description"`
+	Statement   string      `yaml:"statement"`
+	Parameters  []Parameter `yaml:"parameters"`
 }
 
 func (r CloudSQLPgGenericConfig) toolKind() string {
@@ -53,9 +53,10 @@ func (r CloudSQLPgGenericConfig) Initialize(srcs map[string]sources.Source) (Too
 
 	// finish tool setup
 	t := CloudSQLPgGenericTool{
-		Name:   r.Name,
-		Kind:   CloudSQLPgSQLGenericKind,
-		Source: s,
+		Name:       r.Name,
+		Kind:       CloudSQLPgSQLGenericKind,
+		Source:     s,
+		Parameters: r.Parameters,
 	}
 	return t, nil
 }
@@ -64,11 +65,16 @@ func (r CloudSQLPgGenericConfig) Initialize(srcs map[string]sources.Source) (Too
 var _ Tool = CloudSQLPgGenericTool{}
 
 type CloudSQLPgGenericTool struct {
-	Name   string `yaml:"name"`
-	Kind   string `yaml:"kind"`
-	Source sources.CloudSQLPgSource
+	Name       string `yaml:"name"`
+	Kind       string `yaml:"kind"`
+	Source     sources.CloudSQLPgSource
+	Parameters []Parameter `yaml:"parameters"`
 }
 
-func (t CloudSQLPgGenericTool) Invoke() (string, error) {
-	return fmt.Sprintf("Stub tool call for %q!", t.Name), nil
+func (t CloudSQLPgGenericTool) Invoke(params []any) (string, error) {
+	return fmt.Sprintf("Stub tool call for %q! Parameters parsed: %q", t.Name, params), nil
+}
+
+func (t CloudSQLPgGenericTool) ParseParams(data map[string]any) ([]any, error) {
+	return parseParams(t.Parameters, data)
 }

--- a/internal/tools/cloud_sql_pg_test.go
+++ b/internal/tools/cloud_sql_pg_test.go
@@ -40,9 +40,9 @@ func TestParseFromYaml(t *testing.T) {
 					statement: |
 						SELECT * FROM SQL_STATEMENT;
 					parameters:
-						country:
-							type: string
-							description: some description
+						- name: country
+						  type: string
+						  description: some description
 			`,
 			want: tools.Configs{
 				"example_tool": tools.CloudSQLPgGenericConfig{
@@ -51,8 +51,9 @@ func TestParseFromYaml(t *testing.T) {
 					Source:      "my-pg-instance",
 					Description: "some description",
 					Statement:   "SELECT * FROM SQL_STATEMENT;\n",
-					Parameters: map[string]tools.Parameter{
-						"country": {
+					Parameters: []tools.Parameter{
+						{
+							Name:        "country",
 							Type:        "string",
 							Description: "some description",
 						},


### PR DESCRIPTION
This PR adds preliminary parsing of parameters. Currently it only supports 4 types: string, int, float32, and bool. Almost certainly we will need to introduce more complicated parsing configuration (to handle objects and arrays), but my initial attempts got quickly complicated, so I simplified in the short term. 

This also makes 2 breaking changes to config.yaml:
- changes "parameters" to be a list over object -- this is because parameter ordering is important, and needs to be preserved
- removed the "required" field from parameter objects -- we need to determine how to handle optional parameters in SQL queries