### PR TITLE
fix: prevent tool calls through MCP when auth is required

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -346,6 +346,13 @@ func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		}
 		s.logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
 
+		if !tool.Authorized([]string{}) {
+			err = fmt.Errorf("unauthorized Tool call: `authRequired` is set for the target Tool")
+			s.logger.DebugContext(ctx, err.Error())
+			res = newJSONRPCError(baseMessage.Id, mcp.INVALID_REQUEST, err.Error(), nil)
+			break
+		}
+
 		result := mcp.ToolCall(ctx, tool, params)
 		res = mcp.JSONRPCResponse{
 			Jsonrpc: mcp.JSONRPC_VERSION,

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -505,6 +505,23 @@ func RunMCPToolCallMethod(t *testing.T, invoke_param_want, fail_invocation_want 
 			want: `{"jsonrpc":"2.0","id":"invoke-insufficient-parameter","error":{"code":-32602,"message":"provided parameters were invalid: parameter \"name\" is required"}}`,
 		},
 		{
+			name:          "MCP Invoke my-auth-required-tool",
+			api:           "http://127.0.0.1:5000/mcp",
+			requestHeader: map[string]string{},
+			requestBody: mcp.JSONRPCRequest{
+				Jsonrpc: "2.0",
+				Id:      "invoke my-auth-required-tool",
+				Request: mcp.Request{
+					Method: "tools/call",
+				},
+				Params: map[string]any{
+					"name":      "my-auth-required-tool",
+					"arguments": map[string]any{},
+				},
+			},
+			want: "{\"jsonrpc\":\"2.0\",\"id\":\"invoke my-auth-required-tool\",\"error\":{\"code\":-32600,\"message\":\"unauthorized Tool call: `authRequired` is set for the target Tool\"}}",
+		},
+		{
 			name:          "MCP Invoke my-fail-tool",
 			api:           "http://127.0.0.1:5000/mcp",
 			requestHeader: map[string]string{},


### PR DESCRIPTION
MCP does not support the `authRequired` feature. Disallow all MCP Tool call to Tools with `authRequired` set.

Fixes: https://github.com/googleapis/genai-toolbox/issues/543