### PR TITLE
feat: add IAM AuthN to Cloud SQL Sources

### DIFF
--- a/docs/en/resources/sources/cloud-sql-pg.md
+++ b/docs/en/resources/sources/cloud-sql-pg.md
@@ -42,6 +42,11 @@ scope](https://cloud.google.com/compute/docs/access/service-accounts#accesscopes
 to connect using the Cloud SQL Admin API.
 {{< /notice >}}
 
+To connect to your Cloud SQL Source using IAM authentication:
+
+1. Specify your IAM email as the `user` or leave it blank for Toolbox to fetch from ADC.
+2. Leave the `password` field blank.
+
 [csql-go-conn]: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
@@ -93,6 +98,6 @@ sources:
 | region    |  string  |     true     | Name of the GCP region that the cluster was created in (e.g. "us-central1").                |
 | instance  |  string  |     true     | Name of the Cloud SQL instance within the cluster (e.g. "my-instance").                     |
 | database  |  string  |     true     | Name of the Postgres database to connect to (e.g. "my_db").                                 |
-| user      |  string  |     true     | Name of the Postgres user to connect as (e.g. "my-pg-user").                                |
-| password  |  string  |     true     | Password of the Postgres user (e.g. "my-password").                                         |
+| user      |  string  |     false     | Name of the Postgres user to connect as (e.g. "my-pg-user"). Defaults to IAM auth using [ADC][adc] email if unspecified.                               |
+| password  |  string  |     false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.                                        |
 | ipType    |  string  |    false     | IP Type of the Cloud SQL instance; must be one of `public` or `private`. Default: `public`. |

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
@@ -103,7 +103,7 @@ func initCloudSQLMssqlConnection(ctx context.Context, tracer trace.Tracer, name,
 	if err != nil {
 		return nil, err
 	}
-	opts, err := sources.GetCloudSQLOpts(ipType, userAgent)
+	opts, err := sources.GetCloudSQLOpts(ipType, userAgent, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -92,7 +92,7 @@ func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, n
 	if err != nil {
 		return nil, err
 	}
-	opts, err := sources.GetCloudSQLOpts(ipType, userAgent)
+	opts, err := sources.GetCloudSQLOpts(ipType, userAgent, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -28,7 +28,7 @@ import (
 
 // GetCloudSQLDialOpts retrieve dial options with the right ip type and user agent for cloud sql
 // databases.
-func GetCloudSQLOpts(ipType, userAgent string) ([]cloudsqlconn.Option, error) {
+func GetCloudSQLOpts(ipType, userAgent string, useIAM bool) ([]cloudsqlconn.Option, error) {
 	opts := []cloudsqlconn.Option{cloudsqlconn.WithUserAgent(userAgent)}
 	switch strings.ToLower(ipType) {
 	case "private":
@@ -37,6 +37,10 @@ func GetCloudSQLOpts(ipType, userAgent string) ([]cloudsqlconn.Option, error) {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPublicIP()))
 	default:
 		return nil, fmt.Errorf("invalid ipType %s", ipType)
+	}
+
+	if useIAM {
+		opts = append(opts, cloudsqlconn.WithIAMAuthN())
 	}
 	return opts, nil
 }

--- a/tests/alloydb_pg_integration_test.go
+++ b/tests/alloydb_pg_integration_test.go
@@ -256,7 +256,7 @@ func TestAlloyDBIAMConnection(t *testing.T) {
 			err := RunSourceConnectionTest(t, tc.sourceConfig, ALLOYDB_POSTGRES_TOOL_KIND)
 			if err != nil {
 				if tc.isErr {
-					continue
+					return
 				}
 				t.Fatalf("Connection test failure: %s", err)
 			}

--- a/tests/alloydb_pg_integration_test.go
+++ b/tests/alloydb_pg_integration_test.go
@@ -255,9 +255,10 @@ func TestAlloyDBIAMConnection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := RunSourceConnectionTest(t, tc.sourceConfig, ALLOYDB_POSTGRES_TOOL_KIND)
 			if err != nil {
-				if !tc.isErr {
-					t.Fatalf("Connection test failure: %s", err)
+				if tc.isErr {
+					continue
 				}
+				t.Fatalf("Connection test failure: %s", err)
 			}
 			if tc.isErr {
 				t.Fatalf("Expected error but test passed.")

--- a/tests/alloydb_pg_integration_test.go
+++ b/tests/alloydb_pg_integration_test.go
@@ -259,6 +259,9 @@ func TestAlloyDBIAMConnection(t *testing.T) {
 					t.Fatalf("Connection test failure: %s", err)
 				}
 			}
+			if tc.isErr {
+				t.Fatalf("Expected error but test passed.")
+			}
 		})
 	}
 }

--- a/tests/cloud_sql_pg_integration_test.go
+++ b/tests/cloud_sql_pg_integration_test.go
@@ -188,53 +188,59 @@ func TestCloudSQLIAMConnection(t *testing.T) {
 	serviceAccountEmail := strings.TrimSuffix(SERVICE_ACCOUNT_EMAIL, ".gserviceaccount.com")
 
 	noPassSourceConfig := map[string]any{
-		"kind":     CloudSQL_POSTGRES_SOURCE_KIND,
-		"project":  CloudSQL_POSTGRES_PROJECT,
-		"cluster":  CloudSQL_POSTGRES_CLUSTER,
-		"instance": CloudSQL_POSTGRES_INSTANCE,
-		"region":   CloudSQL_POSTGRES_REGION,
-		"database": CloudSQL_POSTGRES_DATABASE,
+		"kind":     CLOUD_SQL_POSTGRES_SOURCE_KIND,
+		"project":  CLOUD_SQL_POSTGRES_PROJECT,
+		"instance": CLOUD_SQL_POSTGRES_INSTANCE,
+		"region":   CLOUD_SQL_POSTGRES_REGION,
+		"database": CLOUD_SQL_POSTGRES_DATABASE,
 		"user":     serviceAccountEmail,
 	}
 
 	noUserSourceConfig := map[string]any{
-		"kind":     CloudSQL_POSTGRES_SOURCE_KIND,
-		"project":  CloudSQL_POSTGRES_PROJECT,
-		"cluster":  CloudSQL_POSTGRES_CLUSTER,
-		"instance": CloudSQL_POSTGRES_INSTANCE,
-		"region":   CloudSQL_POSTGRES_REGION,
-		"database": CloudSQL_POSTGRES_DATABASE,
+		"kind":     CLOUD_SQL_POSTGRES_SOURCE_KIND,
+		"project":  CLOUD_SQL_POSTGRES_PROJECT,
+		"instance": CLOUD_SQL_POSTGRES_INSTANCE,
+		"region":   CLOUD_SQL_POSTGRES_REGION,
+		"database": CLOUD_SQL_POSTGRES_DATABASE,
 		"password": "random",
 	}
 
 	noUserNoPassSourceConfig := map[string]any{
-		"kind":     CloudSQL_POSTGRES_SOURCE_KIND,
-		"project":  CloudSQL_POSTGRES_PROJECT,
-		"cluster":  CloudSQL_POSTGRES_CLUSTER,
-		"instance": CloudSQL_POSTGRES_INSTANCE,
-		"region":   CloudSQL_POSTGRES_REGION,
-		"database": CloudSQL_POSTGRES_DATABASE,
+		"kind":     CLOUD_SQL_POSTGRES_SOURCE_KIND,
+		"project":  CLOUD_SQL_POSTGRES_PROJECT,
+		"instance": CLOUD_SQL_POSTGRES_INSTANCE,
+		"region":   CLOUD_SQL_POSTGRES_REGION,
+		"database": CLOUD_SQL_POSTGRES_DATABASE,
 	}
 	tcs := []struct {
 		name         string
 		sourceConfig map[string]any
+		isErr        bool
 	}{
 		{
 			name:         "no user no pass",
 			sourceConfig: noUserNoPassSourceConfig,
+			isErr:        false,
 		},
 		{
 			name:         "no password",
 			sourceConfig: noPassSourceConfig,
+			isErr:        false,
 		},
 		{
 			name:         "no user",
 			sourceConfig: noUserSourceConfig,
+			isErr:        true,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			RunSourceConnectionTest(t, tc.sourceConfig, CloudSQL_POSTGRES_TOOL_KIND)
+			err := RunSourceConnectionTest(t, tc.sourceConfig, CLOUD_SQL_POSTGRES_TOOL_KIND)
+			if err != nil {
+				if !tc.isErr {
+					t.Fatalf("Connection test failure: %s", err)
+				}
+			}
 		})
 	}
 }

--- a/tests/cloud_sql_pg_integration_test.go
+++ b/tests/cloud_sql_pg_integration_test.go
@@ -238,7 +238,7 @@ func TestCloudSQLIAMConnection(t *testing.T) {
 			err := RunSourceConnectionTest(t, tc.sourceConfig, CLOUD_SQL_POSTGRES_TOOL_KIND)
 			if err != nil {
 				if tc.isErr {
-					continue
+					return
 				}
 				t.Fatalf("Connection test failure: %s", err)
 			}

--- a/tests/cloud_sql_pg_integration_test.go
+++ b/tests/cloud_sql_pg_integration_test.go
@@ -241,6 +241,9 @@ func TestCloudSQLIAMConnection(t *testing.T) {
 					t.Fatalf("Connection test failure: %s", err)
 				}
 			}
+			if tc.isErr {
+				t.Fatalf("Expected error but test passed.")
+			}
 		})
 	}
 }

--- a/tests/cloud_sql_pg_integration_test.go
+++ b/tests/cloud_sql_pg_integration_test.go
@@ -237,9 +237,10 @@ func TestCloudSQLIAMConnection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := RunSourceConnectionTest(t, tc.sourceConfig, CLOUD_SQL_POSTGRES_TOOL_KIND)
 			if err != nil {
-				if !tc.isErr {
-					t.Fatalf("Connection test failure: %s", err)
+				if tc.isErr {
+					continue
 				}
+				t.Fatalf("Connection test failure: %s", err)
 			}
 			if tc.isErr {
 				t.Fatalf("Expected error but test passed.")

--- a/tests/cloud_sql_pg_integration_test.go
+++ b/tests/cloud_sql_pg_integration_test.go
@@ -181,3 +181,60 @@ func TestCloudSQLPgIpConnection(t *testing.T) {
 		})
 	}
 }
+
+func TestCloudSQLIAMConnection(t *testing.T) {
+	getCloudSQLPgVars(t)
+	// service account email used for IAM should trim the suffix
+	serviceAccountEmail := strings.TrimSuffix(SERVICE_ACCOUNT_EMAIL, ".gserviceaccount.com")
+
+	noPassSourceConfig := map[string]any{
+		"kind":     CloudSQL_POSTGRES_SOURCE_KIND,
+		"project":  CloudSQL_POSTGRES_PROJECT,
+		"cluster":  CloudSQL_POSTGRES_CLUSTER,
+		"instance": CloudSQL_POSTGRES_INSTANCE,
+		"region":   CloudSQL_POSTGRES_REGION,
+		"database": CloudSQL_POSTGRES_DATABASE,
+		"user":     serviceAccountEmail,
+	}
+
+	noUserSourceConfig := map[string]any{
+		"kind":     CloudSQL_POSTGRES_SOURCE_KIND,
+		"project":  CloudSQL_POSTGRES_PROJECT,
+		"cluster":  CloudSQL_POSTGRES_CLUSTER,
+		"instance": CloudSQL_POSTGRES_INSTANCE,
+		"region":   CloudSQL_POSTGRES_REGION,
+		"database": CloudSQL_POSTGRES_DATABASE,
+		"password": "random",
+	}
+
+	noUserNoPassSourceConfig := map[string]any{
+		"kind":     CloudSQL_POSTGRES_SOURCE_KIND,
+		"project":  CloudSQL_POSTGRES_PROJECT,
+		"cluster":  CloudSQL_POSTGRES_CLUSTER,
+		"instance": CloudSQL_POSTGRES_INSTANCE,
+		"region":   CloudSQL_POSTGRES_REGION,
+		"database": CloudSQL_POSTGRES_DATABASE,
+	}
+	tcs := []struct {
+		name         string
+		sourceConfig map[string]any
+	}{
+		{
+			name:         "no user no pass",
+			sourceConfig: noUserNoPassSourceConfig,
+		},
+		{
+			name:         "no password",
+			sourceConfig: noPassSourceConfig,
+		},
+		{
+			name:         "no user",
+			sourceConfig: noUserSourceConfig,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			RunSourceConnectionTest(t, tc.sourceConfig, CloudSQL_POSTGRES_TOOL_KIND)
+		})
+	}
+}


### PR DESCRIPTION
Add IAM support for Cloud SQL source connection using Go language connector: https://pkg.go.dev/cloud.google.com/go/cloudsqlconn#section-readme