### PR TITLE
chore: update typo

### DIFF
--- a/docs/en/how-to/connect_tools_using_mcp.md
+++ b/docs/en/how-to/connect_tools_using_mcp.md
@@ -13,7 +13,7 @@ Databases][toolbox] to expose your developer assistant tools to a Cloud SQL for
 Postgres or AlloyDB for Postgres instance:
 
 * [Cursor][cursor]
-* [Windsurf][windsurf] (Codium)
+* [Windsurf][windsurf] (Codeium)
 * [Visual Studio Code][vscode] (Copilot)
 * [Cline][cline]  (VS Code extension)
 * [Claude desktop][claudedesktop]


### PR DESCRIPTION
Windsurf was formerly https://codeium.com/

updating typo `codium` --> `codeium`