### PR TITLE
fix: throw error when items field is missing from array parameter

### DIFF
--- a/internal/tools/parameters_test.go
+++ b/internal/tools/parameters_test.go
@@ -709,3 +709,42 @@ func TestParamManifest(t *testing.T) {
 		})
 	}
 }
+
+func TestFailParametersUnmarshal(t *testing.T) {
+	tcs := []struct {
+		name string
+		in   []map[string]any
+		err  string
+	}{
+		{
+			name: "string array",
+			in: []map[string]any{
+				{
+					"name":        "my_array",
+					"type":        "array",
+					"description": "this param is an array of strings",
+				},
+			},
+			err: "unable to parse as \"array\": unable to parse 'items' field: error parsing parameters: nothing to unmarshal",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var got tools.Parameters
+			// parse map to bytes
+			data, err := yaml.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("unable to marshal input to yaml: %s", err)
+			}
+			// parse bytes to object
+			err = yaml.Unmarshal(data, &got)
+			if err == nil {
+				t.Fatalf("expect parsing to fail")
+			}
+			errStr := err.Error()
+			if errStr != tc.err {
+				t.Fatalf("unexpected error: got %q, want %q", errStr, tc.err)
+			}
+		})
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -36,6 +36,9 @@ func (d *DelayedUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) er
 }
 
 func (d *DelayedUnmarshaler) Unmarshal(v interface{}) error {
+	if d.unmarshal == nil {
+		return fmt.Errorf("nothing to unmarshal")
+	}
 	return d.unmarshal(v)
 }
 


### PR DESCRIPTION
Fixes #291 by throwing a descriptive error when items is not provided.

Example of error when `items` field not provided for array parameter:
```
2025-02-18T14:07:58.77173-08:00 ERROR "unable to parse tool file at \"tools.yaml\": unable to parse as \"postgres-sql\": unable to parse as \"array\": unable to parse 'items' field: error parsing parameters: nothing to unmarshal"
```