### PR TITLE
feat!: replace Source field `ip_type` with `ipType` for consistency

### DIFF
--- a/docs/sources/alloydb-pg.md
+++ b/docs/sources/alloydb-pg.md
@@ -32,15 +32,16 @@ IAM identity has been given the following IAM permissions:
 
 ### Network Path
 
-Currently, this source only supports [connecting over Private
-IP][private-ip]. Most notably, this means
-you need to connect from a VPC that AlloyDB has been connected to.
+Currently, AlloyDB supports connection over both [private IP][private-ip] and
+[public IP][public-ip]. Set the `ipType` parameter in your source
+configuration to `public` or `private`.
 
 [private-ip]: https://cloud.google.com/alloydb/docs/private-ip
+[public-ip]: https://cloud.google.com/alloydb/docs/connect-public-ip
 
 ### Database User
 
-Current, this source only uses standard authentication. You will need to [create a
+Currently, this source only uses standard authentication. You will need to [create a
 PostreSQL user][alloydb-users] to login to the database with.
 
 [alloydb-users]: https://cloud.google.com/alloydb/docs/database-users/about
@@ -69,9 +70,7 @@ sources:
 | region    |  string  |     true     | Name of the GCP region that the cluster was created in (e.g. "us-central1"). |
 | cluster   |  string  |     true     | Name of the AlloyDB cluster (e.g. "my-cluster").                             |
 | instance  |  string  |     true     | Name of the AlloyDB instance within the cluser (e.g. "my-instance").         |
-| ip_type   |  string  |     true     | IP Type of the AlloyDB instance, must be either `public` or `private`. Default: `public`. |
+| ipType   |  string  |     true     | IP Type of the AlloyDB instance, must be either `public` or `private`. Default: `public`. |
 | database  |  string  |     true     | Name of the Postgres database to connect to (e.g. "my_db").                  |
 | user      |  string  |     true     | Name of the Postgres user to connect as (e.g. "my-pg-user").                 |
 | password  |  string  |     true     | Password of the Postgres user (e.g. "my-password").                          |
-
-

--- a/docs/sources/cloud-sql-pg.md
+++ b/docs/sources/cloud-sql-pg.md
@@ -30,16 +30,17 @@ IAM identity has been given the following IAM roles:
 
 ### Network Path
 
-Currently, this source only supports [connecting over Public IP][public-ip].
-Because it uses the Go connector, is uses rotating client certificates to
-establish a secure mTLS connection with the instance.
+Currently, Cloud SQL supports connection over both [private IP][private-ip] and
+[public IP][public-ip]. Set the `ipType` parameter in your source
+configuration to `public` or `private`.
 
+[private-ip]: https://cloud.google.com/sql/docs/postgres/configure-private-ip
 [public-ip]: https://cloud.google.com/sql/docs/postgres/configure-ip
 
 ### Database User
 
 Current, this source only uses standard authentication. You will need to [create a
-PostreSQL user][cloud-sql-users] to login to the database with. 
+PostreSQL user][cloud-sql-users] to login to the database with.
 
 [cloud-sql-users]: https://cloud.google.com/sql/docs/postgres/create-manage-users
 
@@ -65,7 +66,7 @@ sources:
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id"). |
 | region    |  string  |     true     | Name of the GCP region that the cluster was created in (e.g. "us-central1"). |
 | instance  |  string  |     true     | Name of the Cloud SQL instance within the cluser (e.g. "my-instance").       |
-| ip_type   |  string  |     true     | IP Type of the Cloud SQL instance, must be either `public` or `private`. Default: `public`. |
+| ipType   |  string  |     true     | IP Type of the Cloud SQL instance, must be either `public` or `private`. Default: `public`. |
 | database  |  string  |     true     | Name of the Postgres database to connect to (e.g. "my_db").                  |
 | user      |  string  |     true     | Name of the Postgres user to connect as (e.g. "my-pg-user").                 |
 | password  |  string  |     true     | Password of the Postgres user (e.g. "my-password").                          |

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -38,7 +38,7 @@ type Config struct {
 	Region   string         `yaml:"region"`
 	Cluster  string         `yaml:"cluster"`
 	Instance string         `yaml:"instance"`
-	IPType   sources.IPType `yaml:"ip_type"`
+	IPType   sources.IPType `yaml:"ipType"`
 	User     string         `yaml:"user"`
 	Password string         `yaml:"password"`
 	Database string         `yaml:"database"`
@@ -83,18 +83,18 @@ func (s *Source) PostgresPool() *pgxpool.Pool {
 	return s.Pool
 }
 
-func getDialOpts(ip_type string) ([]alloydbconn.DialOption, error) {
-	switch strings.ToLower(ip_type) {
+func getDialOpts(ipType string) ([]alloydbconn.DialOption, error) {
+	switch strings.ToLower(ipType) {
 	case "private":
 		return []alloydbconn.DialOption{alloydbconn.WithPrivateIP()}, nil
 	case "public":
 		return []alloydbconn.DialOption{alloydbconn.WithPublicIP()}, nil
 	default:
-		return nil, fmt.Errorf("invalid ip_type %s", ip_type)
+		return nil, fmt.Errorf("invalid ipType %s", ipType)
 	}
 }
 
-func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ip_type, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceKind, name)
 	defer span.End()
@@ -107,7 +107,7 @@ func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name,
 	}
 
 	// Create a new dialer with options
-	dialOpts, err := getDialOpts(ip_type)
+	dialOpts, err := getDialOpts(ipType)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sources/alloydbpg/alloydb_pg_test.go
+++ b/internal/sources/alloydbpg/alloydb_pg_test.go
@@ -57,7 +57,7 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 			},
 		},
 		{
-			desc: "public ip_type",
+			desc: "public ipType",
 			in: `
 			sources:
 				my-pg-instance:
@@ -66,7 +66,7 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 					region: my-region
 					cluster: my-cluster
 					instance: my-instance
-					ip_type: Public
+					ipType: Public
 					database: my_db
 			`,
 			want: map[string]sources.SourceConfig{
@@ -83,7 +83,7 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 			},
 		},
 		{
-			desc: "private ip_type",
+			desc: "private ipType",
 			in: `
 			sources:
 				my-pg-instance:
@@ -92,7 +92,7 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 					region: my-region
 					cluster: my-cluster
 					instance: my-instance
-					ip_type: private
+					ipType: private
 					database: my_db
 			`,
 			want: map[string]sources.SourceConfig{
@@ -132,7 +132,7 @@ func FailParseFromYamlAlloyDBPg(t *testing.T) {
 		in   string
 	}{
 		{
-			desc: "invalid ip_type",
+			desc: "invalid ipType",
 			in: `
 			sources:
 				my-pg-instance:
@@ -141,7 +141,7 @@ func FailParseFromYamlAlloyDBPg(t *testing.T) {
 					region: my-region
 					cluster: my-cluster
 					instance: my-instance
-					ip_type: fail 
+					ipType: fail 
 					database: my_db
 			`,
 		},

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -37,7 +37,7 @@ type Config struct {
 	Project  string         `yaml:"project"`
 	Region   string         `yaml:"region"`
 	Instance string         `yaml:"instance"`
-	IPType   sources.IPType `yaml:"ip_type"`
+	IPType   sources.IPType `yaml:"ipType"`
 	User     string         `yaml:"user"`
 	Password string         `yaml:"password"`
 	Database string         `yaml:"database"`
@@ -82,18 +82,18 @@ func (s *Source) PostgresPool() *pgxpool.Pool {
 	return s.Pool
 }
 
-func getDialOpts(ip_type string) ([]cloudsqlconn.DialOption, error) {
-	switch strings.ToLower(ip_type) {
+func getDialOpts(ipType string) ([]cloudsqlconn.DialOption, error) {
+	switch strings.ToLower(ipType) {
 	case "private":
 		return []cloudsqlconn.DialOption{cloudsqlconn.WithPrivateIP()}, nil
 	case "public":
 		return []cloudsqlconn.DialOption{cloudsqlconn.WithPublicIP()}, nil
 	default:
-		return nil, fmt.Errorf("invalid ip_type %s", ip_type)
+		return nil, fmt.Errorf("invalid ipType %s", ipType)
 	}
 }
 
-func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ip_type, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceKind, name)
 	defer span.End()
@@ -106,7 +106,7 @@ func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name
 	}
 
 	// Create a new dialer with options
-	dialOpts, err := getDialOpts(ip_type)
+	dialOpts, err := getDialOpts(ipType)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
@@ -54,7 +54,7 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 			},
 		},
 		{
-			desc: "public ip_type",
+			desc: "public ipType",
 			in: `
 			sources:
 				my-pg-instance:
@@ -62,7 +62,7 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 					project: my-project
 					region: my-region
 					instance: my-instance
-					ip_type: Public
+					ipType: Public
 					database: my_db
 			`,
 			want: server.SourceConfigs{
@@ -78,7 +78,7 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 			},
 		},
 		{
-			desc: "private ip_type",
+			desc: "private ipType",
 			in: `
 			sources:
 				my-pg-instance:
@@ -86,7 +86,7 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 					project: my-project
 					region: my-region
 					instance: my-instance
-					ip_type: private 
+					ipType: private 
 					database: my_db
 			`,
 			want: server.SourceConfigs{
@@ -126,7 +126,7 @@ func FailParseFromYamlCloudSQLPg(t *testing.T) {
 		in   string
 	}{
 		{
-			desc: "invalid ip_type",
+			desc: "invalid ipType",
 			in: `
 			sources:
 				my-pg-instance:
@@ -134,7 +134,7 @@ func FailParseFromYamlCloudSQLPg(t *testing.T) {
 					project: my-project
 					region: my-region
 					instance: my-instance
-					ip_type: fail 
+					ipType: fail 
 					database: my_db
 			`,
 		},

--- a/internal/sources/ip_type.go
+++ b/internal/sources/ip_type.go
@@ -31,15 +31,15 @@ func (i *IPType) String() string {
 }
 
 func (i *IPType) UnmarshalYAML(node *yaml.Node) error {
-	var ip_type string
-	if err := node.Decode(&ip_type); err != nil {
+	var ipType string
+	if err := node.Decode(&ipType); err != nil {
 		return err
 	}
-	switch strings.ToLower(ip_type) {
+	switch strings.ToLower(ipType) {
 	case "private", "public":
-		*i = IPType(strings.ToLower(ip_type))
+		*i = IPType(strings.ToLower(ipType))
 		return nil
 	default:
-		return fmt.Errorf(`ip_type invalid: must be one of "public", or "private"`)
+		return fmt.Errorf(`ipType invalid: must be one of "public", or "private"`)
 	}
 }


### PR DESCRIPTION
Replace `ip_type` with `ipType` to match the camel-case of the other fields.
Update docs since we support both private and public IP connections.