### PR TITLE
docs: add example $VERSION for container image installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can also install Toolbox as a container:
 
 ```sh
 # see releases page for other versions
+export VERSION=0.0.1
 docker pull us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:$VERSION
 ```
 


### PR DESCRIPTION
container image uses `0.0.1` whereas the binary or source uses `v0.0.1`. Example is added so that this is clear to the user.