### PR TITLE
docs: Address connection issues in local quickstart with clearer guidance

### DIFF
--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -37,13 +37,13 @@ access by our agent, and create a database user for Toolbox to connect with.
     Here, `postgres` denotes the default postgres superuser.
 
     {{< notice info >}}
-#### Having trouble connecting?
+### Having trouble connecting?
 
 * **Password Prompt:** If you are prompted for a password for the `postgres` user and do not know it (or a blank password doesn't work), your PostgreSQL installation might require a password or a different authentication method.
 * **`FATAL: role "postgres" does not exist`:** This error means the default `postgres` superuser role isn't available under that name on your system.
 * **`Connection refused`:** Ensure your PostgreSQL server is actually running. You can typically check with `sudo systemctl status postgresql` and start it with `sudo systemctl start postgresql` on Linux systems.
 
-#### Common Solution
+### Common Solution
 
 For password issues or if the `postgres` role seems inaccessible directly, try switching to the `postgres` operating system user first. This user often has permission to connect without a password for local connections (this is called peer authentication).
 ```bash

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -37,13 +37,14 @@ access by our agent, and create a database user for Toolbox to connect with.
     Here, `postgres` denotes the default postgres superuser.
 
     {{< notice info >}}
-**Having trouble connecting?**
+#### Having trouble connecting?
 
 * **Password Prompt:** If you are prompted for a password for the `postgres` user and do not know it (or a blank password doesn't work), your PostgreSQL installation might require a password or a different authentication method.
 * **`FATAL: role "postgres" does not exist`:** This error means the default `postgres` superuser role isn't available under that name on your system.
 * **`Connection refused`:** Ensure your PostgreSQL server is actually running. You can typically check with `sudo systemctl status postgresql` and start it with `sudo systemctl start postgresql` on Linux systems.
 
-**Common Solution:**
+#### Common Solution
+
 For password issues or if the `postgres` role seems inaccessible directly, try switching to the `postgres` operating system user first. This user often has permission to connect without a password for local connections (this is called peer authentication).
 ```bash
 sudo -i -u postgres

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -50,7 +50,7 @@ access by our agent, and create a database user for Toolbox to connect with.
 For password issues or if the `postgres` role seems inaccessible directly, try switching to the `postgres` operating system user first. This user often has permission to connect without a password for local connections (this is called peer authentication).
 ```bash
 sudo -i -u postgres
-psql
+psql -h 127.0.0.1
 ```
 Once you are in the `psql` shell using this method, you can proceed with the database creation steps below. Afterwards, type `\q` to exit `psql`, and then `exit` to return to your normal user shell.
 

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -37,13 +37,15 @@ access by our agent, and create a database user for Toolbox to connect with.
     Here, `postgres` denotes the default postgres superuser.
 
     {{< notice info >}}
-### Having trouble connecting?
+#### **Having trouble connecting?**
 
 * **Password Prompt:** If you are prompted for a password for the `postgres` user and do not know it (or a blank password doesn't work), your PostgreSQL installation might require a password or a different authentication method.
 * **`FATAL: role "postgres" does not exist`:** This error means the default `postgres` superuser role isn't available under that name on your system.
 * **`Connection refused`:** Ensure your PostgreSQL server is actually running. You can typically check with `sudo systemctl status postgresql` and start it with `sudo systemctl start postgresql` on Linux systems.
 
-### Common Solution
+<br/>
+
+#### **Common Solution**
 
 For password issues or if the `postgres` role seems inaccessible directly, try switching to the `postgres` operating system user first. This user often has permission to connect without a password for local connections (this is called peer authentication).
 ```bash
@@ -53,12 +55,6 @@ psql
 Once you are in the `psql` shell using this method, you can proceed with the database creation steps below. Afterwards, type `\q` to exit `psql`, and then `exit` to return to your normal user shell.
 
 If desired, once connected to `psql` as the `postgres` OS user, you can set a password for the `postgres` *database* user using: `ALTER USER postgres WITH PASSWORD 'your_chosen_password';`. This would allow direct connection with `-U postgres` and a password next time.
-    {{< /notice >}}
-
-    {{< notice tip >}}
-To enable direct password login for `postgres` next time, set a password in `psql`:
-`ALTER USER postgres WITH PASSWORD 'your_chosen_password';`
-
     {{< /notice >}}
 
 1. Create a new database and a new user:

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -36,6 +36,30 @@ access by our agent, and create a database user for Toolbox to connect with.
 
     Here, `postgres` denotes the default postgres superuser.
 
+    {{< notice info >}}
+**Having trouble connecting?**
+
+* **Password Prompt:** If you are prompted for a password for the `postgres` user and do not know it (or a blank password doesn't work), your PostgreSQL installation might require a password or a different authentication method.
+* **`FATAL: role "postgres" does not exist`:** This error means the default `postgres` superuser role isn't available under that name on your system.
+* **`Connection refused`:** Ensure your PostgreSQL server is actually running. You can typically check with `sudo systemctl status postgresql` and start it with `sudo systemctl start postgresql` on Linux systems.
+
+**Common Solution:**
+For password issues or if the `postgres` role seems inaccessible directly, try switching to the `postgres` operating system user first. This user often has permission to connect without a password for local connections (this is called peer authentication).
+```bash
+sudo -i -u postgres
+psql
+```
+Once you are in the `psql` shell using this method, you can proceed with the database creation steps below. Afterwards, type `\q` to exit `psql`, and then `exit` to return to your normal user shell.
+
+If desired, once connected to `psql` as the `postgres` OS user, you can set a password for the `postgres` *database* user using: `ALTER USER postgres WITH PASSWORD 'your_chosen_password';`. This would allow direct connection with `-U postgres` and a password next time.
+    {{< /notice >}}
+
+    {{< notice tip >}}
+To enable direct password login for `postgres` next time, set a password in `psql`:
+`ALTER USER postgres WITH PASSWORD 'your_chosen_password';`
+
+    {{< /notice >}}
+
 1. Create a new database and a new user:
 
     {{< notice tip >}}
@@ -57,6 +81,7 @@ access by our agent, and create a database user for Toolbox to connect with.
     ```bash
     \q
     ```
+    (If you used `sudo -i -u postgres` and then `psql`, remember you might also need to type `exit` after `\q` to leave the `postgres` user's shell session.)
 
 1. Connect to your database with your new user:
 


### PR DESCRIPTION
Fix for #517 

This PR improves the Local Quickstart guide by adding troubleshooting advice for common PostgreSQL connection issues in [step 1](https://googleapis.github.io/genai-toolbox/getting-started/local_quickstart/#step-1-set-up-your-database).

This reduces friction and improves the setup experience for users following the local quickstart by addressing feedback in #517 regarding difficulties in the initial database connection step.

### Problem
Users faced issues like password prompts or "role 'postgres' does not exist" errors when trying to connect to PostgreSQL with `psql -h 127.0.0.1 -U postgres`.

### Solution
This PR adds a notice that provides solutions for common connection errors, including guidance on using `sudo -i -u postgres` for peer authentication.