### PR TITLE
chore(http): update invocation results formatting

### DIFF
--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -299,7 +299,18 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 		return nil, fmt.Errorf("unexpected status code: %d, response body: %s", resp.StatusCode, string(body))
 	}
 
-	return []any{string(body)}, nil
+	var data any
+	if err = json.Unmarshal(body, &data); err != nil {
+		// if unable to unmarshal data, return result as string.
+		return []any{string(body)}, nil
+	}
+	// if data is a list, return as is.
+	dataList, ok := data.([]any)
+	if ok {
+		return dataList, nil
+	}
+	// if data is not a list (e.g. single map), return data in list.
+	return []any{data}, nil
 }
 
 func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {

--- a/tests/http/http_integration_test.go
+++ b/tests/http/http_integration_test.go
@@ -118,7 +118,7 @@ func handleTool1(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if name == "Alice" {
-		response := `{"id":1,"name":"Alice"},{"id":3,"name":"Sid"}`
+		response := `[{"id":1,"name":"Alice"},{"id":3,"name":"Sid"}]`
 		_, err := w.Write([]byte(response))
 		if err != nil {
 			http.Error(w, "Failed to write response", http.StatusInternalServerError)
@@ -258,7 +258,7 @@ func TestHttpToolEndpoints(t *testing.T) {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)
 	}
-	select_1_want := `["[\"Hello\",\"World\"]\n"]`
+	select_1_want := `["Hello","World"]`
 	tests.RunToolGetTest(t)
 	tests.RunToolInvokeTest(t, select_1_want)
 	runAdvancedHTTPInvokeTest(t)
@@ -280,7 +280,7 @@ func runAdvancedHTTPInvokeTest(t *testing.T) {
 			api:           "http://127.0.0.1:5000/api/tool/my-advanced-tool/invoke",
 			requestHeader: map[string]string{},
 			requestBody:   bytes.NewBuffer([]byte(`{"animalArray": ["rabbit", "ostrich", "whale"], "id": 3, "country": "US", "X-Other-Header": "test"}`)),
-			want:          `["[\"Hello\",\"World\"]\n"]`,
+			want:          `["Hello","World"]`,
 			isErr:         false,
 		},
 		{


### PR DESCRIPTION
Update http tools `Invoke` method.
* use `json.Unmarshal` for response body that are either list or json map. This will allow us to return lists as is (e.g. `[{map}]` instead of having to nest it in an additional list (e.g. `[]any{ [{map}] }`)
* for response body that are strings or fail to unmarshal, return it as is.