### PR TITLE
chore: remove automated label sync

### DIFF
--- a/.github/label-sync.yml
+++ b/.github/label-sync.yml
@@ -1,0 +1,2 @@
+---
+ignored: true


### PR DESCRIPTION
Remove label sync that don't apply for this repo.