### PR TITLE
Replace 'product' with 'solution'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ documentation](https://googleapis.github.io/genai-toolbox/).
 
 
 > [!NOTE] 
-> This product was originally named “Gen AI Toolbox for Databases” as
+> This solution was originally named “Gen AI Toolbox for Databases” as
 > its initial development predated MCP, but was renamed to align with recently
 > added MCP compatibility. 
 

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -11,7 +11,7 @@ such as connection pooling, authentication, and more.
 
 
 {{< notice note >}} 
-This product was originally named “Gen AI Toolbox for
+This solution was originally named “Gen AI Toolbox for
 Databases” as its initial development predated MCP, but was renamed to align
 with recently added MCP compatibility. 
 {{< /notice >}}


### PR DESCRIPTION
To better conform to Google Cloud terminology, Toolbox should be referred to as a "solution" rather than a "product".