### PR TITLE
feat: Add BigQuery source and tool

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -106,6 +106,23 @@ steps:
       - |
         go test -race -v -tags=integration,bigtable ./tests
 
+  - id: "bigquery"
+    name: golang:1
+    waitFor: ["install-dependencies"]
+    entrypoint: /bin/bash
+    env:
+      - "GOPATH=/gopath"
+      - "BIGQUERY_PROJECT=$PROJECT_ID"
+      - "SERVICE_ACCOUNT_EMAIL=$SERVICE_ACCOUNT_EMAIL"
+    secretEnv: ["CLIENT_ID"]
+    volumes:
+      - name: "go"
+        path: "/gopath"
+    args:
+      - -c
+      - |
+        go test -race -v -tags=integration,bigquery ./tests
+
   - id: "postgres"
     name: golang:1
     waitFor: ["install-dependencies"]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,3 +46,4 @@ run:
     - http
     - alloydb_ai_nl
     - bigtable
+    - bigquery

--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -50,15 +50,6 @@ permissions to run jobs and read data) or `roles/bigquery.dataViewer`. See
 [Introduction to BigQuery IAM][grant-permissions] for more information on 
 applying IAM permissions and roles to an identity.
 
-In addition to [setting the ADC for your server][set-adc], you need to ensure 
-the IAM identity has been given the correct IAM permissions for the queries 
-you intend to run. Common predefined roles include `roles/bigquery.user` 
-(which grants permissions to run jobs, including queries, and enumerate 
-datasets) or `roles/bigquery.dataViewer` (for read-only access to datasets). 
-Refer to the [BigQuery access control documentation][grant-permissions] for 
-a comprehensive overview of available roles and how to grant permissions at 
-different resource levels.
-
 [iam-overview]: https://cloud.google.com/bigquery/docs/access-control
 [adc]: https://cloud.google.com/docs/authentication#adc
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc

--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -1,0 +1,56 @@
+---
+title: "BigQuery"
+type: docs
+weight: 1
+description: >
+  BigQuery is Google Cloud's fully managed, petabyte-scale, and cost-effective analytics data warehouse that lets you run analytics over vast amounts of data in near real time. With BigQuery, there's no infrastructure to set up or manage, letting you focus on finding meaningful insights using GoogleSQL and taking advantage of flexible pricing models across on-demand and flat-rate options.
+---
+
+# BigQuery Source
+
+[BigQuery][bigquery-docs] is Google Cloud's fully managed, petabyte-scale, and cost-effective analytics data warehouse that lets you run analytics over vast amounts of data in near real time. With BigQuery, there's no infrastructure to set up or manage, letting you focus on finding meaningful insights using GoogleSQL and taking advantage of flexible pricing models across on-demand and flat-rate options.
+
+If you are new to BigQuery, you can try to [load and query data with the bq tool][bigquery-quickstart-cli].
+
+BigQuery uses [GoogleSQL][bigquery-googlesql] for querying data. GoogleSQL is an ANSI-compliant structured query language (SQL) that is
+also implemented for other Google Cloud services. SQL queries are handled by cluster nodes in the same way as NoSQL data requests. Therefore, the same best practices apply when creating SQL queries to run against your Bigtable data, such as avoiding full table scans or complex filters.
+
+[bigquery-docs]: https://cloud.google.com/bigquery/docs
+[bigquery-quickstart-cli]: https://cloud.google.com/bigquery/docs/quickstarts/quickstart-command-line
+[bigquery-googlesql]: https://cloud.google.com/bigquery/docs/reference/standard-sql/
+
+## Requirements
+
+### IAM Permissions
+
+BigQuery uses [Identity and Access Management (IAM)][iam-overview] to control user and group access to BigQuery resources like projects, datasets, and tables. Toolbox will use your [Application Default Credentials (ADC)][adc] to authorize and authenticate when interacting with [BigQuery][bigquery-docs].
+
+In addition to [setting the ADC for your server][set-adc], you need to ensure the IAM identity has been given the correct IAM permissions for the queries you intend to run. Common roles include `roles/bigquery.user` (which includes permissions to run jobs and read data) or `roles/bigquery.dataViewer`. See [Introduction to BigQuery IAM][grant-permissions] for more information on applying IAM permissions and roles to an identity.
+
+In addition to [setting the ADC for your server][set-adc], you need to ensure the IAM identity has been given the correct IAM permissions for the queries you intend to run. Common predefined roles include `roles/bigquery.user` (which grants permissions to run jobs, including queries, and enumerate datasets) or `roles/bigquery.dataViewer` (for read-only access to datasets). Refer to the [BigQuery access control documentation][grant-permissions] for a comprehensive overview of available roles and how to grant permissions at different resource levels.
+
+[iam-overview]: https://cloud.google.com/bigquery/docs/access-control
+[adc]: https://cloud.google.com/docs/authentication#adc
+[set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[grant-permissions]: https://cloud.google.com/bigquery/docs/access-control
+
+## Example
+
+```yaml
+sources:
+  my-bigquery-source:
+    kind: "bigquery"
+    project: "my-project-id"
+```
+
+## Reference
+
+kind	string	true	Must be "bigquery".
+project	string	true	ID of the GCP project where queries will run and billing occurs (e.g. "my-project-id").
+location	string	false	Default geographic location where BigQuery jobs should run (e.g., "US", "EU"). If unspecified, BigQuery may choose based on dataset location or use a multi-region default.
+
+| **field** | **type** | **required** | **description**                                                               |
+|-----------|:--------:|:------------:|-------------------------------------------------------------------------------|
+| kind      |  string  |     true     | Must be "bigtable".                                                           |
+| project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id"). |
+| location  |  string  |    false     | Specifies the location (e.g., 'US', 'EU') in which to run the query job. This location must match the location of any tables referenced in the query. The default behavior is for it to be executed in the US multi-region |

--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -3,17 +3,32 @@ title: "BigQuery"
 type: docs
 weight: 1
 description: >
-  BigQuery is Google Cloud's fully managed, petabyte-scale, and cost-effective analytics data warehouse that lets you run analytics over vast amounts of data in near real time. With BigQuery, there's no infrastructure to set up or manage, letting you focus on finding meaningful insights using GoogleSQL and taking advantage of flexible pricing models across on-demand and flat-rate options.
+  BigQuery is Google Cloud's fully managed, petabyte-scale, and cost-effective
+  analytics data warehouse that lets you run analytics over vast amounts of 
+  data in near real time. With BigQuery, there's no infrastructure to set 
+  up or manage, letting you focus on finding meaningful insights using 
+  GoogleSQL and taking advantage of flexible pricing models across on-demand 
+  and flat-rate options.
 ---
 
 # BigQuery Source
 
-[BigQuery][bigquery-docs] is Google Cloud's fully managed, petabyte-scale, and cost-effective analytics data warehouse that lets you run analytics over vast amounts of data in near real time. With BigQuery, there's no infrastructure to set up or manage, letting you focus on finding meaningful insights using GoogleSQL and taking advantage of flexible pricing models across on-demand and flat-rate options.
+[BigQuery][bigquery-docs] is Google Cloud's fully managed, petabyte-scale, 
+and cost-effective analytics data warehouse that lets you run analytics 
+over vast amounts of data in near real time. With BigQuery, there's no 
+infrastructure to set up or manage, letting you focus on finding meaningful 
+insights using GoogleSQL and taking advantage of flexible pricing models 
+across on-demand and flat-rate options.
 
-If you are new to BigQuery, you can try to [load and query data with the bq tool][bigquery-quickstart-cli].
+If you are new to BigQuery, you can try to 
+[load and query data with the bq tool][bigquery-quickstart-cli].
 
-BigQuery uses [GoogleSQL][bigquery-googlesql] for querying data. GoogleSQL is an ANSI-compliant structured query language (SQL) that is
-also implemented for other Google Cloud services. SQL queries are handled by cluster nodes in the same way as NoSQL data requests. Therefore, the same best practices apply when creating SQL queries to run against your Bigtable data, such as avoiding full table scans or complex filters.
+BigQuery uses [GoogleSQL][bigquery-googlesql] for querying data. GoogleSQL 
+is an ANSI-compliant structured query language (SQL) that is also implemented 
+for other Google Cloud services. SQL queries are handled by cluster nodes 
+in the same way as NoSQL data requests. Therefore, the same best practices 
+apply when creating SQL queries to run against your Bigtable data, such as 
+avoiding full table scans or complex filters.
 
 [bigquery-docs]: https://cloud.google.com/bigquery/docs
 [bigquery-quickstart-cli]: https://cloud.google.com/bigquery/docs/quickstarts/quickstart-command-line
@@ -23,11 +38,26 @@ also implemented for other Google Cloud services. SQL queries are handled by clu
 
 ### IAM Permissions
 
-BigQuery uses [Identity and Access Management (IAM)][iam-overview] to control user and group access to BigQuery resources like projects, datasets, and tables. Toolbox will use your [Application Default Credentials (ADC)][adc] to authorize and authenticate when interacting with [BigQuery][bigquery-docs].
+BigQuery uses [Identity and Access Management (IAM)][iam-overview] to control 
+user and group access to BigQuery resources like projects, datasets, and tables. 
+Toolbox will use your [Application Default Credentials (ADC)][adc] to authorize 
+and authenticate when interacting with [BigQuery][bigquery-docs].
 
-In addition to [setting the ADC for your server][set-adc], you need to ensure the IAM identity has been given the correct IAM permissions for the queries you intend to run. Common roles include `roles/bigquery.user` (which includes permissions to run jobs and read data) or `roles/bigquery.dataViewer`. See [Introduction to BigQuery IAM][grant-permissions] for more information on applying IAM permissions and roles to an identity.
+In addition to [setting the ADC for your server][set-adc], you need to ensure 
+the IAM identity has been given the correct IAM permissions for the queries 
+you intend to run. Common roles include `roles/bigquery.user` (which includes 
+permissions to run jobs and read data) or `roles/bigquery.dataViewer`. See 
+[Introduction to BigQuery IAM][grant-permissions] for more information on 
+applying IAM permissions and roles to an identity.
 
-In addition to [setting the ADC for your server][set-adc], you need to ensure the IAM identity has been given the correct IAM permissions for the queries you intend to run. Common predefined roles include `roles/bigquery.user` (which grants permissions to run jobs, including queries, and enumerate datasets) or `roles/bigquery.dataViewer` (for read-only access to datasets). Refer to the [BigQuery access control documentation][grant-permissions] for a comprehensive overview of available roles and how to grant permissions at different resource levels.
+In addition to [setting the ADC for your server][set-adc], you need to ensure 
+the IAM identity has been given the correct IAM permissions for the queries 
+you intend to run. Common predefined roles include `roles/bigquery.user` 
+(which grants permissions to run jobs, including queries, and enumerate 
+datasets) or `roles/bigquery.dataViewer` (for read-only access to datasets). 
+Refer to the [BigQuery access control documentation][grant-permissions] for 
+a comprehensive overview of available roles and how to grant permissions at 
+different resource levels.
 
 [iam-overview]: https://cloud.google.com/bigquery/docs/access-control
 [adc]: https://cloud.google.com/docs/authentication#adc
@@ -45,12 +75,8 @@ sources:
 
 ## Reference
 
-kind	string	true	Must be "bigquery".
-project	string	true	ID of the GCP project where queries will run and billing occurs (e.g. "my-project-id").
-location	string	false	Default geographic location where BigQuery jobs should run (e.g., "US", "EU"). If unspecified, BigQuery may choose based on dataset location or use a multi-region default.
-
 | **field** | **type** | **required** | **description**                                                               |
 |-----------|:--------:|:------------:|-------------------------------------------------------------------------------|
 | kind      |  string  |     true     | Must be "bigtable".                                                           |
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id"). |
-| location  |  string  |    false     | Specifies the location (e.g., 'US', 'EU') in which to run the query job. This location must match the location of any tables referenced in the query. The default behavior is for it to be executed in the US multi-region |
+| location  |  string  |    false     | Specifies the location (e.g., 'us', 'asia-northeast1') in which to run the query job. This location must match the location of any tables referenced in the query. The default behavior is for it to be executed in the US multi-region |

--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -27,7 +27,7 @@ BigQuery uses [GoogleSQL][bigquery-googlesql] for querying data. GoogleSQL
 is an ANSI-compliant structured query language (SQL) that is also implemented 
 for other Google Cloud services. SQL queries are handled by cluster nodes 
 in the same way as NoSQL data requests. Therefore, the same best practices 
-apply when creating SQL queries to run against your Bigtable data, such as 
+apply when creating SQL queries to run against your BigQuery data, such as 
 avoiding full table scans or complex filters.
 
 [bigquery-docs]: https://cloud.google.com/bigquery/docs

--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -77,6 +77,6 @@ sources:
 
 | **field** | **type** | **required** | **description**                                                               |
 |-----------|:--------:|:------------:|-------------------------------------------------------------------------------|
-| kind      |  string  |     true     | Must be "bigtable".                                                           |
+| kind      |  string  |     true     | Must be "bigquery".                                                           |
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id"). |
 | location  |  string  |    false     | Specifies the location (e.g., 'us', 'asia-northeast1') in which to run the query job. This location must match the location of any tables referenced in the query. The default behavior is for it to be executed in the US multi-region |

--- a/docs/en/resources/tools/bigquery-sql.md
+++ b/docs/en/resources/tools/bigquery-sql.md
@@ -64,5 +64,5 @@ tools:
 | kind        |                   string                   |     true     | Must be "bigquery-sql".                                                                          |
 | source      |                   string                   |     true     | Name of the source the GoogleSQL should execute on.                                                    |
 | description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |
-| statement   |                   string                   |     true     | SQL statement to execute on.                                                                     |
+| statement   |                   string                   |     true     | The GoogleSQL statement to execute.                                                                     |
 | parameters  | [parameters](_index#specifying-parameters) |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement. |

--- a/docs/en/resources/tools/bigquery-sql.md
+++ b/docs/en/resources/tools/bigquery-sql.md
@@ -1,0 +1,68 @@
+---
+title: "BigQuery-sql"
+type: docs
+weight: 1
+description: >
+  A "bigquery-sql" tool executes a pre-defined SQL statement.
+---
+
+## About
+A `bigquery-sql` tool executes a pre-defined SQL statement. It's compatible with 
+the following sources:
+
+- [bigquery](../sources/bigquery.md)
+
+### GoogleSQL
+
+BigQuery uses [GoogleSQL][bigquery-googlesql] for querying data. The integration
+with Toolbox supports this dialect. The specified SQL statement is executed, and
+parameters can be inserted into the query. BigQuery supports both named parameters
+(e.g., `@name`) and positional parameters (`?`), but they cannot be mixed in the
+same query.
+
+[bigquery-googlesql]: https://cloud.google.com/bigquery/docs/reference/standard-sql/
+
+## Example
+
+```yaml
+tools:
+  # Example: Querying a user table in BigQuery
+  search_users_bq:
+    kind: bigquery-sql
+    source: my-bigquery-source
+    statement: |
+      SELECT
+        id,
+        name,
+        email
+      FROM
+        `my-project.my-dataset.users`
+      WHERE
+        id = @id OR email = @email;
+    description: |
+      Use this tool to get information for a specific user.
+      Takes an id number or a name and returns info on the user.
+
+      Example:
+      {{
+          "id": 123,
+          "name": "Alice",
+      }}
+    parameters:
+      - name: id
+        type: integer
+        description: User ID
+      - name: email
+        type: string
+        description: Email address of the user
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| kind        |                   string                   |     true     | Must be "bigquery-sql".                                                                          |
+| source      |                   string                   |     true     | Name of the source the SQL should execute on.                                                    |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |
+| statement   |                   string                   |     true     | SQL statement to execute on.                                                                     |
+| parameters  | [parameters](_index#specifying-parameters) |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement. |

--- a/docs/en/resources/tools/bigquery-sql.md
+++ b/docs/en/resources/tools/bigquery-sql.md
@@ -62,7 +62,7 @@ tools:
 | **field**   |                  **type**                  | **required** | **description**                                                                                  |
 |-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
 | kind        |                   string                   |     true     | Must be "bigquery-sql".                                                                          |
-| source      |                   string                   |     true     | Name of the source the SQL should execute on.                                                    |
+| source      |                   string                   |     true     | Name of the source the GoogleSQL should execute on.                                                    |
 | description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |
 | statement   |                   string                   |     true     | SQL statement to execute on.                                                                     |
 | parameters  | [parameters](_index#specifying-parameters) |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement. |

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.2
 
 require (
 	cloud.google.com/go/alloydbconn v1.15.1
+	cloud.google.com/go/bigquery v1.66.2
 	cloud.google.com/go/bigtable v1.37.0
 	cloud.google.com/go/cloudsqlconn v1.16.1
 	cloud.google.com/go/spanner v1.79.0
@@ -51,6 +52,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 // indirect
 	github.com/ajg/form v1.5.1 // indirect
+	github.com/apache/arrow/go/v15 v15.0.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 // indirect
@@ -63,9 +65,11 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
@@ -74,10 +78,14 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.35.0 // indirect
@@ -91,11 +99,15 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
+	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
+	golang.org/x/tools v0.29.0 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250414145226-207652e42e2e // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ cloud.google.com/go/datacatalog v1.8.0/go.mod h1:KYuoVOv9BM8EYz/4eMFxrr4DUKhGIOX
 cloud.google.com/go/datacatalog v1.8.1/go.mod h1:RJ58z4rMp3gvETA465Vg+ag8BGgBdnRPEMMSTr5Uv+M=
 cloud.google.com/go/datacatalog v1.12.0/go.mod h1:CWae8rFkfp6LzLumKOnmVh4+Zle4A3NXLzVJ1d1mRm0=
 cloud.google.com/go/datacatalog v1.13.0/go.mod h1:E4Rj9a5ZtAxcQJlEBTLgMTphfP11/lNaAshpoBgemX8=
+cloud.google.com/go/datacatalog v1.24.3 h1:3bAfstDB6rlHyK0TvqxEwaeOvoN9UgCs2bn03+VXmss=
+cloud.google.com/go/datacatalog v1.24.3/go.mod h1:Z4g33XblDxWGHngDzcpfeOU0b1ERlDPTuQoYG6NkF1s=
 cloud.google.com/go/dataflow v0.6.0/go.mod h1:9QwV89cGoxjjSR9/r7eFDqqjtvbKxAK2BaYU6PVk9UM=
 cloud.google.com/go/dataflow v0.7.0/go.mod h1:PX526vb4ijFMesO1o202EaUmouZKBpjHsTlCtB4parQ=
 cloud.google.com/go/dataflow v0.8.0/go.mod h1:Rcf5YgTKPtQyYz8bLYhFoIV/vP39eL7fWNcSOyFfLJE=
@@ -557,6 +559,8 @@ cloud.google.com/go/storage v1.23.0/go.mod h1:vOEEDNFnciUMhBeT6hsJIn3ieU5cFRmzeL
 cloud.google.com/go/storage v1.27.0/go.mod h1:x9DOL8TK/ygDUMieqwfhdpQryTeEkhGKMi80i/iqR2s=
 cloud.google.com/go/storage v1.28.1/go.mod h1:Qnisd4CqDdo6BGs2AD5LLnEsmSQ80wQ5ogcBBKhU86Y=
 cloud.google.com/go/storage v1.29.0/go.mod h1:4puEjyTKnku6gfKoTfNOU/W+a9JyuVNxjpS5GBrB8h4=
+cloud.google.com/go/storage v1.50.0 h1:3TbVkzTooBvnZsk7WaAQfOsNrdoM8QHusXA1cpk6QJs=
+cloud.google.com/go/storage v1.50.0/go.mod h1:l7XeiD//vx5lfqE3RavfmU9yvk5Pp0Zhcv482poyafY=
 cloud.google.com/go/storagetransfer v1.5.0/go.mod h1:dxNzUopWy7RQevYFHewchb29POFv3/AaBgnhqzqiK0w=
 cloud.google.com/go/storagetransfer v1.6.0/go.mod h1:y77xm4CQV/ZhFZH75PLEXY0ROiS7Gh6pSKrM8dJyg6I=
 cloud.google.com/go/storagetransfer v1.7.0/go.mod h1:8Giuj1QNb1kfLAiWM1bN6dHzfdlDAVC9rv9abHot2W4=
@@ -849,11 +853,14 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
+github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
+github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -1027,6 +1034,7 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
@@ -1452,6 +1460,8 @@ gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJ
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=
 gonum.org/v1/gonum v0.11.0/go.mod h1:fSG4YDCxxUZQJ7rKsQrj0gMOg00Il0Z96/qMA4bVQhA=
+gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
+gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 gonum.org/v1/plot v0.9.0/go.mod h1:3Pcqqmp6RHvJI72kgb8fThyUnav364FOsdDo2aGW5lY=

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ cloud.google.com/go/bigquery v1.47.0/go.mod h1:sA9XOgy0A8vQK9+MWhEQTY6Tix87M/Zur
 cloud.google.com/go/bigquery v1.48.0/go.mod h1:QAwSz+ipNgfL5jxiaK7weyOhzdoAy1zFm0Nf1fysJac=
 cloud.google.com/go/bigquery v1.49.0/go.mod h1:Sv8hMmTFFYBlt/ftw2uN6dFdQPzBlREY9yBh7Oy7/4Q=
 cloud.google.com/go/bigquery v1.50.0/go.mod h1:YrleYEh2pSEbgTBZYMJ5SuSr0ML3ypjRB1zgf7pvQLU=
+cloud.google.com/go/bigquery v1.66.2 h1:EKOSqjtO7jPpJoEzDmRctGea3c2EOGoexy8VyY9dNro=
+cloud.google.com/go/bigquery v1.66.2/go.mod h1:+Yd6dRyW8D/FYEjUGodIbu0QaoEmgav7Lwhotup6njo=
 cloud.google.com/go/bigtable v1.37.0 h1:Q+x7y04lQ0B+WXp03wc1/FLhFt4CwcQdkwWT0M4Jp3w=
 cloud.google.com/go/bigtable v1.37.0/go.mod h1:HXqddP6hduwzrtiTCqZPpj9ij4hGZb4Zy1WF/dT+yaU=
 cloud.google.com/go/billing v1.4.0/go.mod h1:g9IdKBEFlItS8bTtlrZdVLWSSdSyFUZKXNS02zKMOZY=
@@ -665,6 +667,8 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
+github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcyOsMLE=
+github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -769,6 +773,8 @@ github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAu
 github.com/go-sql-driver/mysql v1.9.2 h1:4cNKDYQ1I84SXslGddlsrMhc8k4LeDVj6Ad6WRjiHuU=
 github.com/go-sql-driver/mysql v1.9.2/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
 github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
@@ -824,6 +830,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
+github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -932,7 +940,11 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:C
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
+github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -960,6 +972,8 @@ github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
+github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -1014,6 +1028,7 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -1093,6 +1108,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
+golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1135,6 +1152,8 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1417,6 +1436,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
+golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
+golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1425,6 +1446,8 @@ golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=
+golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/auth/google"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	alloydbpgsrc "github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
+	bigquerysrc "github.com/googleapis/genai-toolbox/internal/sources/bigquery"
 	bigtablesrc "github.com/googleapis/genai-toolbox/internal/sources/bigtable"
 	cloudsqlmssqlsrc "github.com/googleapis/genai-toolbox/internal/sources/cloudsqlmssql"
 	cloudsqlmysqlsrc "github.com/googleapis/genai-toolbox/internal/sources/cloudsqlmysql"
@@ -36,6 +37,7 @@ import (
 	spannersrc "github.com/googleapis/genai-toolbox/internal/sources/spanner"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/alloydbainl"
+	"github.com/googleapis/genai-toolbox/internal/tools/bigquery"
 	"github.com/googleapis/genai-toolbox/internal/tools/bigtable"
 	"github.com/googleapis/genai-toolbox/internal/tools/dgraph"
 	httptool "github.com/googleapis/genai-toolbox/internal/tools/http"
@@ -229,6 +231,12 @@ func (c *SourceConfigs) UnmarshalYAML(ctx context.Context, unmarshal func(interf
 				return fmt.Errorf("unable to parse as %q: %w", kind, err)
 			}
 			(*c)[name] = actual
+		case bigquerysrc.SourceKind:
+			actual := bigquerysrc.Config{Name: name}
+			if err := dec.DecodeContext(ctx, &actual); err != nil {
+				return fmt.Errorf("unable to parse as %q: %w", kind, err)
+			}
+			(*c)[name] = actual
 		default:
 			return fmt.Errorf("%q is not a valid kind of data source", kind)
 		}
@@ -360,6 +368,12 @@ func (c *ToolConfigs) UnmarshalYAML(ctx context.Context, unmarshal func(interfac
 			(*c)[name] = actual
 		case httptool.ToolKind:
 			actual := httptool.Config{Name: name}
+			if err := dec.DecodeContext(ctx, &actual); err != nil {
+				return fmt.Errorf("unable to parse as %q: %w", kind, err)
+			}
+			(*c)[name] = actual
+		case bigquery.ToolKind:
+			actual := bigquery.Config{Name: name}
 			if err := dec.DecodeContext(ctx, &actual); err != nil {
 				return fmt.Errorf("unable to parse as %q: %w", kind, err)
 			}

--- a/internal/sources/bigquery/bigquery.go
+++ b/internal/sources/bigquery/bigquery.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"context"
+	"fmt"
+
+	bigqueryapi "cloud.google.com/go/bigquery"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const SourceKind string = "bigquery"
+
+// validate interface
+var _ sources.SourceConfig = Config{}
+
+type Config struct {
+	// BigQuery configs
+	Name     string `yaml:"name" validate:"required"`
+	Kind     string `yaml:"kind" validate:"required"`
+	Project  string `yaml:"project" validate:"required"`
+	Location string `yaml:"location"`
+}
+
+func (r Config) SourceConfigKind() string {
+	// Returns BigQuery source kind
+	return SourceKind
+}
+
+func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
+	// Initializes a BigQuery Google SQL source
+	client, err := initBigQueryConnection(ctx, tracer, r.Name, r.Project)
+	if err != nil {
+		return nil, err
+	}
+	s := &Source{
+		Name:     r.Name,
+		Kind:     SourceKind,
+		Client:   client,
+		Location: r.Location,
+	}
+	return s, nil
+
+}
+
+var _ sources.Source = &Source{}
+
+type Source struct {
+	// BigQuery Google SQL struct with client
+	Name     string `yaml:"name"`
+	Kind     string `yaml:"kind"`
+	Client   *bigqueryapi.Client
+	Location string `yaml:"location"`
+}
+
+func (s *Source) SourceKind() string {
+	// Returns BigQuery Google SQL source kind
+	return SourceKind
+}
+
+func (s *Source) BigQueryClient() *bigqueryapi.Client {
+	return s.Client
+}
+
+func (s *Source) QueryLocation() string {
+	return s.Location
+}
+
+func initBigQueryConnection(
+	ctx context.Context,
+	tracer trace.Tracer,
+	name string,
+	project string,
+) (*bigqueryapi.Client, error) {
+	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceKind, name)
+	defer span.End()
+
+	cred, err := google.FindDefaultCredentials(ctx, bigqueryapi.Scope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find default Google Cloud credentials with scope %q: %w", bigqueryapi.Scope, err)
+	}
+
+	client, err := bigqueryapi.NewClient(ctx, project, option.WithCredentials(cred))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BigQuery client for project %q: %w", project, err)
+	}
+	return client, nil
+}

--- a/internal/sources/bigquery/bigquery.go
+++ b/internal/sources/bigquery/bigquery.go
@@ -46,7 +46,7 @@ func (r Config) SourceConfigKind() string {
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
 	// Initializes a BigQuery Google SQL source
-	client, err := initBigQueryConnection(ctx, tracer, r.Name, r.Project)
+	client, err := initBigQueryConnection(ctx, tracer, r.Name, r.Project, r.Location)
 	if err != nil {
 		return nil, err
 	}
@@ -79,15 +79,12 @@ func (s *Source) BigQueryClient() *bigqueryapi.Client {
 	return s.Client
 }
 
-func (s *Source) QueryLocation() string {
-	return s.Location
-}
-
 func initBigQueryConnection(
 	ctx context.Context,
 	tracer trace.Tracer,
 	name string,
 	project string,
+	location string,
 ) (*bigqueryapi.Client, error) {
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceKind, name)
 	defer span.End()
@@ -98,6 +95,7 @@ func initBigQueryConnection(
 	}
 
 	client, err := bigqueryapi.NewClient(ctx, project, option.WithCredentials(cred))
+	client.Location = location
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BigQuery client for project %q: %w", project, err)
 	}

--- a/internal/sources/bigquery/bigquery_test.go
+++ b/internal/sources/bigquery/bigquery_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery_test
+
+import (
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/sources/bigquery"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+)
+
+func TestParseFromYamlBigQuery(t *testing.T) {
+	tcs := []struct {
+		desc string
+		in   string
+		want server.SourceConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			sources:
+				my-instance:
+					kind: bigquery
+					project: my-project
+					location: us
+			`,
+			want: server.SourceConfigs{
+				"my-instance": bigquery.Config{
+					Name:     "my-instance",
+					Kind:     bigquery.SourceKind,
+					Project:  "my-project",
+					Location: "us",
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := struct {
+				Sources server.SourceConfigs `yaml:"sources"`
+			}{}
+			// Parse contents
+			err := yaml.Unmarshal(testutils.FormatYaml(tc.in), &got)
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if !cmp.Equal(tc.want, got.Sources) {
+				t.Fatalf("incorrect parse: want %v, got %v", tc.want, got.Sources)
+			}
+		})
+	}
+
+}
+
+func TestFailParseFromYaml(t *testing.T) {
+	tcs := []struct {
+		desc string
+		in   string
+		err  string
+	}{
+		{
+			desc: "extra field",
+			in: `
+			sources:
+				my-instance:
+					kind: bigquery
+					project: my-project
+					location: us
+					foo: bar
+			`,
+			err: "unable to parse as \"bigquery\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | kind: bigquery\n   3 | location: us\n   4 | project: my-project",
+		},
+		{
+			desc: "missing required field",
+			in: `
+			sources:
+				my-mysql-instance:
+					kind: bigquery
+					location: us
+			`,
+			err: "unable to parse as \"bigquery\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := struct {
+				Sources server.SourceConfigs `yaml:"sources"`
+			}{}
+			// Parse contents
+			err := yaml.Unmarshal(testutils.FormatYaml(tc.in), &got)
+			if err == nil {
+				t.Fatalf("expect parsing to fail")
+			}
+			errStr := err.Error()
+			if errStr != tc.err {
+				t.Fatalf("unexpected error: got %q, want %q", errStr, tc.err)
+			}
+		})
+	}
+}

--- a/internal/tools/bigquery/bigquery.go
+++ b/internal/tools/bigquery/bigquery.go
@@ -30,7 +30,6 @@ const ToolKind string = "bigquery-sql"
 
 type compatibleSource interface {
 	BigQueryClient() *bigqueryapi.Client
-	QueryLocation() string
 }
 
 // validate compatible sources are still compatible
@@ -82,7 +81,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		Statement:    cfg.Statement,
 		AuthRequired: cfg.AuthRequired,
 		Client:       s.BigQueryClient(),
-		Location:     s.QueryLocation(),
 		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
 		mcpManifest:  mcpManifest,
 	}
@@ -99,7 +97,6 @@ type Tool struct {
 	Parameters   tools.Parameters `yaml:"parameters"`
 
 	Client      *bigqueryapi.Client
-	Location    string
 	Statement   string
 	manifest    tools.Manifest
 	mcpManifest tools.McpManifest
@@ -124,7 +121,6 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 
 	query := t.Client.Query(t.Statement)
 	query.Parameters = namedArgs
-	query.Location = t.Location
 
 	it, err := query.Read(ctx)
 	if err != nil {

--- a/internal/tools/bigquery/bigquery.go
+++ b/internal/tools/bigquery/bigquery.go
@@ -1,0 +1,168 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	bigqueryapi "cloud.google.com/go/bigquery"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	bigqueryds "github.com/googleapis/genai-toolbox/internal/sources/bigquery"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"google.golang.org/api/iterator"
+)
+
+const ToolKind string = "bigquery-sql"
+
+type compatibleSource interface {
+	BigQueryClient() *bigqueryapi.Client
+	QueryLocation() string
+}
+
+// validate compatible sources are still compatible
+var _ compatibleSource = &bigqueryds.Source{}
+
+var compatibleSources = [...]string{bigqueryds.SourceKind}
+
+type Config struct {
+	Name         string           `yaml:"name" validate:"required"`
+	Kind         string           `yaml:"kind" validate:"required"`
+	Source       string           `yaml:"source" validate:"required"`
+	Description  string           `yaml:"description" validate:"required"`
+	Statement    string           `yaml:"statement" validate:"required"`
+	AuthRequired []string         `yaml:"authRequired"`
+	Parameters   tools.Parameters `yaml:"parameters"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigKind() string {
+	return ToolKind
+}
+
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	// verify source exists
+	rawS, ok := srcs[cfg.Source]
+	if !ok {
+		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
+	}
+
+	// verify the source is compatible
+	s, ok := rawS.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
+	}
+
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: cfg.Parameters.McpManifest(),
+	}
+
+	// finish tool setup
+	t := Tool{
+		Name:         cfg.Name,
+		Kind:         ToolKind,
+		Parameters:   cfg.Parameters,
+		Statement:    cfg.Statement,
+		AuthRequired: cfg.AuthRequired,
+		Client:       s.BigQueryClient(),
+		Location:     s.QueryLocation(),
+		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest()},
+		mcpManifest:  mcpManifest,
+	}
+	return t, nil
+}
+
+// validate interface
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	Name         string           `yaml:"name"`
+	Kind         string           `yaml:"kind"`
+	AuthRequired []string         `yaml:"authRequired"`
+	Parameters   tools.Parameters `yaml:"parameters"`
+
+	Client      *bigqueryapi.Client
+	Location    string
+	Statement   string
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+	namedArgs := make([]bigqueryapi.QueryParameter, 0, len(params))
+	paramsMap := params.AsReversedMap()
+	for _, v := range params.AsSlice() {
+		paramName := paramsMap[v]
+		if strings.Contains(t.Statement, "@"+paramName) {
+			namedArgs = append(namedArgs, bigqueryapi.QueryParameter{
+				Name:  paramName,
+				Value: v,
+			})
+		} else {
+			namedArgs = append(namedArgs, bigqueryapi.QueryParameter{
+				Value: v,
+			})
+		}
+	}
+
+	query := t.Client.Query(t.Statement)
+	query.Parameters = namedArgs
+	query.Location = t.Location
+
+	it, err := query.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to execute query: %w", err)
+	}
+
+	var out []any
+	for {
+		var row map[string]bigqueryapi.Value
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("unable to iterate through query results: %w", err)
+		}
+		vMap := make(map[string]any)
+		for key, value := range row {
+			vMap[key] = value
+		}
+		out = append(out, vMap)
+	}
+
+	return out, nil
+}
+
+func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {
+	return tools.ParseParams(t.Parameters, data, claims)
+}
+
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+}

--- a/internal/tools/bigquery/bigquery_test.go
+++ b/internal/tools/bigquery/bigquery_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery_test
+
+import (
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/googleapis/genai-toolbox/internal/tools/bigquery"
+)
+
+func TestParseFromYamlSpanner(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			tools:
+				example_tool:
+					kind: bigquery-sql
+					source: my-instance
+					description: some description
+					statement: |
+						SELECT * FROM SQL_STATEMENT;
+					parameters:
+						- name: country
+						  type: string
+						  description: some description
+			`,
+			want: server.ToolConfigs{
+				"example_tool": bigquery.Config{
+					Name:        "example_tool",
+					Kind:        bigquery.ToolKind,
+					Source:      "my-instance",
+					Description: "some description",
+					Statement:   "SELECT * FROM SQL_STATEMENT;\n",
+					Parameters: []tools.Parameter{
+						tools.NewStringParameter("country", "some description"),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := struct {
+				Tools server.ToolConfigs `yaml:"tools"`
+			}{}
+			// Parse contents
+			err := yaml.UnmarshalContext(ctx, testutils.FormatYaml(tc.in), &got)
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got.Tools); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+
+}

--- a/tests/bigquery_integration_test.go
+++ b/tests/bigquery_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration && bigquery
+
+//
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	bigqueryapi "cloud.google.com/go/bigquery"
+	"github.com/google/uuid"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+)
+
+var (
+	BIGQUERY_SOURCE_KIND = "bigquery"
+	BIGQUERY_TOOL_KIND   = "bigquery-sql"
+	BIGQUERY_PROJECT     = os.Getenv("BIGQUERY_PROJECT")
+)
+
+func getBigQueryVars(t *testing.T, location *string) map[string]any {
+	switch "" {
+	case BIGQUERY_PROJECT:
+		t.Fatal("'BIGQUERY_PROJECT' not set")
+	}
+
+	return map[string]any{
+		"kind":     BIGQUERY_SOURCE_KIND,
+		"project":  BIGQUERY_PROJECT,
+		"location": location,
+	}
+}
+
+func initBigQueryConnection(project string) (*bigqueryapi.Client, error) {
+	ctx := context.Background()
+	cred, err := google.FindDefaultCredentials(ctx, bigqueryapi.Scope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find default Google Cloud credentials with scope %q: %w", bigqueryapi.Scope, err)
+	}
+
+	client, err := bigqueryapi.NewClient(ctx, project, option.WithCredentials(cred))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create BigQuery client for project %q: %w", project, err)
+	}
+	return client, nil
+}
+
+func TestBigQueryToolEndpoints(t *testing.T) {
+	sourceConfig := getBigQueryVars(t, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var args []string
+
+	client, err := initBigQueryConnection(BIGQUERY_PROJECT)
+	if err != nil {
+		t.Fatalf("unable to create Cloud SQL connection pool: %s", err)
+	}
+
+	// create table name with UUID
+	datasetName := fmt.Sprintf("temp_dataset_%s", strings.Replace(uuid.New().String(), "-", "", -1))
+	tableNameParam := fmt.Sprintf("`%s.%s.param_table_%s`",
+		BIGQUERY_PROJECT,
+		datasetName,
+		strings.Replace(uuid.New().String(), "-", "", -1),
+	)
+	tableNameAuth := fmt.Sprintf("`%s.%s.auth_table_%s`",
+		BIGQUERY_PROJECT,
+		datasetName,
+		strings.Replace(uuid.New().String(), "-", "", -1),
+	)
+	// set up data for param tool
+	create_statement1, insert_statement1, tool_statement1, params1 := GetBigQueryParamToolInfo(BIGQUERY_PROJECT, datasetName, tableNameParam)
+	teardownTable1 := SetupBigQueryTable(t, ctx, client, create_statement1, insert_statement1, datasetName, tableNameParam, params1)
+	defer teardownTable1(t)
+
+	// set up data for auth tool
+	create_statement2, insert_statement2, tool_statement2, params2 := GetBigQueryAuthToolInfo(BIGQUERY_PROJECT, datasetName, tableNameAuth)
+	teardownTable2 := SetupBigQueryTable(t, ctx, client, create_statement2, insert_statement2, datasetName, tableNameAuth, params2)
+	defer teardownTable2(t)
+
+	// Write config into a file and pass it to command
+	toolsFile := GetToolsConfig(sourceConfig, BIGQUERY_TOOL_KIND, tool_statement1, tool_statement2)
+
+	cmd, cleanup, err := StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	RunToolGetTest(t)
+
+	select_1_want := "[{\"f0_\":1}]"
+	// partial message, the real error message is too long.
+	fail_invocation_want := "{jsonrpc:2.0,id:invoke-fail-tool,result:{content:[{type:text,text:unable to execute query: googleapi: Error 400: Syntax error: Unexpected identifier SELEC at [1:1]"
+	RunToolInvokeTest(t, select_1_want)
+	RunMCPToolCallMethod(t, fail_invocation_want)
+}

--- a/tests/bigquery_integration_test.go
+++ b/tests/bigquery_integration_test.go
@@ -1,6 +1,5 @@
 //go:build integration && bigquery
 
-//
 // Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/bigquery_integration_test.go
+++ b/tests/bigquery_integration_test.go
@@ -119,7 +119,7 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	RunToolGetTest(t)
 
 	select_1_want := "[{\"f0_\":1}]"
-	// partial message, the real error message is too long.
+	// Partial message; the full error message is too long.
 	fail_invocation_want := "{jsonrpc:2.0,id:invoke-fail-tool,result:{content:[{type:text,text:unable to execute query: googleapi: Error 400: Syntax error: Unexpected identifier SELEC at [1:1]"
 	RunToolInvokeTest(t, select_1_want)
 	RunMCPToolCallMethod(t, fail_invocation_want)

--- a/tests/bigquery_integration_test.go
+++ b/tests/bigquery_integration_test.go
@@ -76,7 +76,7 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	}
 
 	// create table name with UUID
-	datasetName := fmt.Sprintf("temp_dataset_%s", strings.Replace(uuid.New().String(), "-", "", -1))
+	datasetName := fmt.Sprintf("temp_toolbox_test_%s", strings.Replace(uuid.New().String(), "-", "", -1))
 	tableNameParam := fmt.Sprintf("`%s.%s.param_table_%s`",
 		BIGQUERY_PROJECT,
 		datasetName,

--- a/tests/bigquery_integration_test.go
+++ b/tests/bigquery_integration_test.go
@@ -60,9 +60,7 @@ func initBigQueryConnection(project, location string) (*bigqueryapi.Client, erro
 	}
 
 	client, err := bigqueryapi.NewClient(ctx, project, option.WithCredentials(cred))
-	// if location != "" {
 	client.Location = location
-	// }
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BigQuery client for project %q: %w", project, err)
 	}

--- a/tests/bigquery_integration_test.go
+++ b/tests/bigquery_integration_test.go
@@ -37,16 +37,15 @@ var (
 	BIGQUERY_PROJECT     = os.Getenv("BIGQUERY_PROJECT")
 )
 
-func getBigQueryVars(t *testing.T, location *string) map[string]any {
+func getBigQueryVars(t *testing.T) map[string]any {
 	switch "" {
 	case BIGQUERY_PROJECT:
 		t.Fatal("'BIGQUERY_PROJECT' not set")
 	}
 
 	return map[string]any{
-		"kind":     BIGQUERY_SOURCE_KIND,
-		"project":  BIGQUERY_PROJECT,
-		"location": location,
+		"kind":    BIGQUERY_SOURCE_KIND,
+		"project": BIGQUERY_PROJECT,
 	}
 }
 
@@ -65,7 +64,7 @@ func initBigQueryConnection(project string) (*bigqueryapi.Client, error) {
 }
 
 func TestBigQueryToolEndpoints(t *testing.T) {
-	sourceConfig := getBigQueryVars(t, nil)
+	sourceConfig := getBigQueryVars(t)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 

--- a/tests/bigquery_integration_test.go
+++ b/tests/bigquery_integration_test.go
@@ -35,6 +35,7 @@ var (
 	BIGQUERY_SOURCE_KIND = "bigquery"
 	BIGQUERY_TOOL_KIND   = "bigquery-sql"
 	BIGQUERY_PROJECT     = os.Getenv("BIGQUERY_PROJECT")
+	BIGQUERY_LOCATION    = os.Getenv("BIGQUERY_LOCATION")
 )
 
 func getBigQueryVars(t *testing.T) map[string]any {
@@ -44,12 +45,14 @@ func getBigQueryVars(t *testing.T) map[string]any {
 	}
 
 	return map[string]any{
-		"kind":    BIGQUERY_SOURCE_KIND,
-		"project": BIGQUERY_PROJECT,
+		"kind":     BIGQUERY_SOURCE_KIND,
+		"project":  BIGQUERY_PROJECT,
+		"location": BIGQUERY_LOCATION,
 	}
 }
 
-func initBigQueryConnection(project string) (*bigqueryapi.Client, error) {
+// Copied over from bigquery.go
+func initBigQueryConnection(project, location string) (*bigqueryapi.Client, error) {
 	ctx := context.Background()
 	cred, err := google.FindDefaultCredentials(ctx, bigqueryapi.Scope)
 	if err != nil {
@@ -57,6 +60,9 @@ func initBigQueryConnection(project string) (*bigqueryapi.Client, error) {
 	}
 
 	client, err := bigqueryapi.NewClient(ctx, project, option.WithCredentials(cred))
+	// if location != "" {
+	client.Location = location
+	// }
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BigQuery client for project %q: %w", project, err)
 	}
@@ -70,7 +76,7 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 
 	var args []string
 
-	client, err := initBigQueryConnection(BIGQUERY_PROJECT)
+	client, err := initBigQueryConnection(BIGQUERY_PROJECT, BIGQUERY_LOCATION)
 	if err != nil {
 		t.Fatalf("unable to create Cloud SQL connection pool: %s", err)
 	}

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 
 	"github.com/googleapis/genai-toolbox/internal/tools"
+
+	bigqueryapi "cloud.google.com/go/bigquery"
 )
 
 // GetToolsConfig returns a mock tools config file
@@ -271,4 +273,34 @@ func GetSpannerAuthToolInfo(tableName string) (string, string, string, map[strin
 		"email2": "janedoe@gmail.com",
 	}
 	return create_statement, insert_statement, tool_statement, params
+}
+
+// GetBigQueryParamToolInfo returns statements and param for my-param-tool for bigquery kind
+func GetBigQueryParamToolInfo(projectID, datasetID, tableName string) (string, string, string, []bigqueryapi.QueryParameter) {
+	createStatement := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (id INT64, name STRING);`, tableName)
+	insertStatement := fmt.Sprintf(`
+		INSERT INTO %s (id, name) VALUES (?, ?), (?, ?), (?, ?);`, tableName)
+	toolStatement := fmt.Sprintf(`SELECT * FROM %s WHERE id = ? OR name = ? ORDER BY id;`, tableName)
+	params := []bigqueryapi.QueryParameter{
+		{Value: int64(1)}, {Value: "Alice"},
+		{Value: int64(2)}, {Value: "Jane"},
+		{Value: int64(3)}, {Value: "Sid"},
+	}
+	return createStatement, insertStatement, toolStatement, params
+}
+
+// GetBigQueryAuthToolInfo returns statements and param of my-auth-tool for bigquery kind
+func GetBigQueryAuthToolInfo(projectID, datasetID, tableName string) (string, string, string, []bigqueryapi.QueryParameter) {
+	createStatement := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (id INT64, name STRING, email STRING)`, tableName)
+	insertStatement := fmt.Sprintf(`
+		INSERT INTO %s (id, name, email) VALUES (?, ?, ?), (?, ?, ?)`, tableName)
+	toolStatement := fmt.Sprintf(`
+		SELECT name FROM %s WHERE email = ?`, tableName)
+	params := []bigqueryapi.QueryParameter{
+		{Value: int64(1)}, {Value: "Alice"}, {Value: SERVICE_ACCOUNT_EMAIL},
+		{Value: int64(2)}, {Value: "Jane"}, {Value: "janedoe@gmail.com"},
+	}
+	return createStatement, insertStatement, toolStatement, params
 }

--- a/tests/tool_test.go
+++ b/tests/tool_test.go
@@ -28,11 +28,14 @@ import (
 	"strings"
 	"testing"
 
+	bigqueryapi "cloud.google.com/go/bigquery"
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/googleapis/genai-toolbox/internal/server/mcp"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iterator"
 )
 
 // SetupPostgresSQLTable creates and inserts data into a table of tool
@@ -166,6 +169,83 @@ func SetupSpannerTable(t *testing.T, ctx context.Context, adminClient *database.
 		err = op.Wait(ctx)
 		if err != nil {
 			t.Errorf("Teardown failed: %s", err)
+		}
+	}
+}
+
+func SetupBigQueryTable(t *testing.T, ctx context.Context, client *bigqueryapi.Client, create_statement, insert_statement, datasetName string, tableName string, params []bigqueryapi.QueryParameter) func(*testing.T) {
+	// Create dataset
+	dataset := client.Dataset(datasetName)
+	_, err := dataset.Metadata(ctx)
+
+	if err != nil {
+		apiErr, ok := err.(*googleapi.Error)
+		if !ok || apiErr.Code != 404 {
+			t.Fatalf("Failed to check dataset %q existence: %v", datasetName, err)
+		}
+		metadataToCreate := &bigqueryapi.DatasetMetadata{Name: datasetName}
+		if err := dataset.Create(ctx, metadataToCreate); err != nil {
+			t.Fatalf("Failed to create dataset %q: %v", datasetName, err)
+		}
+	}
+
+	// Create table
+	createJob, err := client.Query(create_statement).Run(ctx)
+
+	if err != nil {
+		t.Fatalf("Failed to start create table job for %s: %v", tableName, err)
+	}
+	createStatus, err := createJob.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Failed to wait for create table job for %s: %v", tableName, err)
+	}
+	if err := createStatus.Err(); err != nil {
+		t.Fatalf("Create table job for %s failed: %v", tableName, err)
+	}
+
+	// Insert test data
+	insertQuery := client.Query(insert_statement)
+	insertQuery.Parameters = params
+	insertJob, err := insertQuery.Run(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start insert job for %s: %v", tableName, err)
+	}
+	insertStatus, err := insertJob.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Failed to wait for insert job for %s: %v", tableName, err)
+	}
+	if err := insertStatus.Err(); err != nil {
+		t.Fatalf("Insert job for %s failed: %v", tableName, err)
+	}
+
+	return func(t *testing.T) {
+		// tear down table
+		dropSQL := fmt.Sprintf("drop table %s", tableName)
+		dropJob, err := client.Query(dropSQL).Run(ctx)
+		if err != nil {
+			t.Errorf("Failed to start drop table job for %s: %v", tableName, err)
+			return
+		}
+		dropStatus, err := dropJob.Wait(ctx)
+		if err != nil {
+			t.Errorf("Failed to wait for drop table job for %s: %v", tableName, err)
+			return
+		}
+		if err := dropStatus.Err(); err != nil {
+			t.Errorf("Error dropping table %s: %v", tableName, err)
+		}
+
+		// tear down dataset
+		datasetToTeardown := client.Dataset(datasetName)
+		tablesIterator := datasetToTeardown.Tables(ctx)
+		_, err = tablesIterator.Next()
+
+		if err == iterator.Done {
+			if err := datasetToTeardown.Delete(ctx); err != nil {
+				t.Errorf("Failed to delete dataset %s: %v", datasetName, err)
+			}
+		} else if err != nil {
+			t.Errorf("Failed to list tables in dataset %s to check emptiness: %v.", datasetName, err)
 		}
 	}
 }


### PR DESCRIPTION
A `BigQuery` source can be added as the following example:

```yaml
sources:
  my-bigquery-source:
    kind: bigquery
    project: bigframes-dev
    location: us # This field is optional
```

A `BigQuery` tool can be added as below:
```yaml
tools:
  search-hotels-by-name:
    kind: bigquery-sql
    source: my-bigquery-source
    description: Search for hotels based on name.
    parameters:
      - name: name
        type: string
        description: The name of the hotel.
```