### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/docs/en/how-to/deploy_gke.md
+++ b/docs/en/how-to/deploy_gke.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploy to Kubernetes"
+title: "Deploy to Kubernetes (GKE)"
 type: docs
 weight: 2
 description: >

--- a/docs/en/how-to/deploy_helm.md
+++ b/docs/en/how-to/deploy_helm.md
@@ -1,0 +1,69 @@
+---
+title: "Deploy to Kubernetes (Helm)"
+type: docs
+weight: 2
+description: >
+  How to set up and configure Toolbox to deploy on any Kubernetes cluster using Helm.
+---
+
+# Overview
+
+This chart installs the [MCP Toolbox for Databases](https://googleapis.github.io/genai-toolbox/getting-started/introduction/) (formerly "Gen AI Toolbox for Databases") on [Kubernetes](https://kubernetes.io) via the [Helm](https://helm.sh) package manager.
+
+- [Before you begin](#before-you-begin)
+- [Deploy to Kubernetes](#deploy-to-kubernetes)
+- [Configuration](#configuration)
+
+## Before you begin
+
+Assuming you have a running Kubernetes cluster,
+
+1. Verify if you have `kubectl` installed (version: 1.25+):
+    ```bash
+    kubectl version --client
+    ```
+
+2. Verify if you have `helm` installed (version: 3.1+):
+    ```bash
+    helm version --client
+    ```
+
+## Deploy to Kubernetes
+
+1. Add the Helm repository:
+
+    ```bash
+    helm repo add genai-toolbox https://googleapis.github.io/genai-toolbox
+    helm repo update
+    ```
+
+2. Review and Customize Values
+
+    Download the default values file and edit as needed:
+
+    ```bash
+    helm show values genai-toolbox/genai-toolbox > values.yaml
+    # Edit values.yaml to configure your sources, tools, auth, etc.
+    ```
+
+3. Install the Chart
+
+    ```bash
+    helm install toolbox genai-toolbox/genai-toolbox -f values.yaml --namespace toolbox --create-namespace
+    ```
+
+4. Check that your pods are running:
+
+    ```bash
+    kubectl get pods -n toolbox
+    ```
+
+5. To remove the deployment:
+
+    ```bash
+    helm uninstall toolbox -n toolbox
+    ```
+
+## Configuration
+
+See the GitHub [values.yaml](https://github.com/googleapis/genai-toolbox/blob/main/helm/genai-toolbox/values.yaml) for a list of configurable parameters and their default values.

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,66 @@
+# MCP Toolbox for Databases Helm Chart
+
+This chart installs the [MCP Toolbox for Databases](https://googleapis.github.io/genai-toolbox/getting-started/introduction/) (formerly "Gen AI Toolbox for Databases") on [Kubernetes](https://kubernetes.io) via the [Helm](https://helm.sh) package manager.
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Configuration](#configuration)
+
+## Prerequisites
+
+- Kubernetes 1.22+
+- kubectl 1.22+ 
+- Helm 3.8.0+ 
+
+## Installation
+
+```bash
+# Customize values if necessary
+helm show values genai-toolbox/genai-toolbox > values.yaml
+
+# Add the Helm repository
+helm repo add genai-toolbox https://googleapis.github.io/genai-toolbox
+helm repo update
+helm search repo genai-toolbox
+
+# Install the chart
+helm install toolbox genai-toolbox/genai-toolbox -f values.yaml --namespace toolbox
+
+# Uninstall the chart
+helm uninstall toolbox --namespace toolbox
+```
+
+## Configuration
+
+The following table lists the configurable parameters and their default values.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+| Parameter | Description | Default |
+|---|---|---|
+| `autoscaling.enabled` | Enable Horizontal Pod Autoscaler | false |
+| `autoscaling.maxReplicas` | Maximum number of pods for autoscaling | 5 |
+| `autoscaling.minReplicas` | Minimum number of pods for autoscaling | 1 |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization for autoscaling | 80 |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization for autoscaling | (unset) |
+| `config` | Toolbox YAML config for auth, sources, tools, toolsets | (see values.yaml) |
+| `image.name` | Image name | toolbox |
+| `image.pullPolicy` | Image pull policy | IfNotPresent |
+| `image.repository` | Container image repository | us-central1-docker.pkg.dev/database-toolbox/toolbox/ |
+| `image.tag` | Image tag | latest |
+| `imagePullSecrets` | List of image pull secrets | [] |
+| `livenessProbe` | Liveness probe configuration for the container | `{ httpGet: { path: /, port: 5000 }, initialDelaySeconds: 10, periodSeconds: 60 }` |
+| `namespace` | Kubernetes namespace to deploy into | toolbox |
+| `options.address` | Address to bind the app | 0.0.0.0 |
+| `options.log_level` | Log level | INFO |
+| `options.logging_format` | Logging format | standard |
+| `options.port` | App port | 5000 |
+| `options.telemetry_gcp` | Enable GCP telemetry | false |
+| `options.telemetry_otlp` | OTLP endpoint URL | "" |
+| `options.telemetry_service_name` | Service name for telemetry | toolbox |
+| `readinessProbe` | Readiness probe configuration for the container | `{ httpGet: { path: /, port: 5000 }, initialDelaySeconds: 5, periodSeconds: 5 }` |
+| `replicas` | Number of replicas to deploy | 1 |
+| `resources` | CPU/memory resource requests and limits | `{ requests: { cpu: 100m, memory: 128Mi }, limits: { cpu: 1, memory: 512Mi } }` |
+| `securityContext` | Container-level security context | `{ runAsNonRoot: true, runAsUser: 1000, allowPrivilegeEscalation: false, capabilities: { drop: [ALL] } }` |
+| `serviceAccount.create` | Whether to create a ServiceAccount | true |
+| `serviceAccount.name` | Name of the ServiceAccount | genai-toolbox |

--- a/helm/genai-toolbox/.helmignore
+++ b/helm/genai-toolbox/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/genai-toolbox/Chart.yaml
+++ b/helm/genai-toolbox/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: genai-toolbox
+description: MCP Toolbox for Databases (formerly "Gen AI Toolbox for Databases")
+type: application
+version: 0.1.0
+appVersion: "v0.4.0"
+icon: https://github.com/googleapis/genai-toolbox/blob/main/logo.png

--- a/helm/genai-toolbox/templates/NOTES.txt
+++ b/helm/genai-toolbox/templates/NOTES.txt
@@ -1,0 +1,9 @@
+You've successfully installed the MCP Toolbox for Databases (formerly `genai-toolbox`)!
+
+To get started, you can access the toolbox at http://localhost:{{ .Values.options.port }}/mcp/sse by running the following commands:
+
+```bash
+kubectl port-forward svc/{{ .Values.name }} {{ .Values.options.port }}:{{ .Values.options.port }} -n {{ .Values.namespace }}
+
+npx @modelcontextprotocol/inspector http://localhost:{{ .Values.options.port }}/mcp/sse
+```

--- a/helm/genai-toolbox/templates/deployment.yaml
+++ b/helm/genai-toolbox/templates/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+        - name: {{ .Values.name }}
+          image: "{{ .Values.image.repository }}{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          args: [
+            "--address",
+            "{{ .Values.options.address }}",
+            "--port",
+            "{{ .Values.options.port }}",
+            "--log-level",
+            "{{ .Values.options.log_level }}",
+            "--logging-format",
+            "{{ .Values.options.logging_format }}",
+
+            {{- if .Values.options.telemetry_gcp }}
+            "--telemetry-gcp",
+            "{{ .Values.options.telemetry_gcp }}",
+            {{- end }}
+
+            {{- if .Values.options.telemetry_otlp }}
+            "--telemetry-otlp",
+            "{{ .Values.options.telemetry_otlp }}",
+            {{- end }}
+
+            {{- if .Values.options.telemetry_service_name }}
+            "--telemetry-service-name",
+            "{{ .Values.options.telemetry_service_name }}",
+            {{- end }}
+          ]
+          ports:
+            - containerPort: {{ .Values.options.port }}
+          volumeMounts:
+            - name: {{ .Values.name }}-config
+              mountPath: "/app/tools.yaml"
+              subPath: tools.yaml
+              readOnly: true
+
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: {{ .Values.name }}-config
+          secret:
+            secretName: {{ .Values.name }}-config
+            items:
+              - key: tools.yaml
+                path: tools.yaml
+
+      {{- if .Values.podDistribution.antiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.podDistribution.antiAffinity.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: {{ .Values.name }}
+                topologyKey: kubernetes.io/hostname
+      {{- end }}
+
+      {{- if .Values.podDistribution.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.podDistribution.topologySpread.maxSkew }}
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: {{ .Values.podDistribution.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.name }}
+        - maxSkew: {{ .Values.podDistribution.topologySpread.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.podDistribution.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.name }}
+      {{- end }}

--- a/helm/genai-toolbox/templates/hpa.yaml
+++ b/helm/genai-toolbox/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage | default 80 }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage | default 80 }}
+{{- end }}
+{{- end }}

--- a/helm/genai-toolbox/templates/secret.yaml
+++ b/helm/genai-toolbox/templates/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.name }}-config
+  namespace: {{ .Values.namespace }}
+type: Opaque
+stringData:
+  tools.yaml: |
+    {{ .Values.config | nindent 6 }}

--- a/helm/genai-toolbox/templates/service.yaml
+++ b/helm/genai-toolbox/templates/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.name }}
+  ports:
+    - port: {{ .Values.options.port }}
+      targetPort: {{ .Values.options.port }}

--- a/helm/genai-toolbox/templates/serviceaccount.yaml
+++ b/helm/genai-toolbox/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/helm/genai-toolbox/values.yaml
+++ b/helm/genai-toolbox/values.yaml
@@ -1,0 +1,101 @@
+replicas: 1
+namespace: toolbox
+name: toolbox
+
+options:
+  address: "0.0.0.0"
+  port: 5000
+  log_level: "INFO"
+  logging_format: "standard"
+  telemetry_gcp: false
+  telemetry_otlp: ""
+  telemetry_service_name: "toolbox"
+
+config: |
+  authServices:
+  #   my_auth_app_1:
+  #     kind: google
+  #     clientId: ${YOUR_CLIENT_ID_1}
+  #   my_auth_app_2:
+  #     kind: microsoft
+  #     clientId: ${YOUR_CLIENT_ID_2}
+  #   tenantId: ${YOUR_TENANT_ID_2}
+  
+  sources:
+  #   my-sqlite-db:
+  #     kind: sqlite
+  #     database: ":memory:"
+
+  tools:
+  #   get-user:
+  #     kind: sqlite-sql
+  #     source: my-sqlite-db
+  #     description: Get a user by id.
+  #     parameters:
+  #       - name: id
+  #         type: integer
+  #         description: User ID
+  #     statement: SELECT * FROM users WHERE id = ?
+
+  toolsets:
+  #   my_toolset:
+  #     - get-user
+
+serviceAccount:
+  create: true
+  name: genai-toolbox
+  annotations: {}
+    # iam.gke.io/gcp-service-account: "genai-toolbox@toolbox.iam.gserviceaccount.com"
+    # eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/genai-toolbox"
+
+imagePullSecrets: []
+image:
+  repository: us-central1-docker.pkg.dev/database-toolbox/toolbox/
+  name: toolbox
+  tag: latest
+  pullPolicy: IfNotPresent
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: 5000
+  initialDelaySeconds: 10
+  periodSeconds: 60
+readinessProbe:
+  httpGet:
+    path: /
+    port: 5000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+podDistribution:
+  antiAffinity:
+    enabled: false
+    weight: 100
+  topologySpread:
+    enabled: false
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION
# Overview

This PR adds a Helm chart to the MCP toolbox, related to https://github.com/googleapis/genai-toolbox/issues/486. It's under a top-level directory named `helm/`, containing the chart & configurable `values.yaml`. To name a few,
- HPA auto-scaling & pod topology constraint / [anti-]affinity
- Parity with CLI options
- Auto service account creation with annotations (for auth)

It also includes an update to the GKE documentation, with a new page for Helm installation. Currently working on testing it fully & docs, though wanted to raise it here as a draft.