### PR TITLE
ci: Increase Cloud Build vCPU

### DIFF
--- a/.ci/continuous.release.cloudbuild.yaml
+++ b/.ci/continuous.release.cloudbuild.yaml
@@ -130,6 +130,7 @@ options:
   automapSubstitutions: true
   dynamicSubstitutions: true
   logging: CLOUD_LOGGING_ONLY # Necessary for custom service account
+  machineType: 'E2_HIGHCPU_8'
 
 substitutions:
   _REGION: us-central1


### PR DESCRIPTION
Integration test encountered `signal: killed` error and could be due to out-of-memory issue. Try increasing the Cloud Build vCPU: https://cloud.google.com/build/docs/optimize-builds/increase-vcpu-for-builds