### PR TITLE
fix: correct source type validation for postgres-sql tool

### DIFF
--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -56,7 +56,7 @@ func (r Config) Initialize() (sources.Source, error) {
 		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 
-	s := Source{
+	s := &Source{
 		Name: r.Name,
 		Kind: SourceKind,
 		Pool: pool,
@@ -64,7 +64,7 @@ func (r Config) Initialize() (sources.Source, error) {
 	return s, nil
 }
 
-var _ sources.Source = Source{}
+var _ sources.Source = &Source{}
 
 type Source struct {
 	Name string `yaml:"name"`
@@ -72,7 +72,7 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
-func (s Source) SourceKind() string {
+func (s *Source) SourceKind() string {
 	return SourceKind
 }
 

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -55,7 +55,7 @@ func (r Config) Initialize() (sources.Source, error) {
 		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 
-	s := Source{
+	s := &Source{
 		Name: r.Name,
 		Kind: SourceKind,
 		Pool: pool,
@@ -63,7 +63,7 @@ func (r Config) Initialize() (sources.Source, error) {
 	return s, nil
 }
 
-var _ sources.Source = Source{}
+var _ sources.Source = &Source{}
 
 type Source struct {
 	Name string `yaml:"name"`
@@ -71,7 +71,7 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
-func (s Source) SourceKind() string {
+func (s *Source) SourceKind() string {
 	return SourceKind
 }
 

--- a/internal/sources/postgres/postgres.go
+++ b/internal/sources/postgres/postgres.go
@@ -52,7 +52,7 @@ func (r Config) Initialize() (sources.Source, error) {
 		return nil, fmt.Errorf("Unable to connect successfully: %w", err)
 	}
 
-	s := Source{
+	s := &Source{
 		Name: r.Name,
 		Kind: SourceKind,
 		Pool: pool,
@@ -60,7 +60,7 @@ func (r Config) Initialize() (sources.Source, error) {
 	return s, nil
 }
 
-var _ sources.Source = Source{}
+var _ sources.Source = &Source{}
 
 type Source struct {
 	Name string `yaml:"name"`
@@ -68,7 +68,7 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
-func (s Source) SourceKind() string {
+func (s *Source) SourceKind() string {
 	return SourceKind
 }
 


### PR DESCRIPTION
Fixes a bug introduced in #43 where postgres-tool didn't think any of the sources were valid. 

The root cause of the bug was inconsistent usage of pointer/value in the receiver functions. The fix updates everything to consistently use a pointer receiver function.