### PR TITLE
feat: add support for optional parameters

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -71,7 +71,9 @@ func (t MockTool) McpManifest() tools.McpManifest {
 	for _, p := range t.Params {
 		name := p.GetName()
 		properties[name] = p.McpManifest()
-		required = append(required, name)
+		if !p.IsOptional() {
+			required = append(required, name)
+		}
 	}
 
 	toolsSchema := tools.McpToolsSchema{
@@ -97,6 +99,7 @@ var tool2 = MockTool{
 	Params: tools.Parameters{
 		tools.NewIntParameter("param1", "This is the first parameter."),
 		tools.NewIntParameter("param2", "This is the second parameter."),
+		tools.NewIntParameterWithOptions("param3", "This is the third parameter.", true),
 	},
 }
 

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -40,6 +40,7 @@ var tool2InputSchema = map[string]any{
 	"properties": map[string]any{
 		"param1": map[string]any{"type": "integer", "description": "This is the first parameter."},
 		"param2": map[string]any{"type": "integer", "description": "This is the second parameter."},
+		"param3": map[string]any{"type": "integer", "description": "This is the third parameter."},
 	},
 	"required": []any{"param1", "param2"},
 }


### PR DESCRIPTION
- Add an optional flag to parameters and modify logic to exclude them from the required list when necessary.
- Add test cases for new optional parameters to verify correct functionality.
- Add a new version/overload to the existing parameter creation function to support specifying optionality.