### PR TITLE
feat(langchain-sdk): Support authentication in LangChain Toolbox SDK.

### DIFF
--- a/sdks/langchain/src/toolbox_langchain_sdk/client.py
+++ b/sdks/langchain/src/toolbox_langchain_sdk/client.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Any, Optional, Type
+import warnings
+from typing import Any, Callable, Optional, Type
 
 from aiohttp import ClientSession
 from langchain_core.tools import StructuredTool
@@ -20,6 +21,8 @@ class ToolboxClient:
         """
         self._url: str = url
         self._should_close_session: bool = session is None
+        self._id_token_getters: dict[str, Callable[[], str]] = {}
+        self._tool_param_auth: dict[str, dict[str, list[str]]] = {}
         self._session: ClientSession = session or ClientSession()
 
     async def close(self) -> None:
@@ -77,6 +80,35 @@ class ToolboxClient:
         url = f"{self._url}/api/toolset/{toolset_name or ''}"
         return await _load_yaml(url, self._session)
 
+    def _validate_auth(self, tool_name: str) -> bool:
+        """
+        Helper method that validates the authentication requirements of the tool
+        with the given tool_name. We consider the validation to pass if at least
+        one auth sources of each of the auth parameters, of the given tool, is
+        registered.
+
+        Args:
+            tool_name: Name of the tool to validate auth sources for.
+
+        Returns:
+            True if at least one permitted auth source of each of the auth
+            params, of the given tool, is registered. Also returns True if the
+            given tool does not require any auth sources.
+        """
+
+        if tool_name not in self._tool_param_auth:
+            return True
+
+        for permitted_auth_sources in self._tool_param_auth[tool_name].values():
+            found_match = False
+            for registered_auth_source in self._id_token_getters:
+                if registered_auth_source in permitted_auth_sources:
+                    found_match = True
+                    break
+            if not found_match:
+                return False
+        return True
+
     def _generate_tool(
         self, tool_name: str, manifest: ManifestSchema
     ) -> StructuredTool:
@@ -96,8 +128,16 @@ class ToolboxClient:
             model_name=tool_name, schema=tool_schema.parameters
         )
 
+        # If the tool had parameters that require authentication, then right
+        # before invoking that tool, we validate whether all these required
+        # authentication sources have been registered or not.
         async def _tool_func(**kwargs: Any) -> dict:
-            return await _invoke_tool(self._url, self._session, tool_name, kwargs)
+            if not self._validate_auth(tool_name):
+                raise PermissionError(f"Login required before invoking {tool_name}.")
+
+            return await _invoke_tool(
+                self._url, self._session, tool_name, kwargs, self._id_token_getters
+            )
 
         return StructuredTool.from_function(
             coroutine=_tool_func,
@@ -106,21 +146,89 @@ class ToolboxClient:
             args_schema=tool_model,
         )
 
-    async def load_tool(self, tool_name: str) -> StructuredTool:
+    def _process_auth_params(self, manifest: ManifestSchema) -> None:
+        """
+        Extracts parameters requiring authentication from the manifest.
+        Verifies each parameter has at least one valid auth source.
+
+        Args:
+            manifest: The manifest to validate and modify.
+
+        Warns:
+            UserWarning: If a parameter in the manifest has no valid sources.
+        """
+        for tool_name, tool_schema in manifest.tools.items():
+            non_auth_params = []
+            for param in tool_schema.parameters:
+
+                # Extract auth params from the tool schema.
+                #
+                # These parameters are removed from the manifest to prevent data
+                # validation errors since their values are inferred by the
+                # Toolbox service, not provided by the user.
+                #
+                # Store the permitted authentication sources for each parameter
+                # in '_tool_param_auth' for efficient validation in
+                # '_validate_auth'.
+                if not param.authSources:
+                    non_auth_params.append(param)
+                    continue
+
+                self._tool_param_auth.setdefault(tool_name, {})[
+                    param.name
+                ] = param.authSources
+
+            tool_schema.parameters = non_auth_params
+
+            # If none of the permitted auth sources of a parameter are
+            # registered, raise a warning message to the user.
+            if not self._validate_auth(tool_name):
+                warnings.warn(
+                    f"Some parameters of tool {tool_name} require authentication, but no valid auth sources are registered. Please register the required sources before use."
+                )
+
+    def add_auth_header(
+        self, auth_source: str, get_id_token: Callable[[], str]
+    ) -> None:
+        """
+        Registers a function to retrieve an ID token for a given authentication
+        source.
+
+        Args:
+            auth_source : The name of the authentication source.
+            get_id_token: A function that returns the ID token.
+        """
+        self._id_token_getters[auth_source] = get_id_token
+
+    async def load_tool(
+        self, tool_name: str, auth_headers: dict[str, Callable[[], str]] = {}
+    ) -> StructuredTool:
         """
         Loads the tool, with the given tool name, from the Toolbox service.
 
         Args:
             tool_name: The name of the tool to load.
+            auth_headers: A mapping of authentication source names to
+                functions that retrieve ID tokens. If provided, these will
+                override or be added to the existing ID token getters.
+                Default: Empty.
 
         Returns:
             A tool loaded from the Toolbox
         """
+        for auth_source, get_id_token in auth_headers.items():
+            self.add_auth_header(auth_source, get_id_token)
+
         manifest: ManifestSchema = await self._load_tool_manifest(tool_name)
+
+        self._process_auth_params(manifest)
+
         return self._generate_tool(tool_name, manifest)
 
     async def load_toolset(
-        self, toolset_name: Optional[str] = None
+        self,
+        toolset_name: Optional[str] = None,
+        auth_headers: dict[str, Callable[[], str]] = {},
     ) -> list[StructuredTool]:
         """
         Loads tools from the Toolbox service, optionally filtered by toolset
@@ -129,12 +237,22 @@ class ToolboxClient:
         Args:
             toolset_name: The name of the toolset to load.
                 Default: None. If not provided, then all the tools are loaded.
+            auth_headers: A mapping of authentication source names to
+                functions that retrieve ID tokens. If provided, these will
+                override or be added to the existing ID token getters.
+                Default: Empty.
 
         Returns:
             A list of all tools loaded from the Toolbox.
         """
+        for auth_source, get_id_token in auth_headers.items():
+            self.add_auth_header(auth_source, get_id_token)
+
         tools: list[StructuredTool] = []
         manifest: ManifestSchema = await self._load_toolset_manifest(toolset_name)
+
+        self._process_auth_params(manifest)
+
         for tool_name in manifest.tools:
             tools.append(self._generate_tool(tool_name, manifest))
         return tools

--- a/sdks/langchain/src/toolbox_langchain_sdk/utils.py
+++ b/sdks/langchain/src/toolbox_langchain_sdk/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Optional, Type, cast
+import warnings
+from typing import Any, Callable, Optional, Type, cast
 
 import yaml
 from aiohttp import ClientSession
@@ -9,6 +10,7 @@ class ParameterSchema(BaseModel):
     name: str
     type: str
     description: str
+    authSources: Optional[list[str]] = None
 
 
 class ToolSchema(BaseModel):
@@ -34,8 +36,14 @@ async def _load_yaml(url: str, session: ClientSession) -> ManifestSchema:
     """
     async with session.get(url) as response:
         response.raise_for_status()
-        parsed_yaml = yaml.safe_load(await response.text())
-        return ManifestSchema(**parsed_yaml)
+        try:
+            parsed_yaml = yaml.safe_load(await response.text())
+        except yaml.YAMLError as e:
+            raise yaml.YAMLError(f"Failed to parse YAML from {url}: {e}") from e
+        try:
+            return ManifestSchema(**parsed_yaml)
+        except ValueError as e:
+            raise ValueError(f"Invalid YAML data from {url}: {e}") from e
 
 
 def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[BaseModel]:
@@ -54,7 +62,8 @@ def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[Bas
         field_definitions[field.name] = cast(
             Any,
             (
-                # TODO: Remove the hardcoded optional types once optional fields are supported by Toolbox.
+                # TODO: Remove the hardcoded optional types once optional fields
+                # are supported by Toolbox.
                 Optional[_parse_type(field.type)],
                 Field(description=field.description),
             ),
@@ -88,8 +97,30 @@ def _parse_type(type_: str) -> Any:
         raise ValueError(f"Unsupported schema type: {type_}")
 
 
+def _get_auth_headers(id_token_getters: dict[str, Callable[[], str]]) -> dict[str, str]:
+    """
+    Gets id tokens for the given auth sources in the getters map and returns
+    headers to be included in tool invocation.
+
+    Args:
+          id_token_getters: A dict that maps auth source names to the functions
+              that return its ID token.
+
+    Returns:
+      A dictionary of headers to be included in the tool invocation.
+    """
+    auth_headers = {}
+    for auth_source, get_id_token in id_token_getters.items():
+        auth_headers[f"{auth_source}_token"] = get_id_token()
+    return auth_headers
+
+
 async def _invoke_tool(
-    url: str, session: ClientSession, tool_name: str, data: dict
+    url: str,
+    session: ClientSession,
+    tool_name: str,
+    data: dict,
+    id_token_getters: dict[str, Callable[[], str]],
 ) -> dict:
     """
     Asynchronously makes an API call to the Toolbox service to invoke a tool.
@@ -99,12 +130,29 @@ async def _invoke_tool(
         session: The HTTP client session.
         tool_name: The name of the tool to invoke.
         data: The input data for the tool.
+        id_token_getters: A dict that maps auth source names to the functions
+            that return its ID token.
 
     Returns:
-        A dictionary containing the parsed JSON response from the tool invocation.
+        A dictionary containing the parsed JSON response from the tool
+        invocation.
     """
     url = f"{url}/api/tool/{tool_name}/invoke"
-    async with session.post(url, json=_convert_none_to_empty_string(data)) as response:
+    auth_headers = _get_auth_headers(id_token_getters)
+
+    # ID tokens contain sensitive user information (claims). Transmitting these
+    # over HTTP exposes the data to interception and unauthorized access. Always
+    # use HTTPS to ensure secure communication and protect user privacy.
+    if auth_headers and not url.startswith("https://"):
+        warnings.warn(
+            "Sending ID token over HTTP. User data may be exposed. Use HTTPS for secure communication."
+        )
+
+    async with session.post(
+        url,
+        json=_convert_none_to_empty_string(data),
+        headers=auth_headers,
+    ) as response:
         response.raise_for_status()
         return await response.json()
 

--- a/sdks/langchain/tests/test_client.py
+++ b/sdks/langchain/tests/test_client.py
@@ -1,3 +1,5 @@
+import asyncio
+import warnings
 from unittest.mock import AsyncMock, Mock, call, patch
 
 import aiohttp
@@ -264,7 +266,564 @@ async def test_generate_tool_invoke(mock_invoke_tool):
         client._session,
         "test_tool",
         {"param1": "test_value", "param2": 123},
+        {},
     )
 
     # Assert that the result from _invoke_tool is returned
     assert result == {"result": "test_result"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_param_auth, id_token_getters, expected_result",
+    [
+        ({}, {}, True),  # No auth required
+        (
+            {"tool_name": {"param1": ["auth_source1"]}},
+            {"auth_source1": lambda: "test_token"},
+            True,
+        ),  # Auth required and satisfied (single param)
+        (
+            {"tool_name": {"param1": ["auth_source1"]}},
+            {},
+            False,
+        ),  # Auth required but not satisfied (single param)
+        (
+            {"tool_name": {"param1": ["auth_source1", "auth_source2"]}},
+            {"auth_source2": lambda: "test_token"},
+            True,
+        ),  # Multiple auth sources, one satisfied (single param)
+        (
+            {
+                "tool_name": {
+                    "param1": ["auth_source1"],
+                    "param2": ["auth_source2"],
+                }
+            },
+            {
+                "auth_source1": lambda: "test_token1",
+                "auth_source2": lambda: "test_token2",
+            },
+            True,
+        ),  # Multiple params, auth satisfied
+        (
+            {
+                "tool_name": {
+                    "param1": ["auth_source1"],
+                    "param2": ["auth_source2"],
+                }
+            },
+            {"auth_source1": lambda: "test_token1"},
+            False,
+        ),  # Multiple params, one auth missing
+        (
+            {
+                "tool_name": {
+                    "param1": ["auth_source1", "auth_source3"],
+                    "param2": ["auth_source2"],
+                }
+            },
+            {
+                "auth_source2": lambda: "test_token2",
+                "auth_source3": lambda: "test_token3",
+            },
+            True,
+        ),  # Multiple params, multiple auth sources, satisfied
+    ],
+)
+async def test_validate_auth(tool_param_auth, id_token_getters, expected_result):
+    """Test _validate_auth with different auth scenarios."""
+    client = ToolboxClient("http://test-url")
+    client._tool_param_auth = tool_param_auth
+    for auth_source, get_id_token in id_token_getters.items():
+        client.add_auth_header(auth_source, get_id_token)
+    assert client._validate_auth("tool_name") == expected_result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "manifest, id_token_getters, expected_tool_param_auth, expected_warning",
+    [
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1", type="string", description="Test param"
+                            )
+                        ],
+                    )
+                },
+            ),
+            {},
+            {},
+            None,
+        ),  # No auth params, no warning
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1",
+                                type="string",
+                                description="Test param",
+                                authSources=["auth_source1"],
+                            ),
+                            ParameterSchema(
+                                name="param2", type="string", description="Test param"
+                            ),
+                        ],
+                    )
+                },
+            ),
+            {},
+            {"tool_name": {"param1": ["auth_source1"]}},
+            "Some parameters of tool tool_name require authentication, but no valid auth sources are registered. Please register the required sources before use.",
+        ),  # With auth params, auth not satisfied, warning expected
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1",
+                                type="string",
+                                description="Test param",
+                                authSources=["auth_source1"],
+                            ),
+                            ParameterSchema(
+                                name="param2", type="string", description="Test param"
+                            ),
+                        ],
+                    )
+                },
+            ),
+            {"auth_source1": lambda: "test_token"},
+            {"tool_name": {"param1": ["auth_source1"]}},
+            None,
+        ),  # With auth params, auth satisfied, no warning expected
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1",
+                                type="string",
+                                description="Test param",
+                                authSources=["auth_source1"],
+                            ),
+                            ParameterSchema(
+                                name="param2", type="string", description="Test param"
+                            ),
+                            ParameterSchema(
+                                name="param3",
+                                type="string",
+                                description="Test param",
+                                authSources=[
+                                    "auth_source1",
+                                    "auth_source2",
+                                ],
+                            ),
+                            ParameterSchema(
+                                name="param4",
+                                type="string",
+                                description="Test param",
+                            ),
+                            ParameterSchema(
+                                name="param5",
+                                type="string",
+                                description="Test param",
+                                authSources=[
+                                    "auth_source3",
+                                    "auth_source2",
+                                ],
+                            ),  # more parameters with and without authSources
+                        ],
+                    )
+                },
+            ),
+            {
+                "auth_source2": lambda: "test_token",
+                "auth_source3": lambda: "test_token",
+            },
+            {
+                "tool_name": {
+                    "param1": ["auth_source1"],
+                    "param3": ["auth_source1", "auth_source2"],
+                    "param5": ["auth_source3", "auth_source2"],
+                }
+            },
+            "Some parameters of tool tool_name require authentication, but no valid auth sources are registered. Please register the required sources before use.",
+        ),  # With multiple auth params, auth not satisfied, warning expected
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1",
+                                type="string",
+                                description="Test param",
+                                authSources=["auth_source1"],
+                            ),
+                            ParameterSchema(
+                                name="param2", type="string", description="Test param"
+                            ),
+                            ParameterSchema(
+                                name="param3",
+                                type="string",
+                                description="Test param",
+                                authSources=[
+                                    "auth_source1",
+                                    "auth_source2",
+                                ],
+                            ),
+                            ParameterSchema(
+                                name="param4",
+                                type="string",
+                                description="Test param",
+                            ),
+                            ParameterSchema(
+                                name="param5",
+                                type="string",
+                                description="Test param",
+                                authSources=[
+                                    "auth_source3",
+                                    "auth_source2",
+                                ],
+                            ),  # more parameters with and without authSources
+                        ],
+                    )
+                },
+            ),
+            {
+                "auth_source1": lambda: "test_token",
+                "auth_source3": lambda: "test_token",
+            },
+            {
+                "tool_name": {
+                    "param1": ["auth_source1"],
+                    "param3": ["auth_source1", "auth_source2"],
+                    "param5": ["auth_source3", "auth_source2"],
+                }
+            },
+            None,
+        ),  # With multiple auth params, auth satisfied, warning not expected
+    ],
+)
+async def test_process_auth_params(
+    manifest, id_token_getters, expected_tool_param_auth, expected_warning
+):
+    """Test _process_auth_params with and without auth params."""
+    client = ToolboxClient("http://test-url")
+    client._id_token_getters = id_token_getters
+    if expected_warning:
+        with pytest.warns(UserWarning, match=expected_warning):
+            client._process_auth_params(manifest)
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            client._process_auth_params(manifest)
+    assert client._tool_param_auth == expected_tool_param_auth
+
+
+@pytest.mark.asyncio
+@patch("toolbox_langchain_sdk.client._load_yaml")
+@pytest.mark.parametrize(
+    "params, auth_headers, expected_tool_param_auth",
+    [
+        (
+            [
+                ParameterSchema(name="param1", type="string", description="Test param"),
+                ParameterSchema(name="param2", type="string", description="Test param"),
+            ],
+            {},
+            {},
+        ),  # No auth headers
+        (
+            [
+                ParameterSchema(name="param1", type="string", description="Test param"),
+                ParameterSchema(
+                    name="param2",
+                    type="string",
+                    description="Test param",
+                    authSources=["auth_source1"],
+                ),
+            ],
+            {"auth_source1": lambda: "test_token"},
+            {"tool_name": {"param2": ["auth_source1"]}},
+        ),  # With auth headers
+    ],
+)
+async def test_load_tool(
+    mock_load_yaml, params, auth_headers, expected_tool_param_auth
+):
+    """Test load_tool with and without auth headers."""
+    client = ToolboxClient("http://test-url")
+
+    # Replace with your desired mock manifest data
+    mock_load_yaml.return_value = ManifestSchema(
+        serverVersion="1.0",
+        tools={
+            "tool_name": ToolSchema(
+                description="Test tool",
+                parameters=params,
+            )
+        },
+    )
+
+    tool = await client.load_tool("tool_name", auth_headers)
+
+    assert isinstance(tool, StructuredTool)
+    assert tool.name == "tool_name"
+    assert "param1" in tool.args
+    assert client._tool_param_auth == expected_tool_param_auth
+
+
+@pytest.mark.asyncio
+@patch("toolbox_langchain_sdk.client._load_yaml")
+@pytest.mark.parametrize(
+    "params, auth_headers, expected_tool_param_auth, expected_num_tools",
+    [
+        (
+            [
+                ParameterSchema(name="param1", type="string", description="Test param"),
+                ParameterSchema(name="param2", type="string", description="Test param"),
+            ],
+            {},
+            {},
+            1,
+        ),  # No auth headers
+        (
+            [
+                ParameterSchema(name="param1", type="string", description="Test param"),
+                ParameterSchema(
+                    name="param2",
+                    type="string",
+                    description="Test param",
+                    authSources=["auth_source1"],
+                ),
+            ],
+            {"auth_source1": lambda: "test_token"},
+            {"tool_name": {"param2": ["auth_source1"]}},
+            1,
+        ),  # With auth headers
+    ],
+)
+async def test_load_toolset(
+    mock_load_yaml,
+    params,
+    auth_headers,
+    expected_tool_param_auth,
+    expected_num_tools,
+):
+    """Test load_toolset with and without toolset name and auth headers."""
+    client = ToolboxClient("http://test-url")
+
+    # Replace with your desired mock manifest data
+    mock_load_yaml.return_value = ManifestSchema(
+        serverVersion="1.0",
+        tools={
+            "tool_name": ToolSchema(
+                description="Test tool",
+                parameters=params,
+            )
+        },
+    )
+
+    tools = await client.load_toolset("toolset_name", auth_headers)
+
+    assert isinstance(tools, list)
+    assert len(tools) == expected_num_tools
+    assert all(isinstance(tool, StructuredTool) for tool in tools)
+    assert client._tool_param_auth == expected_tool_param_auth
+
+
+@pytest.mark.asyncio
+@patch("toolbox_langchain_sdk.client._invoke_tool")
+@pytest.mark.parametrize(
+    "manifest, tool_param_auth, id_token_getters, expected_invoke_tool_call",
+    [
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool description",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1",
+                                type="string",
+                                description="Test param",
+                            )
+                        ],
+                    )
+                },
+            ),
+            {},
+            {},
+            True,  # _invoke_tool should be called
+        ),  # Basic tool schema, no auth
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool description",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1",
+                                type="string",
+                                description="Test param",
+                                authSources=["auth_source1"],
+                            )
+                        ],
+                    )
+                },
+            ),
+            {"tool_name": {"param1": ["auth_source1"]}},
+            {},
+            False,  # _invoke_tool should not be called (auth missing)
+        ),  # Tool schema with auth, auth missing
+        (
+            ManifestSchema(
+                serverVersion="1.0",
+                tools={
+                    "tool_name": ToolSchema(
+                        description="Test tool description",
+                        parameters=[
+                            ParameterSchema(
+                                name="param1",
+                                type="string",
+                                description="Test param",
+                                authSources=["auth_source1"],
+                            )
+                        ],
+                    )
+                },
+            ),
+            {"tool_name": {"param1": ["auth_source1"]}},
+            {"auth_source1": lambda: "test_token"},
+            True,  # _invoke_tool should be called
+        ),  # Tool schema with auth, auth present
+    ],
+)
+async def test_generate_tool(
+    mock_invoke_tool,
+    manifest,
+    tool_param_auth,
+    id_token_getters,
+    expected_invoke_tool_call,
+):
+    """Test _generate_tool with different tool schemas and auth scenarios."""
+    client = ToolboxClient("http://test-url")
+    client._tool_param_auth = tool_param_auth
+    for auth_source, get_id_token in id_token_getters.items():
+        client.add_auth_header(auth_source, get_id_token)
+
+    tool = client._generate_tool("tool_name", manifest)
+
+    assert isinstance(tool, StructuredTool)
+    assert tool.name == "tool_name"
+    assert tool.description == "Test tool description"
+    assert tool.args_schema.__name__ == "tool_name"
+
+    # Call the tool function to check if _invoke_tool is called
+    if expected_invoke_tool_call:
+        await tool.coroutine(param1="test_value")
+        mock_invoke_tool.assert_called_once()
+    else:
+        with pytest.raises(PermissionError):
+            await tool.coroutine(param1="test_value")
+        mock_invoke_tool.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.close")
+async def test_del_closes_session(mock_close):
+    """Test that __del__ closes the session when the event loop is running."""
+    client = ToolboxClient("http://test-url")
+
+    # Simulate event loop running
+    loop = asyncio.get_event_loop()
+    loop.create_task(asyncio.sleep(0))
+
+    del client
+
+    # Give the event loop a chance to process the close task
+    await asyncio.sleep(0.1)
+
+    mock_close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.close")
+async def test_del_closes_session_not_running(mock_close):
+    """Test that __del__ closes the session when the event loop is not running."""
+    client = ToolboxClient("http://test-url")
+
+    # Keep a reference to the session
+    session = client._session
+
+    del client
+    import gc
+
+    gc.collect()
+
+    # Now explicitly close the session
+    await session.close()
+
+    mock_close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("toolbox_langchain_sdk.client.asyncio.get_event_loop")
+@patch("aiohttp.ClientSession.close")
+async def test_del_handles_exception(mock_close, mock_get_event_loop):
+    """Test that __del__ handles exceptions gracefully."""
+    client = ToolboxClient("http://test-url")
+
+    # Simulate an exception when getting the event loop
+    mock_get_event_loop.side_effect = Exception("Test exception")
+
+    del client
+
+    # close should not be called because of the exception
+    mock_close.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("toolbox_langchain_sdk.client.asyncio.get_event_loop")
+async def test_del_loop_not_running(mock_get_event_loop):
+    """Test that __del__ handles the case where the loop is not running."""
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    client = ToolboxClient("http://test-url")
+    mock_loop = Mock()
+    mock_loop.is_running.return_value = False
+    mock_get_event_loop.return_value = mock_loop
+
+    del client
+    import gc
+
+    gc.collect()  # Force garbage collection
+
+    # Add a small delay to allow the event loop to process the close coroutine
+    await asyncio.sleep(0.1)
+
+    loop.close()


### PR DESCRIPTION
This PR adds support for authentication in the `ToolboxClient`.

* We add API support for providing methods that fetch ID tokens for given auth sources. The SDK fetches tokens using these methods and formats and includes them in the headers of tool invocation requests.
* The SDK also validates whether the tool's authentication requirements are met with the registered auth sources both after loading tool/toolset (warning) and right before tool invocation (error).
* We do this by filtering out all the parameters of all the tools which have auth sources specified in their respective parameter schema. This filtering is done while loading the tool/toolset.
* We also warn the user in case ID tokens (containing user's information in the form of claims) are sent over HTTP and not HTTPS.

Note: We need to add the same functionality for the LlamaIndex SDK. We also need to update the documentations for the same.