### PR TITLE
docs: add documentation for tools

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -106,11 +106,11 @@ requires another Parameter to be specified under the `items` field:
             description: Name of the airline. 
 ```
 
-| **field**   | **type** | **required** | **description**                                                            |
-|-------------|:--------:|:------------:|----------------------------------------------------------------------------|
-| name        |  string  |     true     | Name of the parameter.                                                     |
-| type        |  string  |     true     | Must be "array"                                                            |
-| description |  string  |     true     | Natural language description of the parameter to describe it to the agent. |
-| items       |  string  |     true     | Specify a Parameter object for the type of the values in the array.        |
+| **field**   |     **type**     | **required** | **description**                                                            |
+|-------------|:----------------:|:------------:|----------------------------------------------------------------------------|
+| name        |      string      |     true     | Name of the parameter.                                                     |
+| type        |      string      |     true     | Must be "array"                                                            |
+| description |      string      |     true     | Natural language description of the parameter to describe it to the agent. |
+| items       | parameter object |     true     | Specify a Parameter object for the type of the values in the array.        |
 
 

--- a/docs/tools/postgres-generic.md
+++ b/docs/tools/postgres-generic.md
@@ -12,7 +12,7 @@ PostgreSQL Generic Tools require one of the following sources:
 ```yaml
 tools:
  search_flights_by_number:
-    kind: cloud-sql-postgres-generic
+    kind: postgres-generic
     source: my-pg-instance
     statement: |
       SELECT * FROM flights
@@ -49,12 +49,12 @@ tools:
 
 ## Reference
 
-| **field**   | **type** | **required** | **description**                                                                          |
-|-------------|:--------:|:------------:|------------------------------------------------------------------------------------------|
-| kind        |  string  |     true     | Must be "postgres-generic".                                                              |
-| source      |  string  |     true     | Name of the source the SQL should execute on.                                            |
-| description |  string  |     true     | Port to connect to (e.g. "5432")                                                         |
-| statement   |  string  |     true     | SQL statement to execute on.                                                             |
-| parameters  |  string  |     true     | List of [parameters](README.md#specifying-parameters) that will be inserted into the SQL statement. |
+| **field**   |                   **type**                   | **required** | **description**                                                                                     |
+|-------------|:--------------------------------------------:|:------------:|-----------------------------------------------------------------------------------------------------|
+| kind        |                    string                    |     true     | Must be "postgres-generic".                                                                         |
+| source      |                    string                    |     true     | Name of the source the SQL should execute on.                                                       |
+| description |                    string                    |     true     | Port to connect to (e.g. "5432")                                                                    |
+| statement   |                    string                    |     true     | SQL statement to execute on.                                                                        |
+| parameters  | [parameter](README.md#specifying-parameters) |     true     | List of [parameters](README.md#specifying-parameters) that will be inserted into the SQL statement. |
 
 


### PR DESCRIPTION
Adds more detailed documentation on tools and parameters. 

Only covers `postgres-generic` right now, looking into seeing if I can eliminate the other two tools. 