### PR TITLE
docs: fix misc typos

### DIFF
--- a/docs/en/resources/sources/alloydb-pg.md
+++ b/docs/en/resources/sources/alloydb-pg.md
@@ -24,7 +24,6 @@ cluster][alloydb-free-trial].
 
 ## Requirements
 
-
 ### IAM Permissions
 
 By default, AlloyDB for PostgreSQL source uses the [AlloyDB Go
@@ -46,14 +45,14 @@ permissions):
 ### Networking
 
 AlloyDB supports connecting over both from external networks via the internet
-([public IP][public-ip]), and internal networks ([private IP][private-ip]). 
-For more information on choosing between the two options, see the AlloyDB page 
+([public IP][public-ip]), and internal networks ([private IP][private-ip]).
+For more information on choosing between the two options, see the AlloyDB page
 [Connection overview][conn-overview].
 
-You can configure the `ipType` parameter in your source configuration to 
+You can configure the `ipType` parameter in your source configuration to
 `public` or `private` to match your cluster's configuration. Regardless of which
 you choose, all connections use IAM-based authorization and are encrypted with
-mTLS. 
+mTLS.
 
 [private-ip]: https://cloud.google.com/alloydb/docs/private-ip
 [public-ip]: https://cloud.google.com/alloydb/docs/connect-public-ip
@@ -90,7 +89,7 @@ sources:
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id").             |
 | region    |  string  |     true     | Name of the GCP region that the cluster was created in (e.g. "us-central1").              |
 | cluster   |  string  |     true     | Name of the AlloyDB cluster (e.g. "my-cluster").                                          |
-| instance  |  string  |     true     | Name of the AlloyDB instance within the cluser (e.g. "my-instance").                      |
+| instance  |  string  |     true     | Name of the AlloyDB instance within the cluster (e.g. "my-instance").                      |
 | database  |  string  |     true     | Name of the Postgres database to connect to (e.g. "my_db").                               |
 | user      |  string  |     true     | Name of the Postgres user to connect as (e.g. "my-pg-user").                              |
 | password  |  string  |     true     | Password of the Postgres user (e.g. "my-password").                                       |

--- a/docs/en/resources/sources/cloud-sql-mssql.md
+++ b/docs/en/resources/sources/cloud-sql-mssql.md
@@ -37,13 +37,14 @@ permissions):
 {{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
-scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
+scope][gce-access-scopes]
 to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[gce-access-scopes]: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
 
 ### Networking
 

--- a/docs/en/resources/sources/cloud-sql-mssql.md
+++ b/docs/en/resources/sources/cloud-sql-mssql.md
@@ -37,14 +37,13 @@ permissions):
 {{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
-scope][gce-access-scopes]
+scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
 to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
-[gce-access-scopes]: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
 
 ### Networking
 

--- a/docs/en/resources/sources/cloud-sql-mssql.md
+++ b/docs/en/resources/sources/cloud-sql-mssql.md
@@ -34,26 +34,25 @@ permissions):
 
 - `roles/cloudsql.client`
 
-{{< notice tip >}} 
+{{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
 scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
-to connect using the Cloud SQL Admin API. 
+to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
-[gce-access-scopes]: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
 
 ### Networking
 
 Cloud SQL supports connecting over both from external networks via the internet
-([public IP][public-ip]), and internal networks ([private IP][private-ip]). 
-For more information on choosing between the two options, see the Cloud SQL page 
+([public IP][public-ip]), and internal networks ([private IP][private-ip]).
+For more information on choosing between the two options, see the Cloud SQL page
 [Connection overview][conn-overview].
 
-You can configure the `ipType` parameter in your source configuration to 
+You can configure the `ipType` parameter in your source configuration to
 `public` or `private` to match your cluster's configuration. Regardless of which
 you choose, all connections use IAM-based authorization and are encrypted with
 mTLS.
@@ -90,7 +89,7 @@ sources:
 | kind      |  string  |     true     | Must be "cloud-sql-mssql".                                                                  |
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id").               |
 | region    |  string  |     true     | Name of the GCP region that the cluster was created in (e.g. "us-central1").                |
-| instance  |  string  |     true     | Name of the Cloud SQL instance within the cluser (e.g. "my-instance").                      |
+| instance  |  string  |     true     | Name of the Cloud SQL instance within the cluster (e.g. "my-instance").                      |
 | database  |  string  |     true     | Name of the Cloud SQL database to connect to (e.g. "my_db").                                |
 | ipAddress |  string  |     true     | IP address of the Cloud SQL instance to connect to.                                         |
 | user      |  string  |     true     | Name of the SQL Server user to connect as (e.g. "my-pg-user").                              |

--- a/docs/en/resources/sources/cloud-sql-mysql.md
+++ b/docs/en/resources/sources/cloud-sql-mysql.md
@@ -11,7 +11,7 @@ description: >
 ## About
 
 [Cloud SQL for MySQL][csql-mysql-docs] is a fully-managed database service
-that helps you set up, maintain, manage, and administer your MySQL 
+that helps you set up, maintain, manage, and administer your MySQL
 relational databases on Google Cloud Platform.
 
 If you are new to Cloud SQL for MySQL, you can try [creating and connecting
@@ -35,29 +35,28 @@ permissions):
 
 - `roles/cloudsql.client`
 
-{{< notice tip >}} 
+{{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
 scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
-to connect using the Cloud SQL Admin API. 
+to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
-[gce-access-scopes]: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
 
 ### Networking
 
 Cloud SQL supports connecting over both from external networks via the internet
-([public IP][public-ip]), and internal networks ([private IP][private-ip]). 
-For more information on choosing between the two options, see the Cloud SQL page 
+([public IP][public-ip]), and internal networks ([private IP][private-ip]).
+For more information on choosing between the two options, see the Cloud SQL page
 [Connection overview][conn-overview].
 
-You can configure the `ipType` parameter in your source configuration to 
+You can configure the `ipType` parameter in your source configuration to
 `public` or `private` to match your cluster's configuration. Regardless of which
 you choose, all connections use IAM-based authorization and are encrypted with
-mTLS. 
+mTLS.
 
 [private-ip]: https://cloud.google.com/sql/docs/mysql/configure-private-ip
 [public-ip]: https://cloud.google.com/sql/docs/mysql/configure-ip
@@ -65,7 +64,7 @@ mTLS.
 
 ### Database User
 
-Current, this source only uses standard authentication. You will need to [create
+Currently, this source only uses standard authentication. You will need to [create
 a MySQL user][cloud-sql-users] to login to the database with.
 
 [cloud-sql-users]: https://cloud.google.com/sql/docs/mysql/create-manage-users

--- a/docs/en/resources/sources/cloud-sql-mysql.md
+++ b/docs/en/resources/sources/cloud-sql-mysql.md
@@ -38,14 +38,13 @@ permissions):
 {{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
-scope][gce-access-scopes]
+scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
 to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
-[gce-access-scopes]: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
 
 ### Networking
 

--- a/docs/en/resources/sources/cloud-sql-mysql.md
+++ b/docs/en/resources/sources/cloud-sql-mysql.md
@@ -38,13 +38,14 @@ permissions):
 {{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
-scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
+scope][gce-access-scopes]
 to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[gce-access-scopes]: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
 
 ### Networking
 

--- a/docs/en/resources/sources/cloud-sql-pg.md
+++ b/docs/en/resources/sources/cloud-sql-pg.md
@@ -38,14 +38,13 @@ permissions):
 {{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
-scope][gce-access-scopes]
+scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
 to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
-[gce-access-scopes]: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
 
 ### Networking
 

--- a/docs/en/resources/sources/cloud-sql-pg.md
+++ b/docs/en/resources/sources/cloud-sql-pg.md
@@ -35,11 +35,11 @@ permissions):
 
 - `roles/cloudsql.client`
 
-{{< notice tip >}} 
+{{< notice tip >}}
 If you are connecting from Compute Engine, make sure your VM
 also has the [proper
-scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
-to connect using the Cloud SQL Admin API. 
+scope][gce-access-scopes]
+to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
@@ -50,14 +50,14 @@ to connect using the Cloud SQL Admin API.
 ### Networking
 
 Cloud SQL supports connecting over both from external networks via the internet
-([public IP][public-ip]), and internal networks ([private IP][private-ip]). 
-For more information on choosing between the two options, see the Cloud SQL page 
+([public IP][public-ip]), and internal networks ([private IP][private-ip]).
+For more information on choosing between the two options, see the Cloud SQL page
 [Connection overview][conn-overview].
 
-You can configure the `ipType` parameter in your source configuration to 
+You can configure the `ipType` parameter in your source configuration to
 `public` or `private` to match your cluster's configuration. Regardless of which
 you choose, all connections use IAM-based authorization and are encrypted with
-mTLS. 
+mTLS.
 
 [private-ip]: https://cloud.google.com/sql/docs/postgres/configure-private-ip
 [public-ip]: https://cloud.google.com/sql/docs/postgres/configure-ip
@@ -65,8 +65,8 @@ mTLS.
 
 ### Database User
 
-Current, this source only uses standard authentication. You will need to [create
-a PostreSQL user][cloud-sql-users] to login to the database with.
+Currently, this source only uses standard authentication. You will need to [create
+a PostgreSQL user][cloud-sql-users] to login to the database with.
 
 [cloud-sql-users]: https://cloud.google.com/sql/docs/postgres/create-manage-users
 

--- a/docs/en/resources/sources/postgres.md
+++ b/docs/en/resources/sources/postgres.md
@@ -7,7 +7,7 @@ description: >
 
 ---
 
-##  About
+## About
 
 [PostgreSQL][pg-docs] is a powerful, open source object-relational database
 system with over 35 years of active development that has earned it a strong
@@ -20,7 +20,7 @@ reputation for reliability, feature robustness, and performance.
 ### Database User
 
 This source only uses standard authentication. You will need to [create a
-PostreSQL user][pg-users] to login to the database with. 
+PostgreSQL user][pg-users] to login to the database with.
 
 [pg-users]: https://www.postgresql.org/docs/current/sql-createuser.html
 
@@ -47,5 +47,3 @@ sources:
 | database  |  string  |     true     | Name of the Postgres database to connect to (e.g. "my_db").            |
 | user      |  string  |     true     | Name of the Postgres user to connect as (e.g. "my-pg-user").           |
 | password  |  string  |     true     | Password of the Postgres user (e.g. "my-password").                    |
-
-

--- a/docs/en/resources/tools/dgraph-dql.md
+++ b/docs/en/resources/tools/dgraph-dql.md
@@ -9,8 +9,9 @@ description: >
 
 ## About
 
-A ` dgraph-dql` tool executes a pre-defined DQL statement against a Dgraph
+A `dgraph-dql` tool executes a pre-defined DQL statement against a Dgraph
 database. It's compatible with any of the following sources:
+
 - [dgraph](../sources/dgraph.md)
 
 To run a statement as a query, you need to set the config `isQuery=true`. For
@@ -60,7 +61,6 @@ tools:
         type: string
         description: admin
 
-
 {{< /tab >}}
 {{< tab header="Mutation" lang="yaml" >}}
 
@@ -105,6 +105,7 @@ tools:
 {{< /tabpane >}}
 
 ## Reference
+
 | **field**   |                  **type**                  | **required** | **description**                                                                              |
 |-------------|:------------------------------------------:|:------------:|----------------------------------------------------------------------------------------------|
 | kind        |                   string                   |     true     | Must be "dgraph-dql".                                                                        |

--- a/docs/en/resources/tools/mssql-sql.md
+++ b/docs/en/resources/tools/mssql-sql.md
@@ -11,6 +11,7 @@ description: >
 
 A `mssql-sql` tool executes a pre-defined SQL statement against a SQL Server
 database. It's compatible with any of the following sources:
+
 - [cloud-sql-mssql](../sources/cloud-sql-mssql.md)
 - [mssql](../sources/mssql.md)
 

--- a/docs/en/resources/tools/mysql-sql.md
+++ b/docs/en/resources/tools/mysql-sql.md
@@ -9,8 +9,9 @@ description: >
 
 ## About
 
-A `mysql-sql` tool executes a pre-defined SQL statement against a mysql 
+A `mysql-sql` tool executes a pre-defined SQL statement against a mysql
 database. It's compatible with any of the following sources:
+
 - [cloud-sql-mysql](../sources/cloud-sql-mysql.md)
 - [mysql](../sources/mysql.md)
 
@@ -68,5 +69,3 @@ tools:
 | description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |
 | statement   |                   string                   |     true     | SQL statement to execute on.                                                                     |
 | parameters  | [parameters](_index#specifying-parameters) |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement. |
-
-

--- a/docs/en/resources/tools/neo4j-cypher.md
+++ b/docs/en/resources/tools/neo4j-cypher.md
@@ -11,6 +11,7 @@ description: >
 
 A `neo4j-cypher` tool executes a pre-defined Cypher statement against a Neo4j
 database. It's compatible with any of the following sources:
+
 - [neo4j](../sources/neo4j.md)
 
 The specified Cypher statement is executed as a [parameterized
@@ -67,5 +68,3 @@ tools:
 | description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                              |
 | statement   |                   string                   |     true     | Cypher statement to execute                                                                     |
 | parameters  | [parameters](_index#specifying-parameters) |    false     | List of [parameters](_index#specifying-parameters) that will be used with the Cypher statement. |
-
-

--- a/docs/en/resources/tools/postgres-sql.md
+++ b/docs/en/resources/tools/postgres-sql.md
@@ -11,6 +11,7 @@ description: >
 
 A `postgres-sql` tool executes a pre-defined SQL statement against a Postgres
 database. It's compatible with any of the following sources:
+
 - [alloydb-postgres](../sources/alloydb-pg.md)
 - [cloud-sql-postgres](../sources/cloud-sql-pg.md)
 - [postgres](../sources/postgres.md)
@@ -19,7 +20,6 @@ The specified SQL statement is executed as a [prepared statement][pg-prepare],
 and specified parameters will inserted according to their position: e.g. `1`
 will be the first parameter specified, `$@` will be the second parameter, and so
 on.
-
 
 [pg-prepare]: https://www.postgresql.org/docs/current/sql-prepare.html
 
@@ -72,5 +72,3 @@ tools:
 | description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |
 | statement   |                   string                   |     true     | SQL statement to execute on.                                                                     |
 | parameters  | [parameters](_index#specifying-parameters) |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement. |
-
-

--- a/docs/en/resources/tools/spanner-sql.md
+++ b/docs/en/resources/tools/spanner-sql.md
@@ -12,8 +12,8 @@ description: >
 A `spanner-sql` tool executes a pre-defined SQL statement (either `googlesql` or
 `postgresql`) against a Cloud Spanner database. It's compatible with any of the
 following sources:
-- [spanner](../sources/spanner.md)
 
+- [spanner](../sources/spanner.md)
 
 ### GoogleSQL
 
@@ -33,7 +33,6 @@ the second parameter, and so on.
 [pg-prepare]: https://www.postgresql.org/docs/current/sql-prepare.html
 
 ## Example
-
 
 {{< tabpane >}}
 {{< tab header="GoogleSQL" lang="yaml" >}}
@@ -125,4 +124,3 @@ tools:
 | description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |
 | statement   |                   string                   |     true     | SQL statement to execute on.                                                                     |
 | parameters  | [parameters](_index#specifying-parameters) |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement. |
-

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -30,7 +30,7 @@ import (
 	httpsrc "github.com/googleapis/genai-toolbox/internal/sources/http"
 	mssqlsrc "github.com/googleapis/genai-toolbox/internal/sources/mssql"
 	mysqlsrc "github.com/googleapis/genai-toolbox/internal/sources/mysql"
-	neo4jrc "github.com/googleapis/genai-toolbox/internal/sources/neo4j"
+	neo4jsrc "github.com/googleapis/genai-toolbox/internal/sources/neo4j"
 	postgressrc "github.com/googleapis/genai-toolbox/internal/sources/postgres"
 	spannersrc "github.com/googleapis/genai-toolbox/internal/sources/spanner"
 	"github.com/googleapis/genai-toolbox/internal/tools"
@@ -190,8 +190,8 @@ func (c *SourceConfigs) UnmarshalYAML(ctx context.Context, unmarshal func(interf
 				return fmt.Errorf("unable to parse as %q: %w", kind, err)
 			}
 			(*c)[name] = actual
-		case neo4jrc.SourceKind:
-			actual := neo4jrc.Config{Name: name}
+		case neo4jsrc.SourceKind:
+			actual := neo4jsrc.Config{Name: name}
 			if err := dec.DecodeContext(ctx, &actual); err != nil {
 				return fmt.Errorf("unable to parse as %q: %w", kind, err)
 			}


### PR DESCRIPTION
fix some typos and formats in code & docs
`neo4jrc` should be `neo4jsrc`