### PR TITLE
fix: renovatebot to run go mod tidy post update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,9 @@
   dependencyDashboardLabels: [
     'type: process',
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   packageRules: [
     {
       groupName: 'GitHub Actions',


### PR DESCRIPTION
Currently renovate bot doesn't run go mod tidy, hence, all the renovate bot PR failed the lint checks.