### PR TITLE
ci: setup continuous release

### DIFF
--- a/.ci/continuous.release.cloudbuild.yaml
+++ b/.ci/continuous.release.cloudbuild.yaml
@@ -1,0 +1,139 @@
+# Copyright 2024 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: "build-docker"
+    name: "gcr.io/cloud-builders/docker"
+    waitFor: ['-']
+    script: |
+        #!/usr/bin/env bash
+        docker buildx build --build-arg METADATA_TAGS=$(git rev-parse HEAD) -t ${_DOCKER_URI}:$REF_NAME .
+
+  - id: "push-docker"
+    name: "gcr.io/cloud-builders/docker"
+    waitFor:
+      - "build-docker"
+    script: |
+        #!/usr/bin/env bash
+        docker push ${_DOCKER_URI}:$REF_NAME
+
+  - id: "install-dependencies"
+    name: golang:1
+    waitFor: ['-']
+    env:
+      - 'GOPATH=/gopath'
+    volumes:
+      - name: 'go'
+        path: '/gopath'
+    script: |
+        go get -d ./...
+
+  - id: "build-linux-amd64"
+    name: golang:1
+    waitFor: 
+      - "install-dependencies"
+    env:
+      - 'GOPATH=/gopath'
+    volumes:
+      - name: 'go'
+        path: '/gopath'
+    script: |
+        #!/usr/bin/env bash
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+          go build -ldflags "-X github.com/googleapis/genai-toolbox/cmd.metadataString=binary.linux.amd64.$REF_NAME" -o toolbox.linux.amd64
+
+  - id: "store-linux-amd64"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "build-linux-amd64"
+    script: |
+        #!/usr/bin/env bash
+        gcloud storage cp toolbox.linux.amd64 gs://$_BUCKET_NAME/$REF_NAME/linux/amd64/toolbox
+
+  - id: "build-darwin-arm64"
+    name: golang:1
+    waitFor: 
+      - "install-dependencies"
+    env:
+      - 'GOPATH=/gopath'
+    volumes:
+      - name: 'go'
+        path: '/gopath'
+    script: |
+        #!/usr/bin/env bash
+        CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 \
+          go build -ldflags "-X github.com/googleapis/genai-toolbox/cmd.metadataString=binary.darwin.arm64.$REF_NAME" -o toolbox.darwin.arm64
+
+  - id: "store-darwin-arm64"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "build-darwin-arm64"
+    script: |
+        #!/usr/bin/env bash
+        gcloud storage cp toolbox.darwin.arm64 gs://$_BUCKET_NAME/$REF_NAME/darwin/arm64/toolbox
+
+  - id: "build-darwin-amd64"
+    name: golang:1
+    waitFor: 
+      - "install-dependencies"
+    env:
+      - 'GOPATH=/gopath'
+    volumes:
+      - name: 'go'
+        path: '/gopath'
+    script: |
+        #!/usr/bin/env bash
+        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
+          go build -ldflags "-X github.com/googleapis/genai-toolbox/cmd.metadataString=binary.darwin.amd64.$REF_NAME" -o toolbox.darwin.amd64
+
+  - id: "store-darwin-amd64"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "build-darwin-amd64"
+    script: |
+        #!/usr/bin/env bash
+        gcloud storage cp toolbox.darwin.amd64 gs://$_BUCKET_NAME/$REF_NAME/darwin/amd64/toolbox
+
+  - id: "build-windows-amd64"
+    name: golang:1
+    waitFor: 
+      - "install-dependencies"
+    env:
+      - 'GOPATH=/gopath'
+    volumes:
+      - name: 'go'
+        path: '/gopath'
+    script: |
+        #!/usr/bin/env bash
+        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
+          go build -ldflags "-X github.com/googleapis/genai-toolbox/cmd.metadataString=binary.windows.amd64.$REF_NAME" -o toolbox.windows.amd64
+
+  - id: "store-windows-amd64"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "build-windows-amd64"
+    script: |
+        #!/usr/bin/env bash
+        gcloud storage cp toolbox.windows.amd64 gs://$_BUCKET_NAME/$REF_NAME/windows/amd64/toolbox
+
+options:
+  automapSubstitutions: true
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY # Necessary for custom service account
+
+substitutions:
+  _REGION: us-central1
+  _AR_HOSTNAME: ${_REGION}-docker.pkg.dev
+  _AR_REPO_NAME: toolbox-dev
+  _BUCKET_NAME: genai-toolbox-dev
+  _DOCKER_URI: ${_AR_HOSTNAME}/${PROJECT_ID}/${_AR_REPO_NAME}/toolbox


### PR DESCRIPTION
Setup continuous release for Toolbox.
Cloudbuild triggers releases when there's a push to the main branch.

Binary url: `https://storage.googleapis.com/genai-toolbox-dev/$REF_NAME/darwin/amd64/toolbox`
image url: `us-central1-docker.pkg.dev/database-toolbox/toolbox-dev/toolbox:$REF_NAME`