### PR TITLE
docs: use env-based project in LlamaIndex Quickstart

### DIFF
--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -369,7 +369,7 @@ async def main():
     # TODO(developer): replace this with another model if needed
     llm = GoogleGenAI(
         model="gemini-1.5-pro",
-        vertexai_config={"project": "project-id", "location": "us-central1"},
+        vertexai_config={"location": "us-central1"},
     )
     # llm = GoogleGenAI(
     #     api_key=os.getenv("GOOGLE_API_KEY"),


### PR DESCRIPTION
The `GoogleGenAI` llm directly takes in the `Project ID` [set up](https://googleapis.github.io/genai-toolbox/samples/bigquery/local_quickstart/#before-you-begin) in the quickstart. 

Partially fixes https://github.com/googleapis/genai-toolbox/issues/518