### PR TITLE
feat: Add `AuthSources` to `Parameter` config

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/authSources"
 	"github.com/googleapis/genai-toolbox/internal/authSources/googleAuth"
 	"github.com/googleapis/genai-toolbox/internal/server"
 	cloudsqlpgsrc "github.com/googleapis/genai-toolbox/internal/sources/cloudsqlpg"
@@ -230,7 +231,7 @@ func TestParseToolFile(t *testing.T) {
 					Description: "some description",
 					Statement:   "SELECT * FROM SQL_STATEMENT;\n",
 					Parameters: []tools.Parameter{
-						tools.NewStringParameter("country", "some description"),
+						tools.NewStringParameter("country", "some description", make([]authSources.AuthSource, 0)),
 					},
 				},
 			},

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -83,6 +83,9 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
 		return
 	}
+	authSource := r.Header[http.CanonicalHeaderKey("AuthSource")][0]
+	authToken := r.Header[http.CanonicalHeaderKey("AuthToken")][0]
+	claims, _ := tool.Authenticate(authSource, authToken)
 
 	var data map[string]interface{}
 	if err := render.DecodeJSON(r.Body, &data); err != nil {
@@ -92,7 +95,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params, err := tool.ParseParams(data)
+	params, err := tool.ParseParams(data, claims)
 	if err != nil {
 		err := fmt.Errorf("provided parameters were invalid: %w", err)
 		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/googleapis/genai-toolbox/internal/authSources"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 )
 
@@ -37,8 +38,12 @@ func (t MockTool) Invoke([]any) (string, error) {
 	return "", nil
 }
 
-func (t MockTool) ParseParams(data map[string]any) ([]any, error) {
-	return tools.ParseParams(t.Params, data)
+func (t MockTool) ParseParams(data map[string]any, claims map[string]any) ([]any, error) {
+	return tools.ParseParams(t.Params, data, claims)
+}
+
+func (t MockTool) Authenticate(authSource string, authToken string) (map[string]any, error) {
+	return make(map[string]any), nil
 }
 
 func (t MockTool) Manifest() tools.Manifest {
@@ -51,6 +56,7 @@ func (t MockTool) Manifest() tools.Manifest {
 
 func TestToolsetEndpoint(t *testing.T) {
 	// Set up resources to test against
+	var authSources []authSources.AuthSource
 	tool1 := MockTool{
 		Name:   "no_params",
 		Params: []tools.Parameter{},
@@ -58,8 +64,8 @@ func TestToolsetEndpoint(t *testing.T) {
 	tool2 := MockTool{
 		Name: "some_params",
 		Params: tools.Parameters{
-			tools.NewIntParameter("param1", "This is the first parameter."),
-			tools.NewIntParameter("param2", "This is the second parameter."),
+			tools.NewIntParameter("param1", "This is the first parameter.", authSources),
+			tools.NewIntParameter("param2", "This is the second parameter.", authSources),
 		},
 	}
 	toolsMap := map[string]tools.Tool{tool1.Name: tool1, tool2.Name: tool2}
@@ -176,6 +182,7 @@ func TestToolsetEndpoint(t *testing.T) {
 }
 func TestToolGetEndpoint(t *testing.T) {
 	// Set up resources to test against
+	var authSources []authSources.AuthSource
 	tool1 := MockTool{
 		Name:   "no_params",
 		Params: []tools.Parameter{},
@@ -183,8 +190,8 @@ func TestToolGetEndpoint(t *testing.T) {
 	tool2 := MockTool{
 		Name: "some_params",
 		Params: tools.Parameters{
-			tools.NewIntParameter("param1", "This is the first parameter."),
-			tools.NewIntParameter("param2", "This is the second parameter."),
+			tools.NewIntParameter("param1", "This is the first parameter.", authSources),
+			tools.NewIntParameter("param2", "This is the second parameter.", authSources),
 		},
 	}
 	toolsMap := map[string]tools.Tool{tool1.Name: tool1, tool2.Name: tool2}

--- a/internal/tools/parameters.go
+++ b/internal/tools/parameters.go
@@ -17,6 +17,7 @@ package tools
 import (
 	"fmt"
 
+	authSources "github.com/googleapis/genai-toolbox/internal/authSources"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,7 +30,7 @@ const (
 )
 
 // ParseParams is a helper function for parsing Parameters from an arbitraryJSON object.
-func ParseParams(ps Parameters, data map[string]any) ([]any, error) {
+func ParseParams(ps Parameters, data map[string]any, claims map[string]any) ([]any, error) {
 	params := []any{}
 	for _, p := range ps {
 		v, ok := data[p.GetName()]
@@ -50,6 +51,7 @@ type Parameter interface {
 	// but this is done to differentiate it from the fields in CommonParameter.
 	GetName() string
 	GetType() string
+	GetAuthSources() []authSources.AuthSource
 	Parse(any) (any, error)
 	Manifest() ParameterManifest
 }
@@ -169,13 +171,14 @@ func (e ParseTypeError) Error() string {
 }
 
 // NewStringParameter is a convenience function for initializing a StringParameter.
-func NewStringParameter(name, desc string) *StringParameter {
+func NewStringParameter(name, desc string, authSources []authSources.AuthSource) *StringParameter {
 	return &StringParameter{
 		CommonParameter: CommonParameter{
 			Name: name,
 			Type: typeString,
 			Desc: desc,
 		},
+		AuthSources: authSources,
 	}
 }
 
@@ -184,6 +187,7 @@ var _ Parameter = &StringParameter{}
 // StringParameter is a parameter representing the "string" type.
 type StringParameter struct {
 	CommonParameter `yaml:",inline"`
+	AuthSources     []authSources.AuthSource `yaml:"auth_sources"`
 }
 
 // Parse casts the value "v" as a "string".
@@ -194,15 +198,19 @@ func (p *StringParameter) Parse(v any) (any, error) {
 	}
 	return newV, nil
 }
+func (p *StringParameter) GetAuthSources() []authSources.AuthSource {
+	return p.AuthSources
+}
 
 // NewIntParameter is a convenience function for initializing a IntParameter.
-func NewIntParameter(name, desc string) *IntParameter {
+func NewIntParameter(name, desc string, authSources []authSources.AuthSource) *IntParameter {
 	return &IntParameter{
 		CommonParameter: CommonParameter{
 			Name: name,
 			Type: typeInt,
 			Desc: desc,
 		},
+		AuthSources: authSources,
 	}
 }
 
@@ -211,6 +219,7 @@ var _ Parameter = &IntParameter{}
 // IntParameter is a parameter representing the "int" type.
 type IntParameter struct {
 	CommonParameter `yaml:",inline"`
+	AuthSources     []authSources.AuthSource `yaml:"auth_sources"`
 }
 
 func (p *IntParameter) Parse(v any) (any, error) {
@@ -221,14 +230,19 @@ func (p *IntParameter) Parse(v any) (any, error) {
 	return newV, nil
 }
 
+func (p *IntParameter) GetAuthSources() []authSources.AuthSource {
+	return p.AuthSources
+}
+
 // NewFloatParameter is a convenience function for initializing a FloatParameter.
-func NewFloatParameter(name, desc string) *FloatParameter {
+func NewFloatParameter(name, desc string, authSources []authSources.AuthSource) *FloatParameter {
 	return &FloatParameter{
 		CommonParameter: CommonParameter{
 			Name: name,
 			Type: typeFloat,
 			Desc: desc,
 		},
+		AuthSources: authSources,
 	}
 }
 
@@ -237,6 +251,7 @@ var _ Parameter = &FloatParameter{}
 // FloatParameter is a parameter representing the "float" type.
 type FloatParameter struct {
 	CommonParameter `yaml:",inline"`
+	AuthSources     []authSources.AuthSource `yaml:"auth_sources"`
 }
 
 func (p *FloatParameter) Parse(v any) (any, error) {
@@ -247,14 +262,19 @@ func (p *FloatParameter) Parse(v any) (any, error) {
 	return newV, nil
 }
 
+func (p *FloatParameter) GetAuthSources() []authSources.AuthSource {
+	return p.AuthSources
+}
+
 // NewBooleanParameter is a convenience function for initializing a BooleanParameter.
-func NewBooleanParameter(name, desc string) *BooleanParameter {
+func NewBooleanParameter(name, desc string, authSources []authSources.AuthSource) *BooleanParameter {
 	return &BooleanParameter{
 		CommonParameter: CommonParameter{
 			Name: name,
 			Type: typeBool,
 			Desc: desc,
 		},
+		AuthSources: authSources,
 	}
 }
 
@@ -263,6 +283,7 @@ var _ Parameter = &BooleanParameter{}
 // BooleanParameter is a parameter representing the "boolean" type.
 type BooleanParameter struct {
 	CommonParameter `yaml:",inline"`
+	AuthSources     []authSources.AuthSource `yaml:"auth_sources"`
 }
 
 func (p *BooleanParameter) Parse(v any) (any, error) {
@@ -273,15 +294,20 @@ func (p *BooleanParameter) Parse(v any) (any, error) {
 	return newV, nil
 }
 
+func (p *BooleanParameter) GetAuthSources() []authSources.AuthSource {
+	return p.AuthSources
+}
+
 // NewArrayParameter is a convenience function for initializing an ArrayParameter.
-func NewArrayParameter(name, desc string, items Parameter) *ArrayParameter {
+func NewArrayParameter(name, desc string, items Parameter, authSources []authSources.AuthSource) *ArrayParameter {
 	return &ArrayParameter{
 		CommonParameter: CommonParameter{
 			Name: name,
 			Type: typeArray,
 			Desc: desc,
 		},
-		Items: items,
+		Items:       items,
+		AuthSources: authSources,
 	}
 }
 
@@ -290,7 +316,8 @@ var _ Parameter = &ArrayParameter{}
 // ArrayParameter is a parameter representing the "array" type.
 type ArrayParameter struct {
 	CommonParameter `yaml:",inline"`
-	Items           Parameter `yaml:"items"`
+	Items           Parameter                `yaml:"items"`
+	AuthSources     []authSources.AuthSource `yaml:"auth_sources"`
 }
 
 func (p *ArrayParameter) UnmarshalYAML(node *yaml.Node) error {
@@ -335,4 +362,8 @@ func (p *ArrayParameter) Parse(v any) (any, error) {
 		rtn = append(rtn, val)
 	}
 	return rtn, nil
+}
+
+func (p *ArrayParameter) GetAuthSources() []authSources.AuthSource {
+	return p.AuthSources
 }

--- a/internal/tools/parameters_test.go
+++ b/internal/tools/parameters_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	authSources "github.com/googleapis/genai-toolbox/internal/authSources"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"gopkg.in/yaml.v3"
 )
 
 func TestParametersMarhsall(t *testing.T) {
+	var authSources []authSources.AuthSource
 	tcs := []struct {
 		name string
 		in   []map[string]any
@@ -39,7 +41,7 @@ func TestParametersMarhsall(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewStringParameter("my_string", "this param is a string"),
+				tools.NewStringParameter("my_string", "this param is a string", authSources),
 			},
 		},
 		{
@@ -52,7 +54,7 @@ func TestParametersMarhsall(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewIntParameter("my_integer", "this param is an int"),
+				tools.NewIntParameter("my_integer", "this param is an int", authSources),
 			},
 		},
 		{
@@ -65,7 +67,7 @@ func TestParametersMarhsall(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewFloatParameter("my_float", "my param is a float"),
+				tools.NewFloatParameter("my_float", "my param is a float", authSources),
 			},
 		},
 		{
@@ -78,7 +80,7 @@ func TestParametersMarhsall(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewBooleanParameter("my_bool", "this param is a boolean"),
+				tools.NewBooleanParameter("my_bool", "this param is a boolean", authSources),
 			},
 		},
 		{
@@ -94,7 +96,7 @@ func TestParametersMarhsall(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewArrayParameter("my_array", "this param is an array of strings", tools.NewStringParameter("", "")),
+				tools.NewArrayParameter("my_array", "this param is an array of strings", tools.NewStringParameter("", "", authSources), authSources),
 			},
 		},
 		{
@@ -110,7 +112,7 @@ func TestParametersMarhsall(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewArrayParameter("my_array", "this param is an array of floats", tools.NewFloatParameter("", "")),
+				tools.NewArrayParameter("my_array", "this param is an array of floats", tools.NewFloatParameter("", "", authSources), authSources),
 			},
 		},
 	}
@@ -135,6 +137,7 @@ func TestParametersMarhsall(t *testing.T) {
 }
 
 func TestParametersParse(t *testing.T) {
+	var authSources []authSources.AuthSource
 	tcs := []struct {
 		name   string
 		params tools.Parameters
@@ -144,7 +147,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "string",
 			params: tools.Parameters{
-				tools.NewStringParameter("my_string", "this param is a string"),
+				tools.NewStringParameter("my_string", "this param is a string", authSources),
 			},
 			in: map[string]any{
 				"my_string": "hello world",
@@ -154,7 +157,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "not string",
 			params: tools.Parameters{
-				tools.NewStringParameter("my_string", "this param is a string"),
+				tools.NewStringParameter("my_string", "this param is a string", authSources),
 			},
 			in: map[string]any{
 				"my_string": 4,
@@ -163,7 +166,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "int",
 			params: tools.Parameters{
-				tools.NewIntParameter("my_int", "this param is an int"),
+				tools.NewIntParameter("my_int", "this param is an int", authSources),
 			},
 			in: map[string]any{
 				"my_int": 100,
@@ -173,7 +176,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "not int",
 			params: tools.Parameters{
-				tools.NewIntParameter("my_int", "this param is an int"),
+				tools.NewIntParameter("my_int", "this param is an int", authSources),
 			},
 			in: map[string]any{
 				"my_int": 14.5,
@@ -182,7 +185,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "float",
 			params: tools.Parameters{
-				tools.NewFloatParameter("my_float", "this param is a float"),
+				tools.NewFloatParameter("my_float", "this param is a float", authSources),
 			},
 			in: map[string]any{
 				"my_float": 1.5,
@@ -192,7 +195,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "not float",
 			params: tools.Parameters{
-				tools.NewFloatParameter("my_float", "this param is a float"),
+				tools.NewFloatParameter("my_float", "this param is a float", authSources),
 			},
 			in: map[string]any{
 				"my_float": true,
@@ -201,7 +204,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "bool",
 			params: tools.Parameters{
-				tools.NewBooleanParameter("my_bool", "this param is a bool"),
+				tools.NewBooleanParameter("my_bool", "this param is a bool", authSources),
 			},
 			in: map[string]any{
 				"my_bool": true,
@@ -211,7 +214,7 @@ func TestParametersParse(t *testing.T) {
 		{
 			name: "bool",
 			params: tools.Parameters{
-				tools.NewBooleanParameter("my_bool", "this param is a bool"),
+				tools.NewBooleanParameter("my_bool", "this param is a bool", authSources),
 			},
 			in: map[string]any{
 				"my_bool": "true",
@@ -232,7 +235,7 @@ func TestParametersParse(t *testing.T) {
 				t.Fatalf("unable to unmarshal: %s", err)
 			}
 
-			gotAll, err := tools.ParseParams(tc.params, m)
+			gotAll, err := tools.ParseParams(tc.params, m, make(map[string]any))
 			if err != nil {
 				if len(tc.want) == 0 {
 					// error is expected if no items in want

--- a/internal/tools/postgressql/postgressql_test.go
+++ b/internal/tools/postgressql/postgressql_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/authSources"
 	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
@@ -26,6 +27,7 @@ import (
 )
 
 func TestParseFromYamlPostgres(t *testing.T) {
+	var authSources []authSources.AuthSource
 	tcs := []struct {
 		desc string
 		in   string
@@ -54,7 +56,7 @@ func TestParseFromYamlPostgres(t *testing.T) {
 					Description: "some description",
 					Statement:   "SELECT * FROM SQL_STATEMENT;\n",
 					Parameters: []tools.Parameter{
-						tools.NewStringParameter("country", "some description"),
+						tools.NewStringParameter("country", "some description", authSources),
 					},
 				},
 			},

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -25,8 +25,9 @@ type ToolConfig interface {
 
 type Tool interface {
 	Invoke([]any) (string, error)
-	ParseParams(data map[string]any) ([]any, error)
+	ParseParams(data map[string]any, claims map[string]any) ([]any, error)
 	Manifest() Manifest
+	Authenticate(authSource string, authToken string) (map[string]any, error)
 }
 
 // Manifest is the representation of tools sent to Client SDKs.


### PR DESCRIPTION
Add authSources to every Parameter type implementation to support authenticated params.