### PR TITLE
ci(llamaindex): Update env variable to use typecheck build from sdks/llamaindex/src

### DIFF
--- a/.github/workflows/lint-llamaindex.yaml
+++ b/.github/workflows/lint-llamaindex.yaml
@@ -49,4 +49,6 @@ jobs:
           isort --check .
 
       - name: Run type-check
+        env:
+          MYPYPATH: 'sdks/llamaindex/src'
         run: mypy --install-types --non-interactive --explicit-package-bases sdks/llamaindex


### PR DESCRIPTION
Running lint type checker (mypy) on the sdk tests can raise errors like: https://github.com/googleapis/genai-toolbox/actions/runs/12194679407/job/34018934437 because it's looking in the wrong place for type definitions.

To fix this, we'll tell the type checker (mypy) to specifically include the toolbox_llamaindex_sdk module from our SDK source code when it's checking the tests. This will ensure it uses the correct type information and avoids these errors.