### PR TITLE
chore: fix incorrect source name

### DIFF
--- a/docs/sources/alloydb-pg.md
+++ b/docs/sources/alloydb-pg.md
@@ -48,7 +48,7 @@ PostreSQL user][alloydb-users] to login to the database with.
 ```yaml
 sources:
     my-alloydb-pg-source:
-        kind: "alloydb-pg-postgres"
+        kind: "alloydb-postgres"
         project: "my-project-name"
         region: "us-central1"
         cluster: "my-cluster"


### PR DESCRIPTION
Fix's the source name in one of the examples. 