### PR TITLE
fix(langchain-sdk): Simplifying ToolboxTool with BaseTool inheritance

### DIFF
--- a/sdks/langchain/tests/test_tools.py
+++ b/sdks/langchain/tests/test_tools.py
@@ -269,6 +269,14 @@ async def test_toolbox_tool_call(toolbox_tool):
 
 
 @pytest.mark.asyncio
+async def test_toolbox_sync_tool_call_(toolbox_tool):
+    async for tool in toolbox_tool:
+        with pytest.raises(NotImplementedError) as e:
+            result = tool.invoke({"param1": "test-value", "param2": 123})
+        assert "Sync tool calls not supported yet." in str(e.value)
+
+
+@pytest.mark.asyncio
 async def test_toolbox_tool_call_with_bound_params(toolbox_tool):
     async for tool in toolbox_tool:
         tool = tool.bind_params({"param1": "bound-value"})


### PR DESCRIPTION
Previously, we utilized `StructuredTool.from_function` to create tools. Following the recent changes (#171 ) that introduced a dedicated custom class implementing the `BaseTool` interface, this PR updates `ToolboxTool` to inherit directly from `BaseTool` for a cleaner and more streamlined approach.

Implementing the `BaseTool` interface enforces to implement `_run` method, which is executed when the tool is invoke synchronously. For now since only async tool calls are supported, we throw a `NotImplementedError`. In a future PR, we will add synchronous support to `ToolboxTool` as well.