### PR TITLE
fix!(spanner): use googlesql for dialect name

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -141,7 +141,7 @@ func (c *SourceConfigs) UnmarshalYAML(node *yaml.Node) error {
 			}
 			(*c)[name] = actual
 		case spannersrc.SourceKind:
-			actual := spannersrc.Config{Name: name, Dialect: "google_standard_sql"}
+			actual := spannersrc.Config{Name: name, Dialect: "googlesql"}
 			if err := n.Decode(&actual); err != nil {
 				return fmt.Errorf("unable to parse as %q: %w", k.Kind, err)
 			}

--- a/internal/sources/dialect.go
+++ b/internal/sources/dialect.go
@@ -28,7 +28,7 @@ func (i *Dialect) String() string {
 	if string(*i) != "" {
 		return strings.ToLower(string(*i))
 	}
-	return "google_standard_sql"
+	return "googlesql"
 }
 
 func (i *Dialect) UnmarshalYAML(node *yaml.Node) error {
@@ -37,10 +37,10 @@ func (i *Dialect) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	switch strings.ToLower(dialect) {
-	case "google_standard_sql", "postgresql":
+	case "googlesql", "postgresql":
 		*i = Dialect(strings.ToLower(dialect))
 		return nil
 	default:
-		return fmt.Errorf(`dialect invalid: must be one of "google_standard_sql", or "postgresql"`)
+		return fmt.Errorf(`dialect invalid: must be one of "googlesql", or "postgresql"`)
 	}
 }

--- a/internal/sources/spanner/spanner_test.go
+++ b/internal/sources/spanner/spanner_test.go
@@ -47,7 +47,7 @@ func TestParseFromYamlSpannerDb(t *testing.T) {
 					Kind:     spanner.SourceKind,
 					Project:  "my-project",
 					Instance: "my-instance",
-					Dialect:  "google_standard_sql",
+					Dialect:  "googlesql",
 					Database: "my_db",
 				},
 			},
@@ -60,7 +60,7 @@ func TestParseFromYamlSpannerDb(t *testing.T) {
 					kind: spanner
 					project: my-project
 					instance: my-instance
-					dialect: Google_standard_sql
+					dialect: Googlesql 
 					database: my_db
 			`,
 			want: map[string]sources.SourceConfig{
@@ -69,7 +69,7 @@ func TestParseFromYamlSpannerDb(t *testing.T) {
 					Kind:     spanner.SourceKind,
 					Project:  "my-project",
 					Instance: "my-instance",
-					Dialect:  "google_standard_sql",
+					Dialect:  "googlesql",
 					Database: "my_db",
 				},
 			},

--- a/internal/tools/spanner/spanner.go
+++ b/internal/tools/spanner/spanner.go
@@ -108,7 +108,7 @@ type Tool struct {
 
 func getMapParams(params tools.ParamValues, dialect string) (map[string]interface{}, error) {
 	switch strings.ToLower(dialect) {
-	case "google_standard_sql":
+	case "googlesql":
 		return params.AsMap(), nil
 	case "postgresql":
 		return params.AsMapByOrderedKeys(), nil


### PR DESCRIPTION
Google updated the official name from `google_standard_sql` to `googlesql`.