### PR TITLE
docs: use `--tools-file` over deprecated `--tools_file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ go install github.com/googleapis/genai-toolbox@v0.4.0
 execute `toolbox` to start the server:
 
 ```sh
-./toolbox --tools_file "tools.yaml"
+./toolbox --tools-file "tools.yaml"
 ```
 
 You can use `toolbox help` for a full list of flags! To stop the server, send a
@@ -214,7 +214,7 @@ For more detailed instructions on using the Toolbox Llamaindex SDK, see the
 ## Configuration
 
 The primary way to configure Toolbox is through the `tools.yaml` file. If you
-have multiple files, you can tell toolbox which to load with the `--tools_file
+have multiple files, you can tell toolbox which to load with the `--tools-file
 tools.yaml` flag.
 
 You can find more detailed reference documentation to all resource types in the

--- a/docs/en/concepts/telemetry/index.md
+++ b/docs/en/concepts/telemetry/index.md
@@ -28,7 +28,7 @@ The following flags can be used to customize Toolbox logging:
 
 __Example:__
 ```bash
-./toolbox --tools_file "tools.yaml" --log-level warn --logging-format json
+./toolbox --tools-file "tools.yaml" --log-level warn --logging-format json
 ```
 
 ### Level

--- a/docs/en/getting-started/colab_quickstart.ipynb
+++ b/docs/en/getting-started/colab_quickstart.ipynb
@@ -394,7 +394,7 @@
       "outputs": [],
       "source": [
         "# Start a toolbox server\n",
-        "! nohup {TOOLBOX_BINARY_PATH} --tools_file {TOOLS_FILE_PATH} -p {SERVER_PORT} > toolbox.log 2>&1 &"
+        "! nohup {TOOLBOX_BINARY_PATH} --tools-file {TOOLS_FILE_PATH} -p {SERVER_PORT} > toolbox.log 2>&1 &"
       ]
     },
     {

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -92,7 +92,7 @@ go install github.com/googleapis/genai-toolbox@v0.4.0
 execute `toolbox` to start the server:
 
 ```sh
-./toolbox --tools_file "tools.yaml"
+./toolbox --tools-file "tools.yaml"
 ```
 
 You can use `toolbox help` for a full list of flags! To stop the server, send a

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -215,7 +215,7 @@ In this section, we will download Toolbox, configure our tools in a
 1. Run the Toolbox server, pointing to the `tools.yaml` file created earlier:
 
     ```bash
-    ./toolbox --tools_file "tools.yaml"
+    ./toolbox --tools-file "tools.yaml"
     ```
 
 ## Step 3: Connect your agent to Toolbox

--- a/docs/en/getting-started/mcp_quickstart/_index.md
+++ b/docs/en/getting-started/mcp_quickstart/_index.md
@@ -204,7 +204,7 @@ In this section, we will download Toolbox, configure our tools in a
 1. Run the Toolbox server, pointing to the `tools.yaml` file created earlier:
 
     ```bash
-    ./toolbox --tools_file "tools.yaml"
+    ./toolbox --tools-file "tools.yaml"
     ```
 
 ## Step 3: Connect to MCP Inspector

--- a/docs/en/how-to/deploy_docker.md
+++ b/docs/en/how-to/deploy_docker.md
@@ -35,7 +35,7 @@ services:
       - "5000:5000"
     volumes:
       - ./config:/config
-    command: [ "toolbox", "--tools_file", "/config/tools.yaml", "--address", "0.0.0.0"]
+    command: [ "toolbox", "--tools-file", "/config/tools.yaml", "--address", "0.0.0.0"]
     depends_on:
       db:
         condition: service_healthy

--- a/docs/en/how-to/deploy_toolbox.md
+++ b/docs/en/how-to/deploy_toolbox.md
@@ -119,7 +119,7 @@ section.
         --service-account toolbox-identity \
         --region us-central1 \
         --set-secrets "/app/tools.yaml=tools:latest" \
-        --args="--tools_file=/app/tools.yaml","--address=0.0.0.0","--port=8080"
+        --args="--tools-file=/app/tools.yaml","--address=0.0.0.0","--port=8080"
         # --allow-unauthenticated # https://cloud.google.com/run/docs/authenticating/public#gcloud
     ```
 
@@ -131,7 +131,7 @@ section.
         --service-account toolbox-identity \
         --region us-central1 \
         --set-secrets "/app/tools.yaml=tools:latest" \
-        --args="--tools_file=/app/tools.yaml","--address=0.0.0.0","--port=8080" \
+        --args="--tools-file=/app/tools.yaml","--address=0.0.0.0","--port=8080" \
         # TODO(dev): update the following to match your VPC if necessary 
         --network default \
         --subnet default

--- a/docs/en/samples/bigquery/colab_quickstart_bigquery.ipynb
+++ b/docs/en/samples/bigquery/colab_quickstart_bigquery.ipynb
@@ -373,7 +373,7 @@
       "outputs": [],
       "source": [
         "# Start a toolbox server\n",
-        "! nohup {TOOLBOX_BINARY_PATH} --tools_file {TOOLS_FILE_PATH} -p {SERVER_PORT} > toolbox.log 2>&1 &"
+        "! nohup {TOOLBOX_BINARY_PATH} --tools-file {TOOLS_FILE_PATH} -p {SERVER_PORT} > toolbox.log 2>&1 &"
       ]
     },
     {

--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -230,7 +230,7 @@ In this section, we will download Toolbox, configure our tools in a `tools.yaml`
 1.  Run the Toolbox server, pointing to the `tools.yaml` file created earlier:
 
     ```bash
-    ./toolbox --tools_file "tools.yaml"
+    ./toolbox --tools-file "tools.yaml"
     ```
 
 ## Step 3: Connect your agent to Toolbox

--- a/docs/en/samples/bigquery/mcp_quickstart/_index.md
+++ b/docs/en/samples/bigquery/mcp_quickstart/_index.md
@@ -175,7 +175,7 @@ In this section, we will download Toolbox, configure our tools in a `tools.yaml`
 1. Run the Toolbox server, pointing to the `tools.yaml` file created earlier:
 
     ```bash
-    ./toolbox --tools_file "tools.yaml"
+    ./toolbox --tools-file "tools.yaml"
     ```
 
 ## Step 3: Connect to MCP Inspector


### PR DESCRIPTION
Updating docs to use the `--tools-file` flag over the now deprecated `--tools_file`.

The new flag was added as of `v0.3.0` in #384 

This change reduces confusion as current usage in docs results in
following message on startup of Toolbox server:

```sh
Flag --tools_file has been deprecated, please use --tools-file instead
```

Fixes #514 