### PR TITLE
chore: cleanup unused function

### DIFF
--- a/internal/tools/mssqlsql/mssqlsql.go
+++ b/internal/tools/mssqlsql/mssqlsql.go
@@ -81,18 +81,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	return t, nil
 }
 
-func NewGenericTool(name string, stmt string, authRequired []string, desc string, Db *sql.DB, parameters tools.Parameters) Tool {
-	return Tool{
-		Name:         name,
-		Kind:         ToolKind,
-		Statement:    stmt,
-		AuthRequired: authRequired,
-		Db:           Db,
-		manifest:     tools.Manifest{Description: desc, Parameters: parameters.Manifest()},
-		Parameters:   parameters,
-	}
-}
-
 // validate interface
 var _ tools.Tool = Tool{}
 

--- a/internal/tools/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysqlsql/mysqlsql.go
@@ -80,18 +80,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	return t, nil
 }
 
-func NewGenericTool(name string, stmt string, authRequired []string, desc string, pool *sql.DB, parameters tools.Parameters) Tool {
-	return Tool{
-		Name:         name,
-		Kind:         ToolKind,
-		Statement:    stmt,
-		AuthRequired: authRequired,
-		Pool:         pool,
-		manifest:     tools.Manifest{Description: desc, Parameters: parameters.Manifest()},
-		Parameters:   parameters,
-	}
-}
-
 // validate interface
 var _ tools.Tool = Tool{}
 

--- a/internal/tools/postgressql/postgressql.go
+++ b/internal/tools/postgressql/postgressql.go
@@ -82,18 +82,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	return t, nil
 }
 
-func NewGenericTool(name string, stmt string, authRequired []string, desc string, pool *pgxpool.Pool, parameters tools.Parameters) Tool {
-	return Tool{
-		Name:         name,
-		Kind:         ToolKind,
-		Statement:    stmt,
-		AuthRequired: authRequired,
-		Pool:         pool,
-		manifest:     tools.Manifest{Description: desc, Parameters: parameters.Manifest()},
-		Parameters:   parameters,
-	}
-}
-
 // validate interface
 var _ tools.Tool = Tool{}
 

--- a/internal/tools/spanner/spanner.go
+++ b/internal/tools/spanner/spanner.go
@@ -82,19 +82,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	return t, nil
 }
 
-func NewGenericTool(name string, stmt string, authRequired []string, desc string, client *spanner.Client, dialect string, parameters tools.Parameters) Tool {
-	return Tool{
-		Name:         name,
-		Kind:         ToolKind,
-		Statement:    stmt,
-		AuthRequired: authRequired,
-		Client:       client,
-		dialect:      dialect,
-		manifest:     tools.Manifest{Description: desc, Parameters: parameters.Manifest()},
-		Parameters:   parameters,
-	}
-}
-
 // validate interface
 var _ tools.Tool = Tool{}
 


### PR DESCRIPTION
This PR is to remove the `NewGenericTool` function within tools. 

This function was previously added when we are trying to consolidate the three postgres tools. However, since we merged it into a single `postgressql` tool, these functions are not used anymore.