### PR TITLE
docs(tool/spanner-sql): fix spanner-sql kind in example

### DIFF
--- a/docs/en/resources/tools/spanner-sql.md
+++ b/docs/en/resources/tools/spanner-sql.md
@@ -40,7 +40,7 @@ the second parameter, and so on.
 
 tools:
  search_flights_by_number:
-    kind: spanner
+    kind: spanner-sql
     source: my-spanner-instance
     statement: |
       SELECT * FROM flights


### PR DESCRIPTION
Update `spanner-sql` kind in example. It was previously updated throughout the doc, except for the example.
It should be `spanner-sql` instead of `spanner`.

Fixes #302