### PR TITLE
fix(langchain-sdk): Improve session cleanup

### DIFF
--- a/sdks/langchain/src/toolbox_langchain_sdk/client.py
+++ b/sdks/langchain/src/toolbox_langchain_sdk/client.py
@@ -53,16 +53,10 @@ class ToolboxClient:
         collected.
         """
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                loop.create_task(self.close())
-            else:
-                loop.run_until_complete(self.close())
-        except Exception:
-            # We "pass" assuming that the exception is thrown because the event
-            # loop is no longer running, but at that point the Session should
-            # have been closed already anyway.
-            pass
+            loop = asyncio.get_running_loop()
+            loop.create_task(self.close())
+        except RuntimeError:
+            asyncio.run(self.close())
 
     async def _load_tool_manifest(self, tool_name: str) -> ManifestSchema:
         """


### PR DESCRIPTION
This PR improves session cleanup by using `asyncio.get_running_loop` instead of `asyncio.get_event_loop`. The latter is deprecated and has been known to cause complications. If no running loop is found, then a `RuntimeError` is thrown and caught, and a new event loop is spun up to close the session.

Key changes:
* Use `asyncio.get_running_loop` instead of `asyncio.get_event_loop`.
* Catch and handle a specific `RuntimeError` that can occur if no running loop is found.
* Spin up a new event loop to close the session if no running loop is found.

> [!NOTE]
> The corresponding change for LlamaIndex SDK is done in #203.