### PR TITLE
chore: update "Hello, World!" message from the default route of Toolbox.

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -224,7 +224,7 @@ func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, er
 	r.Mount("/api", apiR)
 	// default endpoint for validating server is running
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("🧰 Hello world! 🧰"))
+		_, _ = w.Write([]byte("🧰 Hello, World! 🧰"))
 	})
 
 	return s, nil


### PR DESCRIPTION
The above message is more accurate than the current `"Hello world!"` message. [wiki](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program)