### PR TITLE
chore: implement mcp manager

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -86,7 +86,7 @@ func TestToolsetEndpoint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, body, err := runRequest(ts, http.MethodGet, fmt.Sprintf("/toolset/%s", tc.toolsetName), nil)
+			resp, body, err := runRequest(ts, http.MethodGet, fmt.Sprintf("/toolset/%s", tc.toolsetName), nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error during request: %s", err)
 			}
@@ -174,7 +174,7 @@ func TestToolGetEndpoint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, body, err := runRequest(ts, http.MethodGet, fmt.Sprintf("/tool/%s", tc.toolName), nil)
+			resp, body, err := runRequest(ts, http.MethodGet, fmt.Sprintf("/tool/%s", tc.toolName), nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error during request: %s", err)
 			}
@@ -251,7 +251,7 @@ func TestToolInvokeEndpoint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, body, err := runRequest(ts, http.MethodPost, fmt.Sprintf("/tool/%s/invoke", tc.toolName), tc.requestBody)
+			resp, body, err := runRequest(ts, http.MethodPost, fmt.Sprintf("/tool/%s/invoke", tc.toolName), tc.requestBody, nil)
 			if err != nil {
 				t.Fatalf("unexpected error during request: %s", err)
 			}

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -153,12 +153,12 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 		t.Fatalf("unable to create custom metrics: %s", err)
 	}
 
-	sseManager := &sseManager{
+	mcpM := &mcpManager{
 		mu:          sync.RWMutex{},
-		sseSessions: make(map[string]*sseSession),
+		mcpSessions: make(map[string]*mcpSession),
 	}
 
-	server := Server{version: fakeVersionString, logger: testLogger, instrumentation: instrumentation, sseManager: sseManager, tools: tools, toolsets: toolsets}
+	server := Server{version: fakeVersionString, logger: testLogger, instrumentation: instrumentation, mcpManager: mcpM, tools: tools, toolsets: toolsets}
 	var r chi.Router
 	switch router {
 	case "api":
@@ -197,12 +197,17 @@ func runServer(r chi.Router, tls bool) *httptest.Server {
 	return ts
 }
 
-func runRequest(ts *httptest.Server, method, path string, body io.Reader) (*http.Response, []byte, error) {
+func runRequest(ts *httptest.Server, method, path string, body io.Reader, header map[string]string) (*http.Response, []byte, error) {
 	req, err := http.NewRequest(method, ts.URL+path, body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create request: %w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
+	for k, v := range header {
+		req.Header.Set(k, v)
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to send request: %w", err)

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -35,35 +35,44 @@ import (
 )
 
 type sseSession struct {
-	sessionId  string
 	writer     http.ResponseWriter
 	flusher    http.Flusher
 	done       chan struct{}
 	eventQueue chan string
 }
 
-// sseManager manages and control access to sse sessions
-type sseManager struct {
-	mu          sync.RWMutex
-	sseSessions map[string]*sseSession
+// mcpSession represents each mcp session connected through initialize method.
+type mcpSession struct {
+	// protocol version negotiated during initialization
+	protocol string
+	// only available for connections that uses sse
+	sseSession *sseSession
+	// represent if the the initialization is successful
+	initialized bool
 }
 
-func (m *sseManager) get(id string) (*sseSession, bool) {
+// mcpManager manages and control access to mcp sesisons
+type mcpManager struct {
+	mu          sync.RWMutex
+	mcpSessions map[string]*mcpSession
+}
+
+func (m *mcpManager) get(id string) (*mcpSession, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	session, ok := m.sseSessions[id]
+	session, ok := m.mcpSessions[id]
 	return session, ok
 }
 
-func (m *sseManager) add(id string, session *sseSession) {
+func (m *mcpManager) add(id string, session *mcpSession) {
 	m.mu.Lock()
-	m.sseSessions[id] = session
+	m.mcpSessions[id] = session
 	m.mu.Unlock()
 }
 
-func (m *sseManager) remove(id string) {
+func (m *mcpManager) remove(id string) {
 	m.mu.Lock()
-	delete(m.sseSessions, id)
+	delete(m.mcpSessions, id)
 	m.mu.Unlock()
 }
 
@@ -128,14 +137,18 @@ func sseHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		_ = render.Render(w, r, newErrResponse(err, http.StatusInternalServerError))
 	}
 	session := &sseSession{
-		sessionId:  sessionId,
 		writer:     w,
 		flusher:    flusher,
 		done:       make(chan struct{}),
 		eventQueue: make(chan string, 100),
 	}
-	s.sseManager.add(sessionId, session)
-	defer s.sseManager.remove(sessionId)
+	mcpSession := &mcpSession{
+		protocol:    "", // not yet negotiated protocol version
+		sseSession:  session,
+		initialized: false,
+	}
+	s.mcpManager.add(sessionId, mcpSession)
+	defer s.mcpManager.remove(sessionId)
 
 	// https scheme formatting if (forwarded) request is a TLS request
 	proto := r.Header.Get("X-Forwarded-Proto")
@@ -181,8 +194,30 @@ func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	ctx, span := s.instrumentation.Tracer.Start(ctx, "toolbox/server/mcp")
 	r = r.WithContext(ctx)
 
-	// TODO: this will be updated to retrieve from request header when update mcpManager
-	protocolVersion := "2024-11-05"
+	var mcpSess *mcpSession
+	var sessionId, protocolVersion string
+
+	// session Id could present in either the header or the URL link (via sse)
+	sessionId = r.Header.Get("Mcp-Session-Id")
+	if sessionId == "" {
+		// if session id is not in header, try checking the url query
+		sessionId = r.URL.Query().Get("sessionId")
+	}
+	// sessionId is received during sse or initialization
+	if sessionId != "" {
+		var ok bool
+		mcpSess, ok = s.mcpManager.get(sessionId)
+		if !ok {
+			s.logger.DebugContext(ctx, "mcp session not available")
+		}
+		protocolVersion = mcpSess.protocol
+	} else {
+		sessionId = uuid.New().String()
+		mcpSess = &mcpSession{}
+		s.mcpManager.add(sessionId, mcpSess)
+	}
+	// TODO: If client send HTTP DELETE to MCP Endpoint with the `MCP-Session-Id`
+	// header, remove the session from mcpManager.
 
 	toolsetName := chi.URLParam(r, "toolsetName")
 	s.logger.DebugContext(ctx, fmt.Sprintf("toolset name: %s", toolsetName))
@@ -203,7 +238,8 @@ func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		s.instrumentation.McpPost.Add(
 			r.Context(),
 			1,
-			metric.WithAttributes(attribute.String("toolbox.sse.sessionId", id)),
+			metric.WithAttributes(attribute.String("toolbox.sse.messageId", id)),
+			metric.WithAttributes(attribute.String("toolbox.sse.sessionId", sessionId)),
 			metric.WithAttributes(attribute.String("toolbox.tool.name", toolName)),
 			metric.WithAttributes(attribute.String("toolbox.toolset.name", toolsetName)),
 			metric.WithAttributes(attribute.String("toolbox.method", method)),
@@ -252,7 +288,10 @@ func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 
 	// Check if message is a notification
 	if baseMessage.Id == nil {
-		mcp.NotificationHandler(ctx, body)
+		mcp.NotificationHandler(ctx, baseMessage.Method, body)
+		if baseMessage.Method == mcputil.INITIALIZE_NOTIFICATIONS {
+			mcpSess.initialized = true
+		}
 		// Notifications do not expect a response
 		// Toolbox doesn't do anything with notifications yet
 		w.WriteHeader(http.StatusAccepted)
@@ -265,9 +304,16 @@ func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	var res any
 	switch method {
 	case mcputil.INITIALIZE:
-		// TODO: will replace with protocol version once update mcpManager
-		res, _ = mcp.InitializeResponse(ctx, baseMessage.Id, body, s.version)
+		res, protocolVersion = mcp.InitializeResponse(ctx, baseMessage.Id, body, s.version)
+		mcpSess.protocol = protocolVersion
+		w.Header().Add("Mcp-Session-Id", sessionId)
 	default:
+		if !mcpSess.initialized {
+			err = fmt.Errorf("session is not initialized")
+			s.logger.DebugContext(ctx, err.Error())
+			res = mcputil.NewError(baseMessage.Id, mcputil.INVALID_REQUEST, err.Error(), nil)
+			break
+		}
 		toolset, ok := s.toolsets[toolsetName]
 		if !ok {
 			err = fmt.Errorf("toolset does not exist")
@@ -279,17 +325,16 @@ func mcpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// retrieve sse session
-	sessionId := r.URL.Query().Get("sessionId")
-	session, ok := s.sseManager.get(sessionId)
-	if !ok {
+	sseSess := mcpSess.sseSession
+	if sseSess == nil {
 		s.logger.DebugContext(ctx, "sse session not available")
 	} else {
 		// queue sse event
 		eventData, _ := json.Marshal(res)
 		select {
-		case session.eventQueue <- fmt.Sprintf("event: message\ndata: %s\n\n", eventData):
+		case sseSess.eventQueue <- fmt.Sprintf("event: message\ndata: %s\n\n", eventData):
 			s.logger.DebugContext(ctx, "event queue successful")
-		case <-session.done:
+		case <-sseSess.done:
 			s.logger.DebugContext(ctx, "session is close")
 		default:
 			s.logger.DebugContext(ctx, "unable to add to event queue")

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -81,7 +81,7 @@ func InitializeResponse(ctx context.Context, id mcputil.RequestId, body []byte, 
 
 // NotificationHandler process notifications request. It MUST NOT send a response.
 // Currently Toolbox does not process any notifications.
-func NotificationHandler(ctx context.Context, body []byte) {
+func NotificationHandler(ctx context.Context, method string, body []byte) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {

--- a/internal/server/mcp/util/lifecycle.go
+++ b/internal/server/mcp/util/lifecycle.go
@@ -18,7 +18,8 @@ const (
 	// SERVER_NAME is the server name used in Implementation.
 	SERVER_NAME = "Toolbox"
 	// methods that are supported
-	INITIALIZE = "initialize"
+	INITIALIZE               = "initialize"
+	INITIALIZE_NOTIFICATIONS = "notifications/initialized"
 )
 
 /* Initialization */

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -58,7 +58,7 @@ var tool3InputSchema = map[string]any{
 	"required": []any{"my_array"},
 }
 
-func TestMcpEndpoint(t *testing.T) {
+func TestMcpEndpointWithoutInitialized(t *testing.T) {
 	mockTools := []MockTool{tool1, tool2, tool3}
 	toolsMap, toolsets := setUpResources(t, mockTools)
 	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets)
@@ -74,27 +74,178 @@ func TestMcpEndpoint(t *testing.T) {
 		want  map[string]any
 	}{
 		{
-			name: "initialize",
+			name: "tools/list",
 			url:  "/",
 			body: util.JSONRPCRequest{
 				Jsonrpc: jsonrpcVersion,
-				Id:      "mcp-initialize",
+				Id:      "tools-list",
 				Request: util.Request{
-					Method: "initialize",
+					Method: "tools/list",
+				},
+			},
+			isErr: true,
+			want: map[string]any{
+				"jsonrpc": jsonrpcVersion,
+				"id":      "tools-list",
+				"error": map[string]any{
+					"code":    -32600.0,
+					"message": "session is not initialized",
+				},
+			},
+		},
+		{
+			name:  "missing method",
+			url:   "/",
+			isErr: true,
+			body: util.JSONRPCRequest{
+				Jsonrpc: jsonrpcVersion,
+				Id:      "missing-method",
+				Request: util.Request{},
+			},
+			want: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "missing-method",
+				"error": map[string]any{
+					"code":    -32601.0,
+					"message": "method not found",
+				},
+			},
+		},
+		{
+			name:  "invalid jsonrpc version",
+			url:   "/",
+			isErr: true,
+			body: util.JSONRPCRequest{
+				Jsonrpc: "1.0",
+				Id:      "invalid-jsonrpc-version",
+				Request: util.Request{
+					Method: "foo",
 				},
 			},
 			want: map[string]any{
 				"jsonrpc": "2.0",
-				"id":      "mcp-initialize",
-				"result": map[string]any{
-					"protocolVersion": protocolVersion,
-					"capabilities": map[string]any{
-						"tools": map[string]any{"listChanged": false},
-					},
-					"serverInfo": map[string]any{"name": serverName, "version": fakeVersionString},
+				"id":      "invalid-jsonrpc-version",
+				"error": map[string]any{
+					"code":    -32600.0,
+					"message": "invalid json-rpc version",
 				},
 			},
 		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqMarshal, err := json.Marshal(tc.body)
+			if err != nil {
+				t.Fatalf("unexpected error during marshaling of body")
+			}
+
+			resp, body, err := runRequest(ts, http.MethodPost, tc.url, bytes.NewBuffer(reqMarshal), nil)
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+
+			// Notifications don't expect a response.
+			if tc.want != nil {
+				if contentType := resp.Header.Get("Content-type"); contentType != "application/json" {
+					t.Fatalf("unexpected content-type header: want %s, got %s", "application/json", contentType)
+				}
+
+				var got map[string]any
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("unexpected error unmarshalling body: %s", err)
+				}
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("unexpected response: got %+v, want %+v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func runInitializeLifecycle(t *testing.T, ts *httptest.Server) string {
+	initializeRequestBody := map[string]any{
+		"jsonrpc": jsonrpcVersion,
+		"id":      "mcp-initialize",
+		"method":  "initialize",
+	}
+	initializeWant := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "mcp-initialize",
+		"result": map[string]any{
+			"protocolVersion": protocolVersion,
+			"capabilities": map[string]any{
+				"tools": map[string]any{"listChanged": false},
+			},
+			"serverInfo": map[string]any{"name": serverName, "version": fakeVersionString},
+		},
+	}
+	reqMarshal, err := json.Marshal(initializeRequestBody)
+	if err != nil {
+		t.Fatalf("unexpected error during marshaling of body")
+	}
+
+	resp, body, err := runRequest(ts, http.MethodPost, "/", bytes.NewBuffer(reqMarshal), nil)
+	if err != nil {
+		t.Fatalf("unexpected error during request: %s", err)
+	}
+
+	if contentType := resp.Header.Get("Content-type"); contentType != "application/json" {
+		t.Fatalf("unexpected content-type header: want %s, got %s", "application/json", contentType)
+	}
+
+	sessionId := resp.Header.Get("Mcp-Session-Id")
+	if sessionId == "" {
+		t.Fatalf("missing Mcp-Session-Id from header")
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unexpected error unmarshalling body: %s", err)
+	}
+	if !reflect.DeepEqual(got, initializeWant) {
+		t.Fatalf("unexpected response: got %+v, want %+v", got, initializeWant)
+	}
+
+	header := map[string]string{
+		"Mcp-Session-Id": sessionId,
+	}
+
+	initializeNotificationBody := map[string]any{
+		"jsonrpc": jsonrpcVersion,
+		"method":  "notifications/initialized",
+	}
+	notiMarshal, err := json.Marshal(initializeNotificationBody)
+	if err != nil {
+		t.Fatalf("unexpected error during marshaling of notifications body")
+	}
+
+	_, _, err = runRequest(ts, http.MethodPost, "/", bytes.NewBuffer(notiMarshal), header)
+	if err != nil {
+		t.Fatalf("unexpected error during request: %s", err)
+	}
+	return sessionId
+}
+
+func TestMcpEndpoint(t *testing.T) {
+	mockTools := []MockTool{tool1, tool2, tool3}
+	toolsMap, toolsets := setUpResources(t, mockTools)
+	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets)
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	sessionId := runInitializeLifecycle(t, ts)
+	header := map[string]string{
+		"Mcp-Session-Id": sessionId,
+	}
+
+	testCases := []struct {
+		name  string
+		url   string
+		isErr bool
+		body  util.JSONRPCRequest
+		want  map[string]any
+	}{
 		{
 			name: "basic notification",
 			url:  "/",
@@ -246,7 +397,7 @@ func TestMcpEndpoint(t *testing.T) {
 				t.Fatalf("unexpected error during marshaling of body")
 			}
 
-			resp, body, err := runRequest(ts, http.MethodPost, tc.url, bytes.NewBuffer(reqMarshal))
+			resp, body, err := runRequest(ts, http.MethodPost, tc.url, bytes.NewBuffer(reqMarshal), header)
 			if err != nil {
 				t.Fatalf("unexpected error during request: %s", err)
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,7 +43,7 @@ type Server struct {
 	root            chi.Router
 	logger          log.Logger
 	instrumentation *Instrumentation
-	sseManager      *sseManager
+	mcpManager      *mcpManager
 
 	sources      map[string]sources.Source
 	authServices map[string]auth.AuthService
@@ -205,9 +205,9 @@ func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, er
 	addr := net.JoinHostPort(cfg.Address, strconv.Itoa(cfg.Port))
 	srv := &http.Server{Addr: addr, Handler: r}
 
-	sseManager := &sseManager{
+	mcpM := &mcpManager{
 		mu:          sync.RWMutex{},
-		sseSessions: make(map[string]*sseSession),
+		mcpSessions: make(map[string]*mcpSession),
 	}
 
 	s := &Server{
@@ -216,7 +216,7 @@ func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, er
 		root:            r,
 		logger:          l,
 		instrumentation: instrumentation,
-		sseManager:      sseManager,
+		mcpManager:      mcpM,
 
 		sources:      sourcesMap,
 		authServices: authServicesMap,


### PR DESCRIPTION
Implement mcp manager to manage the different session. This is needed to keep track of the protocol version of each sessions.