### PR TITLE
docs: update colab badge link

### DIFF
--- a/docs/en/getting-started/colab_quickstart.ipynb
+++ b/docs/en/getting-started/colab_quickstart.ipynb
@@ -29,7 +29,7 @@
         "id": "5sZ7_HCYJm4y"
       },
       "source": [
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/googleapis/genai-toolbox/tree/main/docs/en/getting-started/colab_quickstart.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/googleapis/genai-toolbox/blob/main/docs/en/getting-started/colab_quickstart.ipynb)"
       ]
     },
     {


### PR DESCRIPTION
The "Open in Colab" badge on the getting started quickstart links to the GitHub file and not the colab.

Updating it to properly point at https://colab.research.google.com/github/googleapis/genai-toolbox/blob/main/docs/en/getting-started/colab_quickstart.ipynb