### PR TITLE
fix: fix casting to string

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -229,7 +229,7 @@ func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
-	id = baseMessage.Id.(string)
+	id = fmt.Sprintf("%s", baseMessage.Id)
 	method = baseMessage.Method
 
 	var res mcp.JSONRPCMessage


### PR DESCRIPTION
variable `id` is used in metrics to record the session id.

`json.Number` will throw an error when casting to string with `.(string)`.