### PR TITLE
fix: validate required common fields for parameters

### DIFF
--- a/internal/tools/parameters.go
+++ b/internal/tools/parameters.go
@@ -189,34 +189,38 @@ func parseParamFromDelayedUnmarshaler(u *util.DelayedUnmarshaler) (Parameter, er
 		return nil, fmt.Errorf("parameter is missing 'type' field: %w", err)
 	}
 
+	dec, err := util.NewStrictDecoder(p)
+	if err != nil {
+		return nil, fmt.Errorf("error creating decoder: %w", err)
+	}
 	switch t {
 	case typeString:
 		a := &StringParameter{}
-		if err := u.Unmarshal(a); err != nil {
+		if err := dec.Decode(a); err != nil {
 			return nil, fmt.Errorf("unable to parse as %q: %w", t, err)
 		}
 		return a, nil
 	case typeInt:
 		a := &IntParameter{}
-		if err := u.Unmarshal(a); err != nil {
+		if err := dec.Decode(a); err != nil {
 			return nil, fmt.Errorf("unable to parse as %q: %w", t, err)
 		}
 		return a, nil
 	case typeFloat:
 		a := &FloatParameter{}
-		if err := u.Unmarshal(a); err != nil {
+		if err := dec.Decode(a); err != nil {
 			return nil, fmt.Errorf("unable to parse as %q: %w", t, err)
 		}
 		return a, nil
 	case typeBool:
 		a := &BooleanParameter{}
-		if err := u.Unmarshal(a); err != nil {
+		if err := dec.Decode(a); err != nil {
 			return nil, fmt.Errorf("unable to parse as %q: %w", t, err)
 		}
 		return a, nil
 	case typeArray:
 		a := &ArrayParameter{}
-		if err := u.Unmarshal(a); err != nil {
+		if err := dec.Decode(a); err != nil {
 			return nil, fmt.Errorf("unable to parse as %q: %w", t, err)
 		}
 		return a, nil
@@ -243,9 +247,9 @@ type ParameterManifest struct {
 
 // CommonParameter are default fields that are emebdding in most Parameter implementations. Embedding this stuct will give the object Name() and Type() functions.
 type CommonParameter struct {
-	Name        string            `yaml:"name"`
-	Type        string            `yaml:"type"`
-	Desc        string            `yaml:"description"`
+	Name        string            `yaml:"name" validate:"required"`
+	Type        string            `yaml:"type" validate:"required"`
+	Desc        string            `yaml:"description" validate:"required"`
 	AuthSources []ParamAuthSource `yaml:"authSources"`
 }
 

--- a/internal/tools/parameters_test.go
+++ b/internal/tools/parameters_test.go
@@ -92,12 +92,14 @@ func TestParametersMarshal(t *testing.T) {
 					"type":        "array",
 					"description": "this param is an array of strings",
 					"items": map[string]string{
-						"type": "string",
+						"name":        "my_string",
+						"type":        "string",
+						"description": "string item",
 					},
 				},
 			},
 			want: tools.Parameters{
-				tools.NewArrayParameter("my_array", "this param is an array of strings", tools.NewStringParameter("", "")),
+				tools.NewArrayParameter("my_array", "this param is an array of strings", tools.NewStringParameter("my_string", "string item")),
 			},
 		},
 		{
@@ -108,12 +110,14 @@ func TestParametersMarshal(t *testing.T) {
 					"type":        "array",
 					"description": "this param is an array of floats",
 					"items": map[string]string{
-						"type": "float",
+						"name":        "my_float",
+						"type":        "float",
+						"description": "float item",
 					},
 				},
 			},
 			want: tools.Parameters{
-				tools.NewArrayParameter("my_array", "this param is an array of floats", tools.NewFloatParameter("", "")),
+				tools.NewArrayParameter("my_array", "this param is an array of floats", tools.NewFloatParameter("my_float", "float item")),
 			},
 		},
 	}
@@ -244,7 +248,9 @@ func TestAuthParametersMarshal(t *testing.T) {
 					"type":        "array",
 					"description": "this param is an array of strings",
 					"items": map[string]string{
-						"type": "string",
+						"name":        "my_string",
+						"type":        "string",
+						"description": "string item",
 					},
 					"authSources": []map[string]string{
 						{
@@ -259,7 +265,7 @@ func TestAuthParametersMarshal(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewArrayParameterWithAuth("my_array", "this param is an array of strings", tools.NewStringParameter("", ""), authSources),
+				tools.NewArrayParameterWithAuth("my_array", "this param is an array of strings", tools.NewStringParameter("my_string", "string item"), authSources),
 			},
 		},
 		{
@@ -270,7 +276,9 @@ func TestAuthParametersMarshal(t *testing.T) {
 					"type":        "array",
 					"description": "this param is an array of floats",
 					"items": map[string]string{
-						"type": "float",
+						"name":        "my_float",
+						"type":        "float",
+						"description": "float item",
 					},
 					"authSources": []map[string]string{
 						{
@@ -285,7 +293,7 @@ func TestAuthParametersMarshal(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewArrayParameterWithAuth("my_array", "this param is an array of floats", tools.NewFloatParameter("", ""), authSources),
+				tools.NewArrayParameterWithAuth("my_array", "this param is an array of floats", tools.NewFloatParameter("my_float", "float item"), authSources),
 			},
 		},
 	}
@@ -717,7 +725,37 @@ func TestFailParametersUnmarshal(t *testing.T) {
 		err  string
 	}{
 		{
-			name: "string array",
+			name: "common parameter missing name",
+			in: []map[string]any{
+				{
+					"type":        "string",
+					"description": "this is a param for string",
+				},
+			},
+			err: "unable to parse as \"string\": Key: 'CommonParameter.Name' Error:Field validation for 'Name' failed on the 'required' tag",
+		},
+		{
+			name: "common parameter missing type",
+			in: []map[string]any{
+				{
+					"name":        "string",
+					"description": "this is a param for string",
+				},
+			},
+			err: "parameter is missing 'type' field: %!w(<nil>)",
+		},
+		{
+			name: "common parameter missing description",
+			in: []map[string]any{
+				{
+					"name": "my_string",
+					"type": "string",
+				},
+			},
+			err: "unable to parse as \"string\": Key: 'CommonParameter.Desc' Error:Field validation for 'Desc' failed on the 'required' tag",
+		},
+		{
+			name: "array parameter missing items",
 			in: []map[string]any{
 				{
 					"name":        "my_array",
@@ -726,6 +764,21 @@ func TestFailParametersUnmarshal(t *testing.T) {
 				},
 			},
 			err: "unable to parse as \"array\": unable to parse 'items' field: error parsing parameters: nothing to unmarshal",
+		},
+		{
+			name: "array parameter missing items' name",
+			in: []map[string]any{
+				{
+					"name":        "my_array",
+					"type":        "array",
+					"description": "this param is an array of strings",
+					"items": map[string]string{
+						"type":        "string",
+						"description": "string item",
+					},
+				},
+			},
+			err: "unable to parse as \"array\": unable to parse 'items' field: unable to parse as \"string\": Key: 'CommonParameter.Name' Error:Field validation for 'Name' failed on the 'required' tag",
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/tools/parameters_test.go
+++ b/internal/tools/parameters_test.go
@@ -709,3 +709,42 @@ func TestParamManifest(t *testing.T) {
 		})
 	}
 }
+
+func TestFailParametersUnmarshal(t *testing.T) {
+	tcs := []struct {
+		name string
+		in   []map[string]any
+		err  string
+	}{
+		{
+			name: "string array",
+			in: []map[string]any{
+				{
+					"name":        "my_array",
+					"type":        "array",
+					"description": "this param is an array of strings",
+				},
+			},
+			err: "unable to parse as \"array\": unable to parse 'items' field: error parsing parameters: nothing to unmarshal",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var got tools.Parameters
+			// parse map to bytes
+			data, err := yaml.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("unable to marshal input to yaml: %s", err)
+			}
+			// parse bytes to object
+			err = yaml.Unmarshal(data, &got)
+			if err == nil {
+				t.Fatalf("expect parsing to fail")
+			}
+			errStr := err.Error()
+			if errStr != tc.err {
+				t.Fatalf("unexpected error: got %q, want %q", errStr, tc.err)
+			}
+		})
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -36,6 +36,9 @@ func (d *DelayedUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) er
 }
 
 func (d *DelayedUnmarshaler) Unmarshal(v interface{}) error {
+	if d.unmarshal == nil {
+		return fmt.Errorf("nothing to unmarshal")
+	}
 	return d.unmarshal(v)
 }
 


### PR DESCRIPTION
Check common parameters for required fields. Throw an error if name or description is not provided.

Example of error when `description` field not provided:
```
2025-02-18T14:11:55.475101-08:00 ERROR "unable to parse tool file at \"tools.yaml\": unable to parse as \"postgres-sql\": unable to parse as \"array\": Key: 'CommonParameter.Desc' Error:Field validation for 'Desc' failed on the 'required' tag"
```