### PR TITLE
fix: update http error code from invocation

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -220,7 +220,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		err = fmt.Errorf("error while invoking tool: %w", err)
 		s.logger.DebugContext(ctx, err.Error())
-		_ = render.Render(w, r, newErrResponse(err, http.StatusInternalServerError))
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
 		return
 	}
 


### PR DESCRIPTION
Update http error code for invocation failure. Invocation may fail if user fail to provide required parameter etc.

Fixes #465