### PR TITLE
fix: #419 TLS https URL for SSE endpoint

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -126,8 +126,13 @@ func sseHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	s.sseManager.add(sessionId, session)
 	defer s.sseManager.remove(sessionId)
 
+	// https scheme formatting if request is a TLS request
+	ssl := ""
+	if r.TLS != nil {
+		ssl = "s"
+	} 
 	// send initial endpoint event
-	messageEndpoint := fmt.Sprintf("http://%s/mcp?sessionId=%s", r.Host, sessionId)
+	messageEndpoint := fmt.Sprintf("http%s://%s/mcp?sessionId=%s", ssl, r.Host, sessionId)
 	s.logger.DebugContext(ctx, fmt.Sprintf("sending endpoint event: %s", messageEndpoint))
 	fmt.Fprintf(w, "event: endpoint\ndata: %s\n\n", messageEndpoint)
 	flusher.Flush()

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -126,13 +126,17 @@ func sseHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	s.sseManager.add(sessionId, session)
 	defer s.sseManager.remove(sessionId)
 
-	// https scheme formatting if request is a TLS request
-	ssl := ""
-	if r.TLS != nil {
-		ssl = "s"
-	} 
+	// https scheme formatting if (forwarded) request is a TLS request
+	proto := r.Header.Get("X-Forwarded-Proto")
+	if (proto == "") {
+		if  r.TLS == nil {
+			proto = "http"
+		} else {
+			proto = "https"
+		}
+	}
 	// send initial endpoint event
-	messageEndpoint := fmt.Sprintf("http%s://%s/mcp?sessionId=%s", ssl, r.Host, sessionId)
+	messageEndpoint := fmt.Sprintf("%s://%s/mcp?sessionId=%s", proto, r.Host, sessionId)
 	s.logger.DebugContext(ctx, fmt.Sprintf("sending endpoint event: %s", messageEndpoint))
 	fmt.Fprintf(w, "event: endpoint\ndata: %s\n\n", messageEndpoint)
 	flusher.Flush()


### PR DESCRIPTION
Fixes that in SSL deployments, e.g. on k8s or cloud run the SSE endpoint was statically returning `http:` 

not a scheme based on request TLS attribute.

Fixes https://github.com/googleapis/genai-toolbox/issues/419