### PR TITLE
Fix warning on duplicate persistence key

### DIFF
--- a/docs/en/resources/tools/dgraph-dql.md
+++ b/docs/en/resources/tools/dgraph-dql.md
@@ -20,7 +20,7 @@ query.
 
 ## Example
 
-{{< tabpane >}}
+{{< tabpane persist="header" >}}
 {{< tab header="Query" lang="yaml" >}}
 
 tools:

--- a/docs/en/resources/tools/spanner-sql.md
+++ b/docs/en/resources/tools/spanner-sql.md
@@ -34,7 +34,7 @@ the second parameter, and so on.
 
 ## Example
 
-{{< tabpane >}}
+{{< tabpane persist="header" >}}
 {{< tab header="GoogleSQL" lang="yaml" >}}
 
 tools:


### PR DESCRIPTION
When previewing the site, warnings are printed out:

```
WARN  Shortcode "tabpane": duplicate tab-persistence key "yaml" detected, disabling persistence to avoid multiple tab display.
```

This PR fixes these issues.