### PR TITLE
chore(ci/cd): pin version of hugo

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3
         with:
-          hugo-version: "latest"
+          hugo-version: "0.145.0"
           extended: true
 
       - name: Setup Node

--- a/.github/workflows/docs_preview_deploy.yaml
+++ b/.github/workflows/docs_preview_deploy.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3
         with:
-          hugo-version: "latest"
+          hugo-version: "0.145.0"
           extended: true
 
       - name: Setup Node

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -2,7 +2,7 @@
 title: "Introduction"
 type: docs
 weight: 1
-description: An introduction to MCP Toolbox for Databases.
+description: An introduction to MCP Toolbox for Databases. 
 ---
 
 MCP Toolbox for Databases is an open source MCP server for databases. It was


### PR DESCRIPTION
Hugo's recent release seems to have broken docsy: https://github.com/gohugoio/hugo/issues/13599
There's a fix in progress: https://github.com/google/docsy/pull/2215

To unblock CI/CD, I've pinned hugo to 0.145.0 instead. 
