### PR TITLE
fix: Auth token verification failure should not throw error immedicately

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -168,10 +168,8 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	for _, aS := range s.authSources {
 		claims, err := aS.GetClaimsFromHeader(r.Header)
 		if err != nil {
-			err = fmt.Errorf("failure getting claims from header: %w", err)
 			s.logger.DebugContext(context.Background(), err.Error())
-			_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
-			return
+			continue
 		}
 		if claims == nil {
 			// authSource not present in header
@@ -187,6 +185,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		verifiedAuthSources[i] = k
 		i++
 	}
+
 	// Check if any of the specified auth sources is verified
 	isAuthorized := tool.Authorized(verifiedAuthSources)
 	if !isAuthorized {

--- a/internal/tools/parameters.go
+++ b/internal/tools/parameters.go
@@ -93,7 +93,7 @@ func parseFromAuthSource(paramAuthSources []ParamAuthSource, claimsMap map[strin
 		}
 		return v, nil
 	}
-	return nil, fmt.Errorf("missing authentication header")
+	return nil, fmt.Errorf("missing or invalid authentication header")
 }
 
 // ParseParams is a helper function for parsing Parameters from an arbitraryJSON object.


### PR DESCRIPTION
Currently, we are throwing 401 error immediately after auth token verification failure. This is not expected in the following situations:
1. Non-auth tool invocation with auth token that is invalid.
2. Auth tool invocation with all the required auth token, but the header contains extra non-required token that is invalid
These requests should pass the authorization check but fail under the current implementation.

Change made in this PR:
1. Do not throw error immediately after auth token verification failure. Instead only log it and continue to the next header iteration.
2. In the parseParams() method, if an auth parameter is missing, we should error with the message telling the user that either the auth header is missing or is invalid.
