### PR TITLE
feat: parse manifest to tools list

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -62,6 +62,29 @@ func (t MockTool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
+func (t MockTool) McpManifest() tools.McpManifest {
+	properties := make(map[string]tools.ParameterMcpManifest)
+	required := make([]string, 0)
+
+	for _, p := range t.Params {
+		name := p.GetName()
+		properties[name] = p.McpManifest()
+		required = append(required, name)
+	}
+
+	toolsSchema := tools.McpToolsSchema{
+		Type:       "object",
+		Properties: properties,
+		Required:   required,
+	}
+
+	return tools.McpManifest{
+		Name:        t.Name,
+		Description: t.Description,
+		InputSchema: toolsSchema,
+	}
+}
+
 var tool1 = MockTool{
 	Name:   "no_params",
 	Params: []tools.Parameter{},

--- a/internal/tools/dgraph/dgraph.go
+++ b/internal/tools/dgraph/dgraph.go
@@ -65,6 +65,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
 	}
 
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: cfg.Parameters.McpManifest(),
+	}
+
 	// finish tool setup
 	t := Tool{
 		Name:         cfg.Name,
@@ -75,6 +81,7 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		IsQuery:      cfg.IsQuery,
 		Timeout:      cfg.Timeout,
 		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		mcpManifest:  mcpManifest,
 	}
 	return t, nil
 }
@@ -92,6 +99,7 @@ type Tool struct {
 	Timeout      string
 	Statement    string
 	manifest     tools.Manifest
+	mcpManifest  tools.McpManifest
 }
 
 func (t Tool) Invoke(params tools.ParamValues) ([]any, error) {
@@ -125,6 +133,10 @@ func (t Tool) ParseParams(data map[string]any, claimsMap map[string]map[string]a
 
 func (t Tool) Manifest() tools.Manifest {
 	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
 }
 
 func (t Tool) Authorized(verifiedAuthServices []string) bool {

--- a/internal/tools/mssqlsql/mssqlsql.go
+++ b/internal/tools/mssqlsql/mssqlsql.go
@@ -68,6 +68,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
 	}
 
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: cfg.Parameters.McpManifest(),
+	}
+
 	// finish tool setup
 	t := Tool{
 		Name:         cfg.Name,
@@ -77,6 +83,7 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		AuthRequired: cfg.AuthRequired,
 		Db:           s.MSSQLDB(),
 		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		mcpManifest:  mcpManifest,
 	}
 	return t, nil
 }
@@ -90,9 +97,10 @@ type Tool struct {
 	AuthRequired []string         `yaml:"authRequired"`
 	Parameters   tools.Parameters `yaml:"parameters"`
 
-	Db        *sql.DB
-	Statement string
-	manifest  tools.Manifest
+	Db          *sql.DB
+	Statement   string
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) Invoke(params tools.ParamValues) ([]any, error) {
@@ -155,6 +163,10 @@ func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any)
 
 func (t Tool) Manifest() tools.Manifest {
 	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
 }
 
 func (t Tool) Authorized(verifiedAuthServices []string) bool {

--- a/internal/tools/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysqlsql/mysqlsql.go
@@ -67,6 +67,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
 	}
 
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: cfg.Parameters.McpManifest(),
+	}
+
 	// finish tool setup
 	t := Tool{
 		Name:         cfg.Name,
@@ -76,6 +82,7 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		AuthRequired: cfg.AuthRequired,
 		Pool:         s.MySQLPool(),
 		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		mcpManifest:  mcpManifest,
 	}
 	return t, nil
 }
@@ -89,9 +96,10 @@ type Tool struct {
 	AuthRequired []string         `yaml:"authRequired"`
 	Parameters   tools.Parameters `yaml:"parameters"`
 
-	Pool      *sql.DB
-	Statement string
-	manifest  tools.Manifest
+	Pool        *sql.DB
+	Statement   string
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) Invoke(params tools.ParamValues) ([]any, error) {
@@ -150,6 +158,10 @@ func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any)
 
 func (t Tool) Manifest() tools.Manifest {
 	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
 }
 
 func (t Tool) Authorized(verifiedAuthServices []string) bool {

--- a/internal/tools/neo4j/neo4j.go
+++ b/internal/tools/neo4j/neo4j.go
@@ -66,15 +66,22 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
 	}
 
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: cfg.Parameters.McpManifest(),
+	}
+
 	// finish tool setup
 	t := Tool{
-		Name:       cfg.Name,
-		Kind:       ToolKind,
-		Parameters: cfg.Parameters,
-		Statement:  cfg.Statement,
-		Driver:     s.Neo4jDriver(),
-		Database:   s.Neo4jDatabase(),
-		manifest:   tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		Name:        cfg.Name,
+		Kind:        ToolKind,
+		Parameters:  cfg.Parameters,
+		Statement:   cfg.Statement,
+		Driver:      s.Neo4jDriver(),
+		Database:    s.Neo4jDatabase(),
+		manifest:    tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }
@@ -88,10 +95,11 @@ type Tool struct {
 	Parameters   tools.Parameters `yaml:"parameters"`
 	AuthRequired []string         `yaml:"authRequired"`
 
-	Driver    neo4j.DriverWithContext
-	Database  string
-	Statement string
-	manifest  tools.Manifest
+	Driver      neo4j.DriverWithContext
+	Database    string
+	Statement   string
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) Invoke(params tools.ParamValues) ([]any, error) {
@@ -125,6 +133,10 @@ func (t Tool) ParseParams(data map[string]any, claimsMap map[string]map[string]a
 
 func (t Tool) Manifest() tools.Manifest {
 	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
 }
 
 func (t Tool) Authorized(verifiedAuthServices []string) bool {

--- a/internal/tools/parameters_test.go
+++ b/internal/tools/parameters_test.go
@@ -847,6 +847,52 @@ func TestParamManifest(t *testing.T) {
 	}
 }
 
+func TestParamMcpManifest(t *testing.T) {
+	tcs := []struct {
+		name string
+		in   tools.Parameter
+		want tools.ParameterMcpManifest
+	}{
+		{
+			name: "string",
+			in:   tools.NewStringParameter("foo-string", "bar"),
+			want: tools.ParameterMcpManifest{Type: "string", Description: "bar"},
+		},
+		{
+			name: "int",
+			in:   tools.NewIntParameter("foo-int", "bar"),
+			want: tools.ParameterMcpManifest{Type: "integer", Description: "bar"},
+		},
+		{
+			name: "float",
+			in:   tools.NewFloatParameter("foo-float", "bar"),
+			want: tools.ParameterMcpManifest{Type: "float", Description: "bar"},
+		},
+		{
+			name: "boolean",
+			in:   tools.NewBooleanParameter("foo-bool", "bar"),
+			want: tools.ParameterMcpManifest{Type: "boolean", Description: "bar"},
+		},
+		{
+			name: "array",
+			in:   tools.NewArrayParameter("foo-array", "bar", tools.NewStringParameter("foo-string", "bar")),
+			want: tools.ParameterMcpManifest{
+				Type:        "array",
+				Description: "bar",
+				Items:       &tools.ParameterMcpManifest{Type: "string", Description: "bar"},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.McpManifest()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("unexpected manifest: got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFailParametersUnmarshal(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
 	if err != nil {

--- a/internal/tools/postgressql/postgressql.go
+++ b/internal/tools/postgressql/postgressql.go
@@ -69,6 +69,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
 	}
 
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: cfg.Parameters.McpManifest(),
+	}
+
 	// finish tool setup
 	t := Tool{
 		Name:         cfg.Name,
@@ -78,6 +84,7 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		AuthRequired: cfg.AuthRequired,
 		Pool:         s.PostgresPool(),
 		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		mcpManifest:  mcpManifest,
 	}
 	return t, nil
 }
@@ -91,9 +98,10 @@ type Tool struct {
 	AuthRequired []string         `yaml:"authRequired"`
 	Parameters   tools.Parameters `yaml:"parameters"`
 
-	Pool      *pgxpool.Pool
-	Statement string
-	manifest  tools.Manifest
+	Pool        *pgxpool.Pool
+	Statement   string
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) Invoke(params tools.ParamValues) ([]any, error) {
@@ -127,6 +135,10 @@ func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any)
 
 func (t Tool) Manifest() tools.Manifest {
 	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
 }
 
 func (t Tool) Authorized(verifiedAuthServices []string) bool {

--- a/internal/tools/spanner/spanner.go
+++ b/internal/tools/spanner/spanner.go
@@ -68,6 +68,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
 	}
 
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: cfg.Parameters.McpManifest(),
+	}
+
 	// finish tool setup
 	t := Tool{
 		Name:         cfg.Name,
@@ -78,6 +84,7 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		Client:       s.SpannerClient(),
 		dialect:      s.DatabaseDialect(),
 		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		mcpManifest:  mcpManifest,
 	}
 	return t, nil
 }
@@ -91,10 +98,11 @@ type Tool struct {
 	AuthRequired []string         `yaml:"authRequired"`
 	Parameters   tools.Parameters `yaml:"parameters"`
 
-	Client    *spanner.Client
-	dialect   string
-	Statement string
-	manifest  tools.Manifest
+	Client      *spanner.Client
+	dialect     string
+	Statement   string
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func getMapParams(params tools.ParamValues, dialect string) (map[string]interface{}, error) {
@@ -155,6 +163,10 @@ func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any)
 
 func (t Tool) Manifest() tools.Manifest {
 	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
 }
 
 func (t Tool) Authorized(verifiedAuthServices []string) bool {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -44,7 +44,7 @@ type McpManifest struct {
 	// The name of the tool.
 	Name string `json:"name"`
 	// A human-readable description of the tool.
-	Description string `json:"desciprtion,omitempty"`
+	Description string `json:"description,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
 	InputSchema McpToolsSchema `json:"inputSchema,omitempty"`
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -29,6 +29,7 @@ type Tool interface {
 	Invoke(ParamValues) ([]any, error)
 	ParseParams(map[string]any, map[string]map[string]any) (ParamValues, error)
 	Manifest() Manifest
+	McpManifest() McpManifest
 	Authorized([]string) bool
 }
 
@@ -36,6 +37,16 @@ type Tool interface {
 type Manifest struct {
 	Description string              `json:"description"`
 	Parameters  []ParameterManifest `json:"parameters"`
+}
+
+// Definition for a tool the MCP client can call.
+type McpManifest struct {
+	// The name of the tool.
+	Name string `json:"name"`
+	// A human-readable description of the tool.
+	Description string `json:"desciprtion,omitempty"`
+	// A JSON Schema object defining the expected parameters for the tool.
+	InputSchema McpToolsSchema `json:"inputSchema,omitempty"`
 }
 
 // Helper function that returns if a tool invocation request is authorized


### PR DESCRIPTION
Parse existing toolbox manifest to ToolsList that is compatible with MCP [tools definition](https://modelcontextprotocol.io/docs/concepts/tools#tool-definition-structure).

AuthServices will be omitted since MCP doesn't support auth at this time.
