### PR TITLE
feat: add tool call method

### DIFF
--- a/internal/server/mcp/method.go
+++ b/internal/server/mcp/method.go
@@ -15,6 +15,9 @@
 package mcp
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/googleapis/genai-toolbox/internal/tools"
 )
 
@@ -43,4 +46,29 @@ func ToolsList(toolset tools.Toolset) ListToolsResult {
 		Tools: mcpManifest,
 	}
 	return result
+}
+
+// ToolCall runs tool invocation and return a CallToolResult
+func ToolCall(tool tools.Tool, params tools.ParamValues) CallToolResult {
+	res, err := tool.Invoke(params)
+	if err != nil {
+		text := TextContent{
+			Type: "text",
+			Text: err.Error(),
+		}
+		return CallToolResult{Content: []TextContent{text}}
+	}
+
+	content := make([]TextContent, 0)
+	for _, d := range res {
+		text := TextContent{Type: "text"}
+		dM, err := json.Marshal(d)
+		if err != nil {
+			text.Text = fmt.Sprintf("fail to marshal: %s, result: %s", err, d)
+		} else {
+			text.Text = string(dM)
+		}
+		content = append(content, text)
+	}
+	return CallToolResult{Content: content}
 }

--- a/tests/alloydb_pg_integration_test.go
+++ b/tests/alloydb_pg_integration_test.go
@@ -164,6 +164,7 @@ func TestAlloyDBToolEndpoints(t *testing.T) {
 
 	select_1_want := "[{\"?column?\":1}]"
 	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t)
 }
 
 // Test connection with different IP type

--- a/tests/cloud_sql_mssql_integration_test.go
+++ b/tests/cloud_sql_mssql_integration_test.go
@@ -151,6 +151,7 @@ func TestCloudSQLMssqlToolEndpoints(t *testing.T) {
 
 	select_1_want := "[{\"\":1}]"
 	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t)
 }
 
 // Test connection with different IP type

--- a/tests/cloud_sql_mysql_integration_test.go
+++ b/tests/cloud_sql_mysql_integration_test.go
@@ -146,6 +146,7 @@ func TestCloudSQLMySQLToolEndpoints(t *testing.T) {
 
 	select_1_want := "[{\"1\":1}]"
 	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t)
 }
 
 // Test connection with different IP type

--- a/tests/cloud_sql_pg_integration_test.go
+++ b/tests/cloud_sql_pg_integration_test.go
@@ -150,6 +150,7 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 
 	select_1_want := "[{\"?column?\":1}]"
 	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t)
 }
 
 // Test connection with different IP type

--- a/tests/mssql_integration_test.go
+++ b/tests/mssql_integration_test.go
@@ -123,4 +123,5 @@ func TestMsSQLToolEndpoints(t *testing.T) {
 
 	select_1_want := "[{\"\":1}]"
 	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t)
 }

--- a/tests/mysql_integration_test.go
+++ b/tests/mysql_integration_test.go
@@ -122,4 +122,5 @@ func TestMySQLToolEndpoints(t *testing.T) {
 
 	select_1_want := "[{\"1\":1}]"
 	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t)
 }

--- a/tests/postgres_integration_test.go
+++ b/tests/postgres_integration_test.go
@@ -122,4 +122,5 @@ func TestPostgres(t *testing.T) {
 
 	select_1_want := "[{\"?column?\":1}]"
 	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t)
 }

--- a/tests/tool_test.go
+++ b/tests/tool_test.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/googleapis/genai-toolbox/internal/server/mcp"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -293,6 +294,122 @@ func RunToolInvokeTest(t *testing.T, select_1_want string) {
 			}
 
 			if got != tc.want {
+				t.Fatalf("unexpected value: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// RunMCPToolCallMethod runs the tool/call for mcp endpoint
+func RunMCPToolCallMethod(t *testing.T) {
+	// Test tool invoke endpoint
+	invokeTcs := []struct {
+		name          string
+		api           string
+		requestBody   mcp.JSONRPCRequest
+		requestHeader map[string]string
+		want          string
+	}{
+		{
+			name:          "MCP Invoke my-param-tool",
+			api:           "http://127.0.0.1:5000/mcp",
+			requestHeader: map[string]string{},
+			requestBody: mcp.JSONRPCRequest{
+				Jsonrpc: "2.0",
+				Id:      "my-param-tool",
+				Request: mcp.Request{
+					Method: "tools/call",
+				},
+				Params: map[string]any{
+					"name": "my-param-tool",
+					"arguments": map[string]any{
+						"id":   int(3),
+						"name": "Alice",
+					},
+				},
+			},
+			want: `{"jsonrpc":"2.0","id":"my-param-tool","result":{"content":[{"type":"text","text":"{\"id\":1,\"name\":\"Alice\"}"},{"type":"text","text":"{\"id\":3,\"name\":\"Sid\"}"}]}}`,
+		},
+		{
+			name:          "MCP Invoke invalid tool",
+			api:           "http://127.0.0.1:5000/mcp",
+			requestHeader: map[string]string{},
+			requestBody: mcp.JSONRPCRequest{
+				Jsonrpc: "2.0",
+				Id:      "invalid-tool",
+				Request: mcp.Request{
+					Method: "tools/call",
+				},
+				Params: map[string]any{
+					"name":      "foo",
+					"arguments": map[string]any{},
+				},
+			},
+			want: `{"jsonrpc":"2.0","id":"invalid-tool","error":{"code":-32602,"message":"invalid tool name: tool with name \"foo\" does not exist"}}`,
+		},
+		{
+			name:          "MCP Invoke my-tool without parameters",
+			api:           "http://127.0.0.1:5000/mcp",
+			requestHeader: map[string]string{},
+			requestBody: mcp.JSONRPCRequest{
+				Jsonrpc: "2.0",
+				Id:      "invoke-without-parameter",
+				Request: mcp.Request{
+					Method: "tools/call",
+				},
+				Params: map[string]any{
+					"name":      "my-tool",
+					"arguments": map[string]any{},
+				},
+			},
+			want: `{"jsonrpc":"2.0","id":"invoke-without-parameter","error":{"code":-32602,"message":"invalid tool name: tool with name \"my-tool\" does not exist"}}`,
+		},
+		{
+			name:          "MCP Invoke my-tool with insufficient parameters",
+			api:           "http://127.0.0.1:5000/mcp",
+			requestHeader: map[string]string{},
+			requestBody: mcp.JSONRPCRequest{
+				Jsonrpc: "2.0",
+				Id:      "invoke-insufficient-parameter",
+				Request: mcp.Request{
+					Method: "tools/call",
+				},
+				Params: map[string]any{
+					"name":      "my-tool",
+					"arguments": map[string]any{"id": 1},
+				},
+			},
+			want: `{"jsonrpc":"2.0","id":"invoke-insufficient-parameter","error":{"code":-32602,"message":"invalid tool name: tool with name \"my-tool\" does not exist"}}`,
+		},
+	}
+	for _, tc := range invokeTcs {
+		t.Run(tc.name, func(t *testing.T) {
+			reqMarshal, err := json.Marshal(tc.requestBody)
+			if err != nil {
+				t.Fatalf("unexpected error during marshaling of request body")
+			}
+			// Send Tool invocation request
+			req, err := http.NewRequest(http.MethodPost, tc.api, bytes.NewBuffer(reqMarshal))
+			if err != nil {
+				t.Fatalf("unable to create request: %s", err)
+			}
+			req.Header.Add("Content-type", "application/json")
+			for k, v := range tc.requestHeader {
+				req.Header.Add(k, v)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("unable to send request: %s", err)
+			}
+			respBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("unable to read request body: %s", err)
+			}
+			defer resp.Body.Close()
+			got := string(bytes.TrimSpace(respBody))
+
+			if got != tc.want {
+				fmt.Printf("res is %s\n\n", got)
 				t.Fatalf("unexpected value: got %q, want %q", got, tc.want)
 			}
 		})


### PR DESCRIPTION
Add `tools/call` method. 

Example to call the `tools/list` method:
`curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params":{"name": "my-tool"}}' http://127.0.0.1:5000/mcp`

Toolbox will response with a valid JSONRPCResponse of the result of tool invocation.