### PR TITLE
feat: add http post endpoint for mcp

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -24,8 +24,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
-	"github.com/google/uuid"
-	"github.com/googleapis/genai-toolbox/internal/server/mcp"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -47,8 +45,6 @@ func apiRouter(s *Server) (chi.Router, error) {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) { toolGetHandler(s, w, r) })
 		r.Post("/invoke", func(w http.ResponseWriter, r *http.Request) { toolInvokeHandler(s, w, r) })
 	})
-
-	r.Post("/mcp", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
 
 	return r, nil
 }
@@ -233,59 +229,6 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	}
 
 	_ = render.Render(w, r, &resultResponse{Result: string(resMarshal)})
-}
-
-// mcpHandler handles all mcp messages.
-func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
-	var message json.RawMessage
-	if err := json.NewDecoder(r.Body).Decode(&message); err != nil {
-		id := uuid.New().String()
-		render.JSON(w, r, newJSONRPCError(id, mcp.PARSE_ERROR, err.Error(), nil))
-		return
-	}
-
-	var baseMessage struct {
-		Jsonrpc string        `json:"jsonrpc"`
-		Method  string        `json:"method"`
-		Id      mcp.RequestId `json:"id,omitempty"`
-	}
-	if err := json.Unmarshal(message, &baseMessage); err != nil {
-		render.JSON(w, r, newJSONRPCError(baseMessage.Id, mcp.PARSE_ERROR, err.Error(), nil))
-		return
-	}
-
-	// Check if method is present
-	if baseMessage.Method == "" {
-		render.JSON(w, r, newJSONRPCError(baseMessage.Id, mcp.METHOD_NOT_FOUND, "method not found", nil))
-		return
-	}
-
-	// Check for JSON-RPC 2.0
-	if baseMessage.Jsonrpc != mcp.JSONRPC_VERSION {
-		render.JSON(w, r, newJSONRPCError(baseMessage.Id, mcp.INVALID_REQUEST, "invalid json-rpc version", nil))
-		return
-	}
-
-	// return empty response
-	res := mcp.JSONRPCResponse{
-		Jsonrpc: mcp.JSONRPC_VERSION,
-		Id:      baseMessage.Id,
-		Result:  mcp.EmptyResult{},
-	}
-	render.JSON(w, r, res)
-}
-
-// newJSONRPCError is the response sent back when an error has been encountered in mcp.
-func newJSONRPCError(id mcp.RequestId, code int, message string, data any) mcp.JSONRPCError {
-	return mcp.JSONRPCError{
-		Jsonrpc: mcp.JSONRPC_VERSION,
-		Id:      id,
-		Error: mcp.McpError{
-			Code:    code,
-			Message: message,
-			Data:    data,
-		},
-	}
 }
 
 var _ render.Renderer = &resultResponse{} // Renderer interface for managing response payloads.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestToolsetEndpoint(t *testing.T) {
 	toolsMap, toolsets := setUpResources(t)
-	ts, shutdown := setUpServer(t, toolsMap, toolsets)
+	ts, shutdown := setUpServer(t, "api", toolsMap, toolsets)
 	defer shutdown()
 
 	// wantResponse is a struct for checks against test cases
@@ -119,7 +119,7 @@ func TestToolsetEndpoint(t *testing.T) {
 
 func TestToolGetEndpoint(t *testing.T) {
 	toolsMap, toolsets := setUpResources(t)
-	ts, shutdown := setUpServer(t, toolsMap, toolsets)
+	ts, shutdown := setUpServer(t, "api", toolsMap, toolsets)
 	defer shutdown()
 
 	// wantResponse is a struct for checks against test cases

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/render"
+	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/server/mcp"
+)
+
+// mcpRouter creates a router that represents the routes under /mcp
+func mcpRouter(s *Server) (chi.Router, error) {
+	r := chi.NewRouter()
+
+	r.Use(middleware.AllowContentType("application/json"))
+	r.Use(middleware.StripSlashes)
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+
+	r.Post("/", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
+
+	return r, nil
+}
+
+// mcpHandler handles all mcp messages.
+func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
+	var baseMessage struct {
+		Jsonrpc string        `json:"jsonrpc"`
+		Method  string        `json:"method"`
+		Id      mcp.RequestId `json:"id,omitempty"`
+	}
+	if err := decodeJSON(r.Body, &baseMessage); err != nil {
+		// Generate a new uuid if unable to decode
+		id := uuid.New().String()
+		render.JSON(w, r, newJSONRPCError(id, mcp.PARSE_ERROR, err.Error(), nil))
+		return
+	}
+
+	// Check if method is present
+	if baseMessage.Method == "" {
+		render.JSON(w, r, newJSONRPCError(baseMessage.Id, mcp.METHOD_NOT_FOUND, "method not found", nil))
+		return
+	}
+
+	// Check for JSON-RPC 2.0
+	if baseMessage.Jsonrpc != mcp.JSONRPC_VERSION {
+		render.JSON(w, r, newJSONRPCError(baseMessage.Id, mcp.INVALID_REQUEST, "invalid json-rpc version", nil))
+		return
+	}
+
+	// return empty response
+	res := mcp.JSONRPCResponse{
+		Jsonrpc: mcp.JSONRPC_VERSION,
+		Id:      baseMessage.Id,
+		Result:  mcp.EmptyResult{},
+	}
+	render.JSON(w, r, res)
+}
+
+// newJSONRPCError is the response sent back when an error has been encountered in mcp.
+func newJSONRPCError(id mcp.RequestId, code int, message string, data any) mcp.JSONRPCError {
+	return mcp.JSONRPCError{
+		Jsonrpc: mcp.JSONRPC_VERSION,
+		Id:      id,
+		Error: mcp.McpError{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+}

--- a/internal/server/mcp/types.go
+++ b/internal/server/mcp/types.go
@@ -20,9 +20,19 @@ const LATEST_PROTOCOL_VERSION = "2024-11-05"
 // JSONRPC_VERSION is the version of JSON-RPC used by MCP.
 const JSONRPC_VERSION = "2.0"
 
+// Standard JSON-RPC error codes
+const (
+	PARSE_ERROR      = -32700
+	INVALID_REQUEST  = -32600
+	METHOD_NOT_FOUND = -32601
+	INVALID_PARAMS   = -32602
+	INTERNAL_ERROR   = -32603
+)
+
 // ProgressToken is used to associate progress notifications with the original request.
 type ProgressToken interface{}
 
+// Request represents a bidirectional message with method and parameters expecting a response.
 type Request struct {
 	Method string `json:"method"`
 	Params struct {
@@ -38,8 +48,7 @@ type Request struct {
 	} `json:"params,omitempty"`
 }
 
-type Params map[string]interface{}
-
+// Notification is a one-way message requiring no response.
 type Notification struct {
 	Method string `json:"method"`
 	Params struct {
@@ -47,6 +56,7 @@ type Notification struct {
 	} `json:"params,omitempty"`
 }
 
+// Result represents a response for the request query.
 type Result struct {
 	// This result property is reserved by the protocol to allow clients and
 	// servers to attach additional metadata to their responses.
@@ -96,31 +106,7 @@ type JSONRPCError struct {
 	Error   McpError  `json:"error"`
 }
 
-/* JSON-RPC types*/
-
-// JSONRPCMessage represents either a JSONRPCRequest, JSONRPCNotification, JSONRPCResponse, or JSONRPCError
-type JSONRPCMessage interface{}
-
-var _ JSONRPCMessage = JSONRPCError{}
-var _ JSONRPCMessage = JSONRPCRequest{}
-var _ JSONRPCMessage = JSONRPCResponse{}
-var _ JSONRPCMessage = JSONRPCError{}
-
-// Standard JSON-RPC error codes
-const (
-	PARSE_ERROR      = -32700
-	INVALID_REQUEST  = -32600
-	METHOD_NOT_FOUND = -32601
-	INVALID_PARAMS   = -32602
-	INTERNAL_ERROR   = -32603
-)
-
 /* Empty result */
 
 // EmptyResult represents a response that indicates success but carries no data.
 type EmptyResult Result
-
-// ServerResult represents a EmptyResult.
-type ServerResult interface{}
-
-var _ ServerResult = EmptyResult{}

--- a/internal/server/mcp/types.go
+++ b/internal/server/mcp/types.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+// LATEST_PROTOCOL_VERSION is the most recent version of the MCP protocol.
+const LATEST_PROTOCOL_VERSION = "2024-11-05"
+
+// JSONRPC_VERSION is the version of JSON-RPC used by MCP.
+const JSONRPC_VERSION = "2.0"
+
+// ProgressToken is used to associate progress notifications with the original request.
+type ProgressToken interface{}
+
+type Request struct {
+	Method string `json:"method"`
+	Params struct {
+		Meta struct {
+			// If specified, the caller is requesting out-of-band progress
+			// notifications for this request (as represented by
+			// notifications/progress). The value of this parameter is an
+			// opaque token that will be attached to any subsequent
+			// notifications. The receiver is not obligated to provide these
+			// notifications.
+			ProgressToken ProgressToken `json:"progressToken,omitempty"`
+		} `json:"_meta,omitempty"`
+	} `json:"params,omitempty"`
+}
+
+type Params map[string]interface{}
+
+type Notification struct {
+	Method string `json:"method"`
+	Params struct {
+		Meta map[string]interface{} `json:"_meta,omitempty"`
+	} `json:"params,omitempty"`
+}
+
+type Result struct {
+	// This result property is reserved by the protocol to allow clients and
+	// servers to attach additional metadata to their responses.
+	Meta map[string]interface{} `json:"_meta,omitempty"`
+}
+
+// RequestId is a uniquely identifying ID for a request in JSON-RPC.
+// It can be any JSON-serializable value, typically a number or string.
+type RequestId interface{}
+
+// JSONRPCRequest represents a request that expects a response.
+type JSONRPCRequest struct {
+	Jsonrpc string    `json:"jsonrpc"`
+	Id      RequestId `json:"id"`
+	Request
+}
+
+// JSONRPCNotification represents a notification which does not expect a response.
+type JSONRPCNotification struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Notification
+}
+
+// JSONRPCResponse represents a successful (non-error) response to a request.
+type JSONRPCResponse struct {
+	Jsonrpc string      `json:"jsonrpc"`
+	Id      RequestId   `json:"id"`
+	Result  interface{} `json:"result"`
+}
+
+// McpError represents the error content.
+type McpError struct {
+	// The error type that occurred.
+	Code int `json:"code"`
+	// A short description of the error. The message SHOULD be limited
+	// to a concise single sentence.
+	Message string `json:"message"`
+	// Additional information about the error. The value of this member
+	// is defined by the sender (e.g. detailed error information, nested errors etc.).
+	Data interface{} `json:"data,omitempty"`
+}
+
+// JSONRPCError represents a non-successful (error) response to a request.
+type JSONRPCError struct {
+	Jsonrpc string    `json:"jsonrpc"`
+	Id      RequestId `json:"id"`
+	Error   McpError  `json:"error"`
+}
+
+/* JSON-RPC types*/
+
+// JSONRPCMessage represents either a JSONRPCRequest, JSONRPCNotification, JSONRPCResponse, or JSONRPCError
+type JSONRPCMessage interface{}
+
+var _ JSONRPCMessage = JSONRPCError{}
+var _ JSONRPCMessage = JSONRPCRequest{}
+var _ JSONRPCMessage = JSONRPCResponse{}
+var _ JSONRPCMessage = JSONRPCError{}
+
+// Standard JSON-RPC error codes
+const (
+	PARSE_ERROR      = -32700
+	INVALID_REQUEST  = -32600
+	METHOD_NOT_FOUND = -32601
+	INVALID_PARAMS   = -32602
+	INTERNAL_ERROR   = -32603
+)
+
+/* Empty result */
+
+// EmptyResult represents a response that indicates success but carries no data.
+type EmptyResult Result
+
+// ServerResult represents a EmptyResult.
+type ServerResult interface{}
+
+var _ ServerResult = EmptyResult{}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/googleapis/genai-toolbox/internal/server/mcp"
+)
+
+const jsonrpcVersion = "2.0"
+
+func TestMcpEndpoint(t *testing.T) {
+	toolsMap, toolsets := setUpResources(t)
+	ts, shutdown := setUpServer(t, "mcp", toolsMap, toolsets)
+	defer shutdown()
+
+	testCases := []struct {
+		name  string
+		isErr bool
+		body  mcp.JSONRPCRequest
+		want  map[string]any
+	}{
+		{
+			name:  "basic mcp",
+			isErr: false,
+			body: mcp.JSONRPCRequest{
+				Jsonrpc: jsonrpcVersion,
+				Id:      "basic-mcp",
+				Request: mcp.Request{
+					Method: "foo",
+				},
+			},
+			want: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "basic-mcp",
+				"result":  map[string]any{},
+			},
+		},
+		{
+			name:  "missing method",
+			isErr: true,
+			body: mcp.JSONRPCRequest{
+				Jsonrpc: jsonrpcVersion,
+				Id:      "missing-method",
+				Request: mcp.Request{},
+			},
+			want: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "missing-method",
+				"error": map[string]any{
+					"code":    -32601.0,
+					"message": "method not found",
+				},
+			},
+		},
+		{
+			name:  "invalid jsonrpc version",
+			isErr: true,
+			body: mcp.JSONRPCRequest{
+				Jsonrpc: "1.0",
+				Id:      "invalid-jsonrpc-version",
+				Request: mcp.Request{
+					Method: "foo",
+				},
+			},
+			want: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "invalid-jsonrpc-version",
+				"error": map[string]any{
+					"code":    -32600.0,
+					"message": "invalid json-rpc version",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqMarshal, err := json.Marshal(tc.body)
+			if err != nil {
+				t.Fatalf("unexpected error during marshaling of body")
+			}
+
+			resp, body, err := runRequest(ts, http.MethodPost, "/", bytes.NewBuffer(reqMarshal))
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+
+			if contentType := resp.Header.Get("Content-type"); contentType != "application/json" {
+				t.Fatalf("unexpected content-type header: want %s, got %s", "application/json", contentType)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("unexpected error unmarshalling body: %s", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("unexpected response: got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -221,6 +221,11 @@ func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, er
 		return nil, err
 	}
 	r.Mount("/api", apiR)
+	mcpR, err := mcpRouter(s)
+	if err != nil {
+		return nil, err
+	}
+	r.Mount("/mcp", mcpR)
 	// default endpoint for validating server is running
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("🧰 Hello, World! 🧰"))


### PR DESCRIPTION
Add http post endpoint for mcp at `api/mcp`. Types are based on the 2024-11-05 [specification](https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.ts).

Tested with:
`curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "foo"}' http://127.0.0.1:5000/mcp`
Response:
`{"jsonrpc":"2.0","id":1,"result":{}}`

Test cases included.