### PR TITLE
ci: update lint with integration build tag

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,3 +30,6 @@ linters-settings:
         replacement: 'a[b:]'
 issues:
   fix: true
+run:
+  build-tags:
+    - integration

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -49,6 +49,9 @@ func getGoogleIdToken(audience string) (string, error) {
 		}
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
 		return string(body), nil
 	}
 }


### PR DESCRIPTION
Update golangcilint to run the `integration` build tag as well.