### PR TITLE
fix: Update ctx and remove redundancy line

### DIFF
--- a/internal/server/instrumentation.go
+++ b/internal/server/instrumentation.go
@@ -29,7 +29,6 @@ const (
 	toolsetGetCountName = "toolbox.server.toolset.get.count"
 	toolGetCountName    = "toolbox.server.tool.get.count"
 	toolInvokeCountName = "toolbox.server.tool.invoke.count"
-	operationActiveName = "toolbox.server.operation.active"
 )
 
 // Instrumentation defines the telemetry instrumentation for toolbox

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,7 +53,7 @@ func NewServer(cfg ServerConfig, log logLib.Logger) (*Server, error) {
 		return nil, fmt.Errorf("unable to create telemetry instrumentation: %w", err)
 	}
 
-	ctx, span := instrumentation.Tracer.Start(context.Background(), "toolbox/server/init")
+	parentCtx, span := instrumentation.Tracer.Start(context.Background(), "toolbox/server/init")
 	defer span.End()
 
 	logLevel, err := logLib.SeverityToLevel(cfg.LogLevel.String())
@@ -96,7 +96,7 @@ func NewServer(cfg ServerConfig, log logLib.Logger) (*Server, error) {
 	for name, sc := range cfg.SourceConfigs {
 		s, err := func() (sources.Source, error) {
 			ctx, span := instrumentation.Tracer.Start(
-				ctx,
+				parentCtx,
 				"toolbox/server/source/init",
 				trace.WithAttributes(attribute.String("source_kind", sc.SourceConfigKind())),
 				trace.WithAttributes(attribute.String("source_name", name)),
@@ -119,9 +119,8 @@ func NewServer(cfg ServerConfig, log logLib.Logger) (*Server, error) {
 	authSourcesMap := make(map[string]auth.AuthSource)
 	for name, sc := range cfg.AuthSourceConfigs {
 		a, err := func() (auth.AuthSource, error) {
-			var span trace.Span
-			ctx, span = instrumentation.Tracer.Start(
-				ctx,
+			_, span := instrumentation.Tracer.Start(
+				parentCtx,
 				"toolbox/server/auth/init",
 				trace.WithAttributes(attribute.String("auth_kind", sc.AuthSourceConfigKind())),
 				trace.WithAttributes(attribute.String("auth_name", name)),
@@ -144,9 +143,8 @@ func NewServer(cfg ServerConfig, log logLib.Logger) (*Server, error) {
 	toolsMap := make(map[string]tools.Tool)
 	for name, tc := range cfg.ToolConfigs {
 		t, err := func() (tools.Tool, error) {
-			var span trace.Span
-			ctx, span = instrumentation.Tracer.Start(
-				ctx,
+			_, span := instrumentation.Tracer.Start(
+				parentCtx,
 				"toolbox/server/tool/init",
 				trace.WithAttributes(attribute.String("tool_kind", tc.ToolConfigKind())),
 				trace.WithAttributes(attribute.String("tool_name", name)),
@@ -178,9 +176,8 @@ func NewServer(cfg ServerConfig, log logLib.Logger) (*Server, error) {
 	toolsetsMap := make(map[string]tools.Toolset)
 	for name, tc := range cfg.ToolsetConfigs {
 		t, err := func() (tools.Toolset, error) {
-			var span trace.Span
-			ctx, span = instrumentation.Tracer.Start(
-				ctx,
+			_, span := instrumentation.Tracer.Start(
+				parentCtx,
 				"toolbox/server/toolset/init",
 				trace.WithAttributes(attribute.String("toolset_name", name)),
 			)


### PR DESCRIPTION
Remove unused redundancy line.

Update context. Currently the `toolset/init` is a childspan of `tool/init` which is incorrect.