### PR TITLE
feat: add postgres-execute-sql tool

### DIFF
--- a/docs/en/resources/tools/postgres-execute-sql.md
+++ b/docs/en/resources/tools/postgres-execute-sql.md
@@ -1,0 +1,36 @@
+---
+title: "postgres-execute-sql"
+type: docs
+weight: 1
+description: > 
+  A "postgres-execute-sql" tool executes a SQL statement against a Postgres
+  database.
+---
+
+## About
+
+A `postgres-execute-sql` tool executes a SQL statement against a Postgres
+database. It's compatible with any of the following sources:
+
+- [alloydb-postgres](../sources/alloydb-pg.md)
+- [cloud-sql-postgres](../sources/cloud-sql-pg.md)
+- [postgres](../sources/postgres.md)
+
+## Example
+
+```yaml
+tools:
+ execute_sql_tool:
+    kind: postgres-execute-sql
+    source: my-pg-instance
+    description: |
+      Use this tool to execute sql statement.
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| kind        |                   string                   |     true     | Must be "postgres-execute-sql".                                                                          |
+| source      |                   string                   |     true     | Name of the source the SQL should execute on.                                                    |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |

--- a/docs/en/resources/tools/postgres-execute-sql.md
+++ b/docs/en/resources/tools/postgres-execute-sql.md
@@ -16,6 +16,9 @@ database. It's compatible with any of the following sources:
 - [cloud-sql-postgres](../sources/cloud-sql-pg.md)
 - [postgres](../sources/postgres.md)
 
+`postgres-execute-sql` takes one input parameter `sql` and run the sql
+statement against the `source`.
+
 ## Example
 
 ```yaml
@@ -23,8 +26,7 @@ tools:
  execute_sql_tool:
     kind: postgres-execute-sql
     source: my-pg-instance
-    description: |
-      Use this tool to execute sql statement.
+    description: Use this tool to execute sql statement.
 ```
 
 ## Reference

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -45,6 +45,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/tools/mssqlsql"
 	"github.com/googleapis/genai-toolbox/internal/tools/mysqlsql"
 	neo4jtool "github.com/googleapis/genai-toolbox/internal/tools/neo4j"
+	"github.com/googleapis/genai-toolbox/internal/tools/postgresexecutesql"
 	"github.com/googleapis/genai-toolbox/internal/tools/postgressql"
 	"github.com/googleapis/genai-toolbox/internal/tools/spanner"
 	"github.com/googleapis/genai-toolbox/internal/tools/sqlitesql"
@@ -393,6 +394,12 @@ func (c *ToolConfigs) UnmarshalYAML(ctx context.Context, unmarshal func(interfac
 			(*c)[name] = actual
 		case sqlitesql.ToolKind:
 			actual := sqlitesql.Config{Name: name}
+			if err := dec.DecodeContext(ctx, &actual); err != nil {
+				return fmt.Errorf("unable to parse as %q: %w", kind, err)
+			}
+			(*c)[name] = actual
+		case postgresexecutesql.ToolKind:
+			actual := postgresexecutesql.Config{Name: name}
 			if err := dec.DecodeContext(ctx, &actual); err != nil {
 				return fmt.Errorf("unable to parse as %q: %w", kind, err)
 			}

--- a/internal/tools/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgresexecutesql/postgresexecutesql.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresexecutesql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
+	"github.com/googleapis/genai-toolbox/internal/sources/cloudsqlpg"
+	"github.com/googleapis/genai-toolbox/internal/sources/postgres"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const ToolKind string = "postgres-execute-sql"
+
+type compatibleSource interface {
+	PostgresPool() *pgxpool.Pool
+}
+
+// validate compatible sources are still compatible
+var _ compatibleSource = &alloydbpg.Source{}
+var _ compatibleSource = &cloudsqlpg.Source{}
+var _ compatibleSource = &postgres.Source{}
+
+var compatibleSources = [...]string{alloydbpg.SourceKind, cloudsqlpg.SourceKind, postgres.SourceKind}
+
+type Config struct {
+	Name         string   `yaml:"name" validate:"required"`
+	Kind         string   `yaml:"kind" validate:"required"`
+	Source       string   `yaml:"source" validate:"required"`
+	Description  string   `yaml:"description" validate:"required"`
+	AuthRequired []string `yaml:"authRequired"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigKind() string {
+	return ToolKind
+}
+
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	// verify source exists
+	rawS, ok := srcs[cfg.Source]
+	if !ok {
+		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
+	}
+
+	// verify the source is compatible
+	s, ok := rawS.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", ToolKind, compatibleSources)
+	}
+
+	sqlParameter := tools.NewStringParameter("sql", "The sql to execute.")
+	parameters := tools.Parameters{sqlParameter}
+
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: parameters.McpManifest(),
+	}
+
+	// finish tool setup
+	t := Tool{
+		Name:         cfg.Name,
+		Kind:         ToolKind,
+		Parameters:   parameters,
+		AuthRequired: cfg.AuthRequired,
+		Pool:         s.PostgresPool(),
+		manifest:     tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
+		mcpManifest:  mcpManifest,
+	}
+	return t, nil
+}
+
+// validate interface
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	Name         string           `yaml:"name"`
+	Kind         string           `yaml:"kind"`
+	AuthRequired []string         `yaml:"authRequired"`
+	Parameters   tools.Parameters `yaml:"parameters"`
+
+	Pool        *pgxpool.Pool
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+	sliceParams := params.AsSlice()
+	sql, _ := sliceParams[0].(string)
+
+	results, err := t.Pool.Query(ctx, sql)
+	if err != nil {
+		return nil, fmt.Errorf("unable to execute query: %w", err)
+	}
+
+	fields := results.FieldDescriptions()
+
+	var out []any
+	for results.Next() {
+		v, err := results.Values()
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse row: %w", err)
+		}
+		vMap := make(map[string]any)
+		for i, f := range fields {
+			vMap[f.Name] = v[i]
+		}
+		out = append(out, vMap)
+	}
+
+	return out, nil
+}
+
+func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {
+	return tools.ParseParams(t.Parameters, data, claims)
+}
+
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+}

--- a/internal/tools/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgresexecutesql/postgresexecutesql.go
@@ -105,7 +105,10 @@ type Tool struct {
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
 	sliceParams := params.AsSlice()
-	sql, _ := sliceParams[0].(string)
+	sql, ok := sliceParams[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("unable to get cast %s", sliceParams[0])
+	}
 
 	results, err := t.Pool.Query(ctx, sql)
 	if err != nil {

--- a/internal/tools/postgresexecutesql/postgresexecutesql_test.go
+++ b/internal/tools/postgresexecutesql/postgresexecutesql_test.go
@@ -39,7 +39,7 @@ func TestParseFromYamlExecuteSql(t *testing.T) {
 			in: `
 			tools:
 				example_tool:
-					kind: pg-execute-sql
+					kind: postgres-execute-sql
 					source: my-instance
 					description: some description
 					authRequired:

--- a/internal/tools/postgresexecutesql/postgresexecutesql_test.go
+++ b/internal/tools/postgresexecutesql/postgresexecutesql_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresexecutesql_test
+
+import (
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/tools/postgresexecutesql"
+)
+
+func TestParseFromYamlExecuteSql(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			tools:
+				example_tool:
+					kind: pg-execute-sql
+					source: my-instance
+					description: some description
+					authRequired:
+						- my-google-auth-service
+						- other-auth-service
+			`,
+			want: server.ToolConfigs{
+				"example_tool": postgresexecutesql.Config{
+					Name:         "example_tool",
+					Kind:         postgresexecutesql.ToolKind,
+					Source:       "my-instance",
+					Description:  "some description",
+					AuthRequired: []string{"my-google-auth-service", "other-auth-service"},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := struct {
+				Tools server.ToolConfigs `yaml:"tools"`
+			}{}
+			// Parse contents
+			err := yaml.UnmarshalContext(ctx, testutils.FormatYaml(tc.in), &got)
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got.Tools); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This tool can be used across all postgres sources.

`postgres-execute-sql` config is as below:

```
tools:
  postgres_execute_sql_tool:
    kind: "postgres-execute-sql"
    source: my-alloydb-source // or any other sources that is compatible with this tool
    description: Use this tool to execute sql.
```

The `postgres-execute-sql` tool takes one parameter. Example request as follow:
```
curl -X POST -H "Content-Type: application/json" -d '{"sql": "SELECT 1"}' http://127.0.0.1:5000/api/tool/postgres_execute_sql_tool/invoke
```