### PR TITLE
feat: support connection lifecycle initialize phase

### DIFF
--- a/internal/server/mcp/method.go
+++ b/internal/server/mcp/method.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+func Initialize(version string) InitializeResult {
+	toolsListChanged := false
+	result := InitializeResult{
+		ProtocolVersion: LATEST_PROTOCOL_VERSION,
+		Capabilities: ServerCapabilities{
+			Tools: &ListChanged{
+				ListChanged: &toolsListChanged,
+			},
+		},
+		ServerInfo: Implementation{
+			Name:    SERVER_NAME,
+			Version: version,
+		},
+	}
+	return result
+}

--- a/internal/server/mcp/types.go
+++ b/internal/server/mcp/types.go
@@ -14,6 +14,9 @@
 
 package mcp
 
+// SERVER_NAME is the server name used in Implementation.
+const SERVER_NAME = "Toolbox"
+
 // LATEST_PROTOCOL_VERSION is the most recent version of the MCP protocol.
 const LATEST_PROTOCOL_VERSION = "2024-11-05"
 
@@ -28,6 +31,9 @@ const (
 	INVALID_PARAMS   = -32602
 	INTERNAL_ERROR   = -32603
 )
+
+// JSONRPCMessage represents either a JSONRPCRequest, JSONRPCNotification, JSONRPCResponse, or JSONRPCError.
+type JSONRPCMessage interface{}
 
 // ProgressToken is used to associate progress notifications with the original request.
 type ProgressToken interface{}
@@ -110,3 +116,75 @@ type JSONRPCError struct {
 
 // EmptyResult represents a response that indicates success but carries no data.
 type EmptyResult Result
+
+/* Initialization */
+
+// Params to define MCP Client during initialize request.
+type InitializeParams struct {
+	// The latest version of the Model Context Protocol that the client supports.
+	// The client MAY decide to support older versions as well.
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ClientCapabilities `json:"capabilities"`
+	ClientInfo      Implementation     `json:"clientInfo"`
+}
+
+// InitializeRequest is sent from the client to the server when it first
+// connects, asking it to begin initialization.
+type InitializeRequest struct {
+	Request
+	Params InitializeParams `json:"params"`
+}
+
+// InitializeResult is sent after receiving an initialize request from the
+// client.
+type InitializeResult struct {
+	Result
+	// The version of the Model Context Protocol that the server wants to use.
+	// This may not match the version that the client requested. If the client cannot
+	// support this version, it MUST disconnect.
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ServerCapabilities `json:"capabilities"`
+	ServerInfo      Implementation     `json:"serverInfo"`
+	// Instructions describing how to use the server and its features.
+	//
+	// This can be used by clients to improve the LLM's understanding of
+	// available tools, resources, etc. It can be thought of like a "hint" to the model.
+	// For example, this information MAY be added to the system prompt.
+	Instructions string `json:"instructions,omitempty"`
+}
+
+// InitializedNotification is sent from the client to the server after
+// initialization has finished.
+type InitializedNotification struct {
+	Notification
+}
+
+// ListChange represents whether the server supports notification for changes to the capabilities.
+type ListChanged struct {
+	ListChanged *bool `json:"listChanged,omitempty"`
+}
+
+// ClientCapabilities represents capabilities a client may support. Known
+// capabilities are defined here, in this schema, but this is not a closed set: any
+// client can define its own, additional capabilities.
+type ClientCapabilities struct {
+	// Experimental, non-standard capabilities that the client supports.
+	Experimental map[string]interface{} `json:"experimental,omitempty"`
+	// Present if the client supports listing roots.
+	Roots *ListChanged `json:"roots,omitempty"`
+	// Present if the client supports sampling from an LLM.
+	Sampling struct{} `json:"sampling,omitempty"`
+}
+
+// ServerCapabilities represents capabilities that a server may support. Known
+// capabilities are defined here, in this schema, but this is not a closed set: any
+// server can define its own, additional capabilities.
+type ServerCapabilities struct {
+	Tools *ListChanged `json:"tools,omitempty"`
+}
+
+// Implementation describes the name and version of an MCP implementation.
+type Implementation struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}


### PR DESCRIPTION
Add support for the `initialize` phase for mcp's connection lifecycle.

After receiving the `initialize` request, the server will respond with it's own capabilities and information. Since there are only one protocol supported, we don't have to do protocol version comparison. Toolbox server will response with the default protocol version.

Initial support for MCP Tools will not include list changed notification.

Test cases included.