### PR TITLE
chore: Set content dir via mount

### DIFF
--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -2,7 +2,6 @@ title = 'MCP Toolbox for Databases'
 relativeURLs = true
 
 languageCode = 'en-us'
-contentDir = "../docs/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 
@@ -19,6 +18,9 @@ enableRobotsTXT = true
   [module.hugoVersion]
     extended = true
     min = "0.73.0"
+  [[module.mounts]]
+    source = "../docs/en"
+    target = 'content'
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false


### PR DESCRIPTION
This PR changes the way the content dir is configured: it is now configured via a module mount.
As described in the [official docs](https://gohugo.io/configuration/all/#contentdir), this is a more flexible approach to configure this directory.