### PR TITLE
doc: Update README to improve Toolbox LangChain SDK installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,20 +129,22 @@ application. See below the list of Client SDKs for using various frameworks:
 <details open>
 <summary>LangChain / LangGraph</summary>
 
-Once you've installed the [Toolbox LangChain][toolbox-langchain], you can load
-tools:
+1. Install [Toolbox LangChain SDK][toolbox-langchain]:
+    ```bash
+    pip install toolbox-langchain
+    ```
+1. Load tools:
+    ```python
+    from toolbox_langchain import ToolboxClient
 
-```python
-from toolbox_langchain import ToolboxClient
+    # update the url to point to your server
+    client = ToolboxClient("http://127.0.0.1:5000")
 
-# update the url to point to your server
-client = ToolboxClient("http://127.0.0.1:5000")
+    # these tools can be passed to your application! 
+    tools = await client.aload_toolset()
+    ```
 
-# these tools can be passed to your application! 
-tools = await client.aload_toolset()
-```
-
-For more detailed instructions on using the Toolbox LangChain, see the
+For more detailed instructions on using the Toolbox LangChain SDK, see the
 [project's README][toolbox-langchain-readme].
 
 [toolbox-langchain]: https://github.com/googleapis/genai-toolbox-langchain-python

--- a/docs/en/getting-started/configure.md
+++ b/docs/en/getting-started/configure.md
@@ -78,5 +78,5 @@ You can load toolsets by name:
 all_tools = await client.aload_toolset()
 
 # This will only load the tools listed in 'my_second_toolset'
-my_second_toolset = await aclient.load_toolset("my_second_toolset")
+my_second_toolset = await client.aload_toolset("my_second_toolset")
 ```

--- a/docs/en/resources/authSources/_index.md
+++ b/docs/en/resources/authSources/_index.md
@@ -66,10 +66,10 @@ async def get_auth_token():
     return "YOUR_ID_TOKEN" # Placeholder
 
 # for a single tool use:
-authorized_tool = await toolbox.load_tool("my-tool-name", auth_tokens={"my_auth": get_auth_token})
+authorized_tool = await toolbox.aload_tool("my-tool-name", auth_tokens={"my_auth": get_auth_token})
 
 # for a toolset use: 
-authorized_tools = await toolbox.load_toolset("my-toolset-name", auth_tokens={"my_auth": get_auth_token})
+authorized_tools = await toolbox.aload_toolset("my-toolset-name", auth_tokens={"my_auth": get_auth_token})
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -78,7 +78,7 @@ authorized_tools = await toolbox.load_toolset("my-toolset-name", auth_tokens={"m
 
 {{< tabpane >}}
 {{< tab header="LangChain" lang="Python" >}}
-tools = await toolbox.load_toolset()
+tools = await toolbox.aload_toolset()
 # for a single token
 auth_tools = [tool.add_auth_token("my_auth", get_auth_token) for tool in tools]
 # OR, if multiple tokens are needed


### PR DESCRIPTION
Add the bash command to `pip install` the package directly in the README for a quicker start.

Also add “SDK” after “Toolbox LangChain” to clearly show that “Toolbox LangChain” is an SDK.

> [!NOTE]
> We had released the PyPI package for Toolbox LangChain SDK as `toolbox-langchain` and not `toolbox-langchain-sdk` but it still makes sense to call it “Toolbox LangChain SDK” in natural language.