### PR TITLE
docs: update typo in export_telemetry.md

### DIFF
--- a/docs/en/how-to/export_telemetry.md
+++ b/docs/en/how-to/export_telemetry.md
@@ -56,7 +56,7 @@ service:
       exporters: ["googlecloud"]
 ```
 
-## Running the Connector
+## Running the Collector
 
 There are a couple of steps to run and use a Collector.
 


### PR DESCRIPTION
[`Running the Connector`](https://googleapis.github.io/genai-toolbox/how-to/export_telemetry/#running-the-connector) header should be `Running the Collector`.

Changing "Connector" --> "Collector".