### PR TITLE
docs: update wording and typos for AuthServices

### DIFF
--- a/docs/en/resources/authServices/_index.md
+++ b/docs/en/resources/authServices/_index.md
@@ -11,7 +11,7 @@ can primarily be used by [Tools](../tools) in two different ways:
 
 - [**Authorized Invocation**][auth-invoke] is when a tool
   is validated by the auth service before the call can be invoked. Toolbox
-  will reject an calls that fail to validate or have an invalid token.
+  will reject any calls that fail to validate or have an invalid token.
 - [**Authenticated Parameters**][auth-params] replace the value of a parameter
   with a field from an [OIDC][openid-claims] claim. Toolbox will automatically
   resolve the ID token provided by the client and replace the parameter in the

--- a/docs/en/resources/authServices/_index.md
+++ b/docs/en/resources/authServices/_index.md
@@ -51,7 +51,7 @@ configuration for each tool that should use it:
 
 - **Authorized Invocations** for authorizing a tool call, [use the
   `authRequired` field in a tool config][auth-invoke]
-- **Authenticated Parameters** for using the value from a ODIC claim, [use the
+- **Authenticated Parameters** for using the value from a OIDC claim, [use the
   `authServices` field in a parameter config][auth-params]
 
 ## Specifying ID Tokens from Clients

--- a/docs/en/resources/authServices/_index.md
+++ b/docs/en/resources/authServices/_index.md
@@ -50,7 +50,7 @@ After you've configured an `authService` you'll, need to reference it in the
 configuration for each tool that should use it:
 
 - **Authorized Invocations** for authorizing a tool call, [use the
-  `requiredAuth` field in a tool config][auth-invoke]
+  `authRequired` field in a tool config][auth-invoke]
 - **Authenticated Parameters** for using the value from a ODIC claim, [use the
   `authServices` field in a parameter config][auth-params]
 

--- a/docs/en/resources/authServices/_index.md
+++ b/docs/en/resources/authServices/_index.md
@@ -10,8 +10,8 @@ AuthServices represent services that handle authentication and authorization. It
 can primarily be used by [Tools](../tools) in two different ways:
 
 - [**Authorized Invocation**][auth-invoke] is when a tool
-  to be validate by the auth service before the call can be invoked. Toolbox
-  will rejected an calls that fail to validate or have an invalid token.
+  is validated by the auth service before the call can be invoked. Toolbox
+  will reject an calls that fail to validate or have an invalid token.
 - [**Authenticated Parameters**][auth-params] replace the value of a parameter
   with a field from an [OIDC][openid-claims] claim. Toolbox will automatically
   resolve the ID token provided by the client and replace the parameter in the

--- a/docs/en/resources/tools/_index.md
+++ b/docs/en/resources/tools/_index.md
@@ -93,7 +93,7 @@ in the list using the items field:
 
 ```yaml
     parameters:
-      - name: preffered_airlines
+      - name: preferred_airlines
         type: array
         description: A list of airline, ordered by preference. 
         items:


### PR DESCRIPTION
The wording for `Authorized Invocations` reads a bit funny and has a typo.

Updating it to make a bit more sense and fixing a couple other typos around auth.