### PR TITLE
fix(server/mcp): add /messages endpoint for mcp

### DIFF
--- a/docs/en/how-to/connect_via_mcp.md
+++ b/docs/en/how-to/connect_via_mcp.md
@@ -54,9 +54,9 @@ Add the following configuration to your MCP client configuration:
 
 If you would like to connect to a specific toolset, replace `url` with `"http://127.0.0.1:5000/mcp/{toolset_name}/sse"`.
 {{% /tab %}} {{% tab header="HTTP POST" lang="en" %}}
-Connect to Toolbox HTTP POST via `http://127.0.0.1:5000/mcp`.
+Connect to Toolbox HTTP POST via `http://127.0.0.1:5000/mcp/messages`.
 
-If you would like to connect to a specific toolset, connect via `http://127.0.0.1:5000/mcp/{toolset_name}`.
+If you would like to connect to a specific toolset, connect via `http://127.0.0.1:5000/mcp/{toolset_name}/messages`.
 {{% /tab %}} {{< /tabpane >}}
 
 ### Using the MCP Inspector with Toolbox

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -74,10 +74,12 @@ func mcpRouter(s *Server) (chi.Router, error) {
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
 	r.Get("/sse", func(w http.ResponseWriter, r *http.Request) { sseHandler(s, w, r) })
+	r.Post("/messages", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
 	r.Post("/", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
 
 	r.Route("/{toolsetName}", func(r chi.Router) {
 		r.Get("/sse", func(w http.ResponseWriter, r *http.Request) { sseHandler(s, w, r) })
+		r.Post("/messages", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
 		r.Post("/", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
 	})
 

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -75,12 +75,10 @@ func mcpRouter(s *Server) (chi.Router, error) {
 
 	r.Get("/sse", func(w http.ResponseWriter, r *http.Request) { sseHandler(s, w, r) })
 	r.Post("/messages", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
-	r.Post("/", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
 
 	r.Route("/{toolsetName}", func(r chi.Router) {
 		r.Get("/sse", func(w http.ResponseWriter, r *http.Request) { sseHandler(s, w, r) })
 		r.Post("/messages", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
-		r.Post("/", func(w http.ResponseWriter, r *http.Request) { mcpHandler(s, w, r) })
 	})
 
 	return r, nil
@@ -152,7 +150,7 @@ func sseHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	if toolsetName != "" {
 		toolsetURL = fmt.Sprintf("/%s", toolsetName)
 	}
-	messageEndpoint := fmt.Sprintf("%s://%s/mcp%s?sessionId=%s", proto, r.Host, toolsetURL, sessionId)
+	messageEndpoint := fmt.Sprintf("%s://%s/mcp%s/messages?sessionId=%s", proto, r.Host, toolsetURL, sessionId)
 	s.logger.DebugContext(ctx, fmt.Sprintf("sending endpoint event: %s", messageEndpoint))
 	fmt.Fprintf(w, "event: endpoint\ndata: %s\n\n", messageEndpoint)
 	flusher.Flush()

--- a/tests/alloydbainl/alloydb_ai_nl_integration_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_integration_test.go
@@ -339,7 +339,7 @@ func runAiNlMCPToolCallMethod(t *testing.T) {
 	}{
 		{
 			name:          "MCP Invoke my-simple-tool",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",
@@ -358,7 +358,7 @@ func runAiNlMCPToolCallMethod(t *testing.T) {
 		},
 		{
 			name:          "MCP Invoke invalid tool",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",
@@ -375,7 +375,7 @@ func runAiNlMCPToolCallMethod(t *testing.T) {
 		},
 		{
 			name:          "MCP Invoke my-auth-tool without parameters",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -435,7 +435,7 @@ func RunMCPToolCallMethod(t *testing.T, invoke_param_want, fail_invocation_want 
 	}{
 		{
 			name:          "MCP Invoke my-param-tool",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",
@@ -455,7 +455,7 @@ func RunMCPToolCallMethod(t *testing.T, invoke_param_want, fail_invocation_want 
 		},
 		{
 			name:          "MCP Invoke invalid tool",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",
@@ -472,7 +472,7 @@ func RunMCPToolCallMethod(t *testing.T, invoke_param_want, fail_invocation_want 
 		},
 		{
 			name:          "MCP Invoke my-param-tool without parameters",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",
@@ -489,7 +489,7 @@ func RunMCPToolCallMethod(t *testing.T, invoke_param_want, fail_invocation_want 
 		},
 		{
 			name:          "MCP Invoke my-param-tool with insufficient parameters",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",
@@ -506,7 +506,7 @@ func RunMCPToolCallMethod(t *testing.T, invoke_param_want, fail_invocation_want 
 		},
 		{
 			name:          "MCP Invoke my-auth-required-tool",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",
@@ -523,7 +523,7 @@ func RunMCPToolCallMethod(t *testing.T, invoke_param_want, fail_invocation_want 
 		},
 		{
 			name:          "MCP Invoke my-fail-tool",
-			api:           "http://127.0.0.1:5000/mcp",
+			api:           "http://127.0.0.1:5000/mcp/messages",
 			requestHeader: map[string]string{},
 			requestBody: mcp.JSONRPCRequest{
 				Jsonrpc: "2.0",


### PR DESCRIPTION
Inspector shows `MCP error -32600: toolset does not exist`  

MCP Typescript SDK made this change to forcefully implement /messages in endpoint: https://github.com/modelcontextprotocol/typescript-sdk/commit/5a25fe3a6ca5f6a159c249a63fe2f358cda8a9c5

To prevent from maintaining a variations of endpoints, this PR also removed the existing `/` endpoint. Since `sse` will return with new endpoint that includes `/messages`, existing sse users WILL NOT be impacted with this update.

Related bug that are submitted to modelcontextprotocol: https://github.com/modelcontextprotocol/typescript-sdk/issues/501