### PR TITLE
chore: move logger interface to log/

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -19,8 +19,6 @@ import (
 	"io"
 	"log/slog"
 	"strings"
-
-	"github.com/googleapis/genai-toolbox/toolbox"
 )
 
 // StdLogger is the standard logger
@@ -30,7 +28,7 @@ type StdLogger struct {
 }
 
 // NewStdLogger create a Logger that uses out and err for informational and error messages.
-func NewStdLogger(outW, errW io.Writer, logLevel string) (toolbox.Logger, error) {
+func NewStdLogger(outW, errW io.Writer, logLevel string) (Logger, error) {
 	//Set log level
 	var programLevel = new(slog.LevelVar)
 	slogLevel, err := severityToLevel(logLevel)
@@ -112,7 +110,7 @@ type StructuredLogger struct {
 }
 
 // NewStructuredLogger create a Logger that logs messages using JSON.
-func NewStructuredLogger(outW, errW io.Writer, logLevel string) (toolbox.Logger, error) {
+func NewStructuredLogger(outW, errW io.Writer, logLevel string) (Logger, error) {
 	//Set log level
 	var programLevel = new(slog.LevelVar)
 	slogLevel, err := severityToLevel(logLevel)

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/genai-toolbox/toolbox"
 )
 
 func TestSeverityToLevel(t *testing.T) {
@@ -121,7 +120,7 @@ func TestLevelToSeverityError(t *testing.T) {
 	}
 }
 
-func runLogger(logger toolbox.Logger, logMsg string) {
+func runLogger(logger Logger, logMsg string) {
 	switch logMsg {
 	case "info":
 		logger.Info("log info")

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package toolbox
+package log
 
 // Logger is the interface used throughout the project for logging.
 type Logger interface {


### PR DESCRIPTION
Moved `toolbox/logger.go` into `internal/log/logger.go`.