### PR TITLE
fix: reinitialize required slice if nil

### DIFF
--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -112,6 +112,9 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		bodyMcpManifest.Required,
 		headerMcpManifest.Required,
 	)
+	if concatRequiredManifest == nil {
+		concatRequiredManifest = []string{}
+	}
 
 	// Concatenate parameters for MCP `properties` field
 	concatPropertiesManifest := make(map[string]tools.ParameterMcpManifest)


### PR DESCRIPTION
`slices.Concat` will return `nil` if arrays are all empty instead of an empty slice `[]`. Fix this by setting `[]` if it's `nil`.

Fixes #564