### PR TITLE
test: cleanup integration test

### DIFF
--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -161,10 +161,10 @@ func TestAlloyDBPgToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"?column?\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: ERROR: syntax error at or near \"SELEC\" (SQLSTATE 42601)"}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want, failInvocationWant := tests.GetPostgresWants()
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }
 
 // Test connection with different IP type

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/googleapis/genai-toolbox/tests"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
@@ -91,13 +93,13 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 		strings.Replace(uuid.New().String(), "-", "", -1),
 	)
 	// set up data for param tool
-	create_statement1, insert_statement1, tool_statement1, params1 := tests.GetBigQueryParamToolInfo(BIGQUERY_PROJECT, datasetName, tableNameParam)
-	teardownTable1 := tests.SetupBigQueryTable(t, ctx, client, create_statement1, insert_statement1, datasetName, tableNameParam, params1)
+	create_statement1, insert_statement1, tool_statement1, params1 := getBigQueryParamToolInfo(BIGQUERY_PROJECT, datasetName, tableNameParam)
+	teardownTable1 := setupBigQueryTable(t, ctx, client, create_statement1, insert_statement1, datasetName, tableNameParam, params1)
 	defer teardownTable1(t)
 
 	// set up data for auth tool
-	create_statement2, insert_statement2, tool_statement2, params2 := tests.GetBigQueryAuthToolInfo(BIGQUERY_PROJECT, datasetName, tableNameAuth)
-	teardownTable2 := tests.SetupBigQueryTable(t, ctx, client, create_statement2, insert_statement2, datasetName, tableNameAuth, params2)
+	create_statement2, insert_statement2, tool_statement2, params2 := getBigQueryAuthToolInfo(BIGQUERY_PROJECT, datasetName, tableNameAuth)
+	teardownTable2 := setupBigQueryTable(t, ctx, client, create_statement2, insert_statement2, datasetName, tableNameAuth, params2)
 	defer teardownTable2(t)
 
 	// Write config into a file and pass it to command
@@ -125,4 +127,111 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
 	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
 	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
+}
+
+// getBigQueryParamToolInfo returns statements and param for my-param-tool for bigquery kind
+func getBigQueryParamToolInfo(projectID, datasetID, tableName string) (string, string, string, []bigqueryapi.QueryParameter) {
+	createStatement := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (id INT64, name STRING);`, tableName)
+	insertStatement := fmt.Sprintf(`
+		INSERT INTO %s (id, name) VALUES (?, ?), (?, ?), (?, ?);`, tableName)
+	toolStatement := fmt.Sprintf(`SELECT * FROM %s WHERE id = ? OR name = ? ORDER BY id;`, tableName)
+	params := []bigqueryapi.QueryParameter{
+		{Value: int64(1)}, {Value: "Alice"},
+		{Value: int64(2)}, {Value: "Jane"},
+		{Value: int64(3)}, {Value: "Sid"},
+	}
+	return createStatement, insertStatement, toolStatement, params
+}
+
+// getBigQueryAuthToolInfo returns statements and param of my-auth-tool for bigquery kind
+func getBigQueryAuthToolInfo(projectID, datasetID, tableName string) (string, string, string, []bigqueryapi.QueryParameter) {
+	createStatement := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (id INT64, name STRING, email STRING)`, tableName)
+	insertStatement := fmt.Sprintf(`
+		INSERT INTO %s (id, name, email) VALUES (?, ?, ?), (?, ?, ?)`, tableName)
+	toolStatement := fmt.Sprintf(`
+		SELECT name FROM %s WHERE email = ?`, tableName)
+	params := []bigqueryapi.QueryParameter{
+		{Value: int64(1)}, {Value: "Alice"}, {Value: tests.SERVICE_ACCOUNT_EMAIL},
+		{Value: int64(2)}, {Value: "Jane"}, {Value: "janedoe@gmail.com"},
+	}
+	return createStatement, insertStatement, toolStatement, params
+}
+
+func setupBigQueryTable(t *testing.T, ctx context.Context, client *bigqueryapi.Client, create_statement, insert_statement, datasetName string, tableName string, params []bigqueryapi.QueryParameter) func(*testing.T) {
+	// Create dataset
+	dataset := client.Dataset(datasetName)
+	_, err := dataset.Metadata(ctx)
+
+	if err != nil {
+		apiErr, ok := err.(*googleapi.Error)
+		if !ok || apiErr.Code != 404 {
+			t.Fatalf("Failed to check dataset %q existence: %v", datasetName, err)
+		}
+		metadataToCreate := &bigqueryapi.DatasetMetadata{Name: datasetName}
+		if err := dataset.Create(ctx, metadataToCreate); err != nil {
+			t.Fatalf("Failed to create dataset %q: %v", datasetName, err)
+		}
+	}
+
+	// Create table
+	createJob, err := client.Query(create_statement).Run(ctx)
+
+	if err != nil {
+		t.Fatalf("Failed to start create table job for %s: %v", tableName, err)
+	}
+	createStatus, err := createJob.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Failed to wait for create table job for %s: %v", tableName, err)
+	}
+	if err := createStatus.Err(); err != nil {
+		t.Fatalf("Create table job for %s failed: %v", tableName, err)
+	}
+
+	// Insert test data
+	insertQuery := client.Query(insert_statement)
+	insertQuery.Parameters = params
+	insertJob, err := insertQuery.Run(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start insert job for %s: %v", tableName, err)
+	}
+	insertStatus, err := insertJob.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Failed to wait for insert job for %s: %v", tableName, err)
+	}
+	if err := insertStatus.Err(); err != nil {
+		t.Fatalf("Insert job for %s failed: %v", tableName, err)
+	}
+
+	return func(t *testing.T) {
+		// tear down table
+		dropSQL := fmt.Sprintf("drop table %s", tableName)
+		dropJob, err := client.Query(dropSQL).Run(ctx)
+		if err != nil {
+			t.Errorf("Failed to start drop table job for %s: %v", tableName, err)
+			return
+		}
+		dropStatus, err := dropJob.Wait(ctx)
+		if err != nil {
+			t.Errorf("Failed to wait for drop table job for %s: %v", tableName, err)
+			return
+		}
+		if err := dropStatus.Err(); err != nil {
+			t.Errorf("Error dropping table %s: %v", tableName, err)
+		}
+
+		// tear down dataset
+		datasetToTeardown := client.Dataset(datasetName)
+		tablesIterator := datasetToTeardown.Tables(ctx)
+		_, err = tablesIterator.Next()
+
+		if err == iterator.Done {
+			if err := datasetToTeardown.Delete(ctx); err != nil {
+				t.Errorf("Failed to delete dataset %s: %v", datasetName, err)
+			}
+		} else if err != nil {
+			t.Errorf("Failed to list tables in dataset %s to check emptiness: %v.", datasetName, err)
+		}
+	}
 }

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -119,9 +119,10 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"f0_\":1}]"
+	select1Want := "[{\"f0_\":1}]"
 	// Partial message; the full error message is too long.
-	fail_invocation_want := "{jsonrpc:2.0,id:invoke-fail-tool,result:{content:[{type:text,text:unable to execute query: googleapi: Error 400: Syntax error: Unexpected identifier SELEC at [1:1]"
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	failInvocationWant := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: googleapi: Error 400: Syntax error: Unexpected identifier \"SELEC\" at [1:1], invalidQuery"}],"isError":true}}`
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }

--- a/tests/bigtable/bigtable_integration_test.go
+++ b/tests/bigtable/bigtable_integration_test.go
@@ -104,10 +104,11 @@ func TestBigtableToolEndpoints(t *testing.T) {
 	tests.RunToolGetTest(t)
 
 	// Actual test parameters are set in https://github.com/googleapis/genai-toolbox/blob/52b09a67cb40ac0c5f461598b4673136699a3089/tests/tool_test.go#L250
-	select_1_want := "[{$col1:1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to prepare statement: rpc error: code = InvalidArgument desc = Syntax error: Unexpected identifier SELEC [at 1:1]"}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want := "[{\"$col1\":1}]"
+	failInvocationWant := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to prepare statement: rpc error: code = InvalidArgument desc = Syntax error: Unexpected identifier \"SELEC\" [at 1:1]"}],"isError":true}}`
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }
 
 func getTestData(columnFamilyName string) ([]*bigtable.Mutation, []string) {

--- a/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
+++ b/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
@@ -148,10 +148,10 @@ func TestCloudSQLMssqlToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: mssql: Could not find stored procedure 'SELEC'."}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want, failInvocationWant := tests.GetMssqlWants()
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }
 
 // Test connection with different IP type

--- a/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
+++ b/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
@@ -142,10 +142,10 @@ func TestCloudSQLMysqlToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"1\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SELEC 1' at line 1"}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want, failInvocationWant := tests.GetMysqlWants()
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }
 
 // Test connection with different IP type

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -146,10 +146,10 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"?column?\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: ERROR: syntax error at or near \"SELEC\" (SQLSTATE 42601)"}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want, failInvocationWant := tests.GetPostgresWants()
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }
 
 // Test connection with different IP type

--- a/tests/common.go
+++ b/tests/common.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 
 	"github.com/googleapis/genai-toolbox/internal/tools"
-
-	bigqueryapi "cloud.google.com/go/bigquery"
 )
 
 // GetToolsConfig returns a mock tools config file
@@ -248,59 +246,6 @@ func GetMysqlLAuthToolInfo(tableName string) (string, string, string, []any) {
 	tool_statement := fmt.Sprintf("SELECT name FROM %s WHERE email = ?;", tableName)
 	params := []any{"Alice", SERVICE_ACCOUNT_EMAIL, "Jane", "janedoe@gmail.com"}
 	return create_statement, insert_statement, tool_statement, params
-}
-
-// GetSpannerToolInfo returns statements and param for my-param-tool for spanner-sql kind
-func GetSpannerParamToolInfo(tableName string) (string, string, string, map[string]any) {
-	create_statement := fmt.Sprintf("CREATE TABLE %s (id INT64, name STRING(MAX)) PRIMARY KEY (id)", tableName)
-	insert_statement := fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, @name1), (2, @name2), (3, @name3)", tableName)
-	tool_statement := fmt.Sprintf("SELECT * FROM %s WHERE id = @id OR name = @name", tableName)
-	params := map[string]any{"name1": "Alice", "name2": "Jane", "name3": "Sid"}
-	return create_statement, insert_statement, tool_statement, params
-}
-
-// GetSpannerAuthToolInfo returns statements and param of my-auth-tool for spanner-sql kind
-func GetSpannerAuthToolInfo(tableName string) (string, string, string, map[string]any) {
-	create_statement := fmt.Sprintf("CREATE TABLE %s (id INT64, name STRING(MAX), email STRING(MAX)) PRIMARY KEY (id)", tableName)
-	insert_statement := fmt.Sprintf("INSERT INTO %s (id, name, email) VALUES (1, @name1, @email1), (2, @name2, @email2)", tableName)
-	tool_statement := fmt.Sprintf("SELECT name FROM %s WHERE email = @email", tableName)
-	params := map[string]any{
-		"name1":  "Alice",
-		"email1": SERVICE_ACCOUNT_EMAIL,
-		"name2":  "Jane",
-		"email2": "janedoe@gmail.com",
-	}
-	return create_statement, insert_statement, tool_statement, params
-}
-
-// GetBigQueryParamToolInfo returns statements and param for my-param-tool for bigquery kind
-func GetBigQueryParamToolInfo(projectID, datasetID, tableName string) (string, string, string, []bigqueryapi.QueryParameter) {
-	createStatement := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s (id INT64, name STRING);`, tableName)
-	insertStatement := fmt.Sprintf(`
-		INSERT INTO %s (id, name) VALUES (?, ?), (?, ?), (?, ?);`, tableName)
-	toolStatement := fmt.Sprintf(`SELECT * FROM %s WHERE id = ? OR name = ? ORDER BY id;`, tableName)
-	params := []bigqueryapi.QueryParameter{
-		{Value: int64(1)}, {Value: "Alice"},
-		{Value: int64(2)}, {Value: "Jane"},
-		{Value: int64(3)}, {Value: "Sid"},
-	}
-	return createStatement, insertStatement, toolStatement, params
-}
-
-// GetBigQueryAuthToolInfo returns statements and param of my-auth-tool for bigquery kind
-func GetBigQueryAuthToolInfo(projectID, datasetID, tableName string) (string, string, string, []bigqueryapi.QueryParameter) {
-	createStatement := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s (id INT64, name STRING, email STRING)`, tableName)
-	insertStatement := fmt.Sprintf(`
-		INSERT INTO %s (id, name, email) VALUES (?, ?, ?), (?, ?, ?)`, tableName)
-	toolStatement := fmt.Sprintf(`
-		SELECT name FROM %s WHERE email = ?`, tableName)
-	params := []bigqueryapi.QueryParameter{
-		{Value: int64(1)}, {Value: "Alice"}, {Value: SERVICE_ACCOUNT_EMAIL},
-		{Value: int64(2)}, {Value: "Jane"}, {Value: "janedoe@gmail.com"},
-	}
-	return createStatement, insertStatement, toolStatement, params
 }
 
 func GetNonSpannerInvokeParamWant() (string, string) {

--- a/tests/common.go
+++ b/tests/common.go
@@ -302,3 +302,30 @@ func GetBigQueryAuthToolInfo(projectID, datasetID, tableName string) (string, st
 	}
 	return createStatement, insertStatement, toolStatement, params
 }
+
+func GetNonSpannerInvokeParamWant() (string, string) {
+	invokeParamWant := "[{\"id\":1,\"name\":\"Alice\"},{\"id\":3,\"name\":\"Sid\"}]"
+	mcpInvokeParamWant := `{"jsonrpc":"2.0","id":"my-param-tool","result":{"content":[{"type":"text","text":"{\"id\":1,\"name\":\"Alice\"}"},{"type":"text","text":"{\"id\":3,\"name\":\"Sid\"}"}]}}`
+	return invokeParamWant, mcpInvokeParamWant
+}
+
+// GetPostgresWants return the expected wants for postgres
+func GetPostgresWants() (string, string) {
+	select1Want := "[{\"?column?\":1}]"
+	failInvocationWant := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: ERROR: syntax error at or near \"SELEC\" (SQLSTATE 42601)"}],"isError":true}}`
+	return select1Want, failInvocationWant
+}
+
+// GetMssqlWants return the expected wants for mssql
+func GetMssqlWants() (string, string) {
+	select1Want := "[{\"\":1}]"
+	failInvocationWant := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: mssql: Could not find stored procedure 'SELEC'."}],"isError":true}}`
+	return select1Want, failInvocationWant
+}
+
+// GetMysqlWants return the expected wants for mysql
+func GetMysqlWants() (string, string) {
+	select1Want := "[{\"1\":1}]"
+	failInvocationWant := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SELEC 1' at line 1"}],"isError":true}}`
+	return select1Want, failInvocationWant
+}

--- a/tests/http/http_integration_test.go
+++ b/tests/http/http_integration_test.go
@@ -258,9 +258,11 @@ func TestHttpToolEndpoints(t *testing.T) {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)
 	}
-	select_1_want := `["Hello","World"]`
+
+	select1Want := `["Hello","World"]`
+	invokeParamWant, _ := tests.GetNonSpannerInvokeParamWant()
 	tests.RunToolGetTest(t)
-	tests.RunToolInvokeTest(t, select_1_want)
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
 	runAdvancedHTTPInvokeTest(t)
 }
 

--- a/tests/mssql/mssql_integration_test.go
+++ b/tests/mssql/mssql_integration_test.go
@@ -120,8 +120,8 @@ func TestMssqlToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: mssql: Could not find stored procedure 'SELEC'."}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want, failInvocationWant := tests.GetMssqlWants()
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }

--- a/tests/mysql/mysql_integration_test.go
+++ b/tests/mysql/mysql_integration_test.go
@@ -119,8 +119,8 @@ func TestMysqlToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"1\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SELEC 1' at line 1"}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want, failInvocationWant := tests.GetMysqlWants()
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }

--- a/tests/postgres/postgres_integration_test.go
+++ b/tests/postgres/postgres_integration_test.go
@@ -119,8 +119,8 @@ func TestPostgres(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"?column?\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: ERROR: syntax error at or near \"SELEC\" (SQLSTATE 42601)"}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want, failInvocationWant := tests.GetPostgresWants()
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/google/uuid"
 	"github.com/googleapis/genai-toolbox/tests"
 )
@@ -100,19 +101,19 @@ func TestSpannerToolEndpoints(t *testing.T) {
 	tableNameAuth := "auth_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
 
 	// set up data for param tool
-	create_statement1, insert_statement1, tool_statement1, params1 := tests.GetSpannerParamToolInfo(tableNameParam)
+	create_statement1, insert_statement1, tool_statement1, params1 := getSpannerParamToolInfo(tableNameParam)
 	dbString := fmt.Sprintf(
 		"projects/%s/instances/%s/databases/%s",
 		SPANNER_PROJECT,
 		SPANNER_INSTANCE,
 		SPANNER_DATABASE,
 	)
-	teardownTable1 := tests.SetupSpannerTable(t, ctx, adminClient, dataClient, create_statement1, insert_statement1, tableNameParam, dbString, params1)
+	teardownTable1 := setupSpannerTable(t, ctx, adminClient, dataClient, create_statement1, insert_statement1, tableNameParam, dbString, params1)
 	defer teardownTable1(t)
 
 	// set up data for auth tool
-	create_statement2, insert_statement2, tool_statement2, params2 := tests.GetSpannerAuthToolInfo(tableNameAuth)
-	teardownTable2 := tests.SetupSpannerTable(t, ctx, adminClient, dataClient, create_statement2, insert_statement2, tableNameAuth, dbString, params2)
+	create_statement2, insert_statement2, tool_statement2, params2 := getSpannerAuthToolInfo(tableNameAuth)
+	teardownTable2 := setupSpannerTable(t, ctx, adminClient, dataClient, create_statement2, insert_statement2, tableNameAuth, dbString, params2)
 	defer teardownTable2(t)
 
 	// Write config into a file and pass it to command
@@ -141,4 +142,75 @@ func TestSpannerToolEndpoints(t *testing.T) {
 
 	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
 	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
+}
+
+// getSpannerToolInfo returns statements and param for my-param-tool for spanner-sql kind
+func getSpannerParamToolInfo(tableName string) (string, string, string, map[string]any) {
+	create_statement := fmt.Sprintf("CREATE TABLE %s (id INT64, name STRING(MAX)) PRIMARY KEY (id)", tableName)
+	insert_statement := fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, @name1), (2, @name2), (3, @name3)", tableName)
+	tool_statement := fmt.Sprintf("SELECT * FROM %s WHERE id = @id OR name = @name", tableName)
+	params := map[string]any{"name1": "Alice", "name2": "Jane", "name3": "Sid"}
+	return create_statement, insert_statement, tool_statement, params
+}
+
+// getSpannerAuthToolInfo returns statements and param of my-auth-tool for spanner-sql kind
+func getSpannerAuthToolInfo(tableName string) (string, string, string, map[string]any) {
+	create_statement := fmt.Sprintf("CREATE TABLE %s (id INT64, name STRING(MAX), email STRING(MAX)) PRIMARY KEY (id)", tableName)
+	insert_statement := fmt.Sprintf("INSERT INTO %s (id, name, email) VALUES (1, @name1, @email1), (2, @name2, @email2)", tableName)
+	tool_statement := fmt.Sprintf("SELECT name FROM %s WHERE email = @email", tableName)
+	params := map[string]any{
+		"name1":  "Alice",
+		"email1": tests.SERVICE_ACCOUNT_EMAIL,
+		"name2":  "Jane",
+		"email2": "janedoe@gmail.com",
+	}
+	return create_statement, insert_statement, tool_statement, params
+}
+
+// setupSpannerTable creates and inserts data into a table of tool
+// compatible with spanner-sql tool
+func setupSpannerTable(t *testing.T, ctx context.Context, adminClient *database.DatabaseAdminClient, dataClient *spanner.Client, create_statement, insert_statement, tableName, dbString string, params map[string]any) func(*testing.T) {
+
+	// Create table
+	op, err := adminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+		Database:   dbString,
+		Statements: []string{create_statement},
+	})
+	if err != nil {
+		t.Fatalf("unable to start create table operation %s: %s", tableName, err)
+	}
+	err = op.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unable to create test table %s: %s", tableName, err)
+	}
+
+	// Insert test data
+	_, err = dataClient.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL:    insert_statement,
+			Params: params,
+		}
+		_, err := txn.Update(ctx, stmt)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("unable to insert test data: %s", err)
+	}
+
+	return func(t *testing.T) {
+		// tear down test
+		op, err = adminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+			Database:   dbString,
+			Statements: []string{fmt.Sprintf("DROP TABLE %s", tableName)},
+		})
+		if err != nil {
+			t.Errorf("unable to start drop table operation: %s", err)
+			return
+		}
+
+		err = op.Wait(ctx)
+		if err != nil {
+			t.Errorf("Teardown failed: %s", err)
+		}
+	}
 }

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -134,9 +134,11 @@ func TestSpannerToolEndpoints(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"\":\"1\"}]"
-	fail_invocation_want := `"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute client: unable to parse row: spanner: code = "InvalidArgument", desc = "Syntax error: Unexpected identifier \"SELEC\" [at 1:1]\nSELEC 1;\n^"`
+	select1Want := "[{\"\":\"1\"}]"
+	invokeParamWant := "[{\"id\":\"1\",\"name\":\"Alice\"},{\"id\":\"3\",\"name\":\"Sid\"}]"
+	mcpInvokeParamWant := `{"jsonrpc":"2.0","id":"my-param-tool","result":{"content":[{"type":"text","text":"{\"id\":\"1\",\"name\":\"Alice\"}"},{"type":"text","text":"{\"id\":\"3\",\"name\":\"Sid\"}"}]}}`
+	failInvocationWant := `"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute client: unable to parse row: spanner: code = \"InvalidArgument\", desc = \"Syntax error: Unexpected identifier \\\\\\\"SELEC\\\\\\\" [at 1:1]\\\\nSELEC 1;\\\\n^\"`
 
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }

--- a/tests/sqlite/sqlite_integration_test.go
+++ b/tests/sqlite/sqlite_integration_test.go
@@ -142,8 +142,9 @@ func TestSQLiteToolEndpoint(t *testing.T) {
 
 	tests.RunToolGetTest(t)
 
-	select_1_want := "[{\"1\":1}]"
-	fail_invocation_want := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: SQL logic error: near SELEC: syntax error (1)"}],"isError":true}}`
-	tests.RunToolInvokeTest(t, select_1_want)
-	tests.RunMCPToolCallMethod(t, fail_invocation_want)
+	select1Want := "[{\"1\":1}]"
+	failInvocationWant := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: SQL logic error: near \"SELEC\": syntax error (1)"}],"isError":true}}`
+	invokeParamWant, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
+	tests.RunToolInvokeTest(t, select1Want, invokeParamWant)
+	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)
 }


### PR DESCRIPTION
Remove cleaning `\\` or `\` in `got` and `want` strings of test cases. This is to prevent future the need to manually clean strings before comparing. This also allows us to be aware of the amount of backspace to prevent accidental escaping in src code.

Update integration test that is affected. This includes moving the `want` of test cases for `my-param-tool` invocation to each sources since spanner have a different format (return id as strings instead of int).