### PR TITLE
feat: add a new flag to indicate if stdio is supported

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,7 @@ func NewCommand(opts ...Option) *Command {
 	flags.BoolVar(&cmd.cfg.TelemetryGCP, "telemetry-gcp", false, "Enable exporting directly to Google Cloud Monitoring.")
 	flags.StringVar(&cmd.cfg.TelemetryOTLP, "telemetry-otlp", "", "Enable exporting using OpenTelemetry Protocol (OTLP) to the specified endpoint (e.g. 'http://127.0.0.1:4318')")
 	flags.StringVar(&cmd.cfg.TelemetryServiceName, "telemetry-service-name", "toolbox", "Sets the value of the service.name resource attribute for telemetry data.")
+	flags.BoolVar(&cmd.cfg.Stdio, "stdio", false, "Support MCP stdio transport protocol.")
 
 	// wrap RunE command so that we have access to original Command object
 	cmd.RunE = func(*cobra.Command, []string) error { return run(cmd) }
@@ -163,7 +164,25 @@ func parseToolsFile(ctx context.Context, raw []byte) (ToolsFile, error) {
 	return toolsFile, nil
 }
 
+// updateLogLevel checks if Toolbox have to update the existing log level set by users.
+// stdio doesn't support "debug" and "info" logs.
+func updateLogLevel(stdio bool, logLevel string) bool {
+	if stdio {
+		switch strings.ToUpper(logLevel) {
+		case log.Debug, log.Info:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
 func run(cmd *Command) error {
+	if updateLogLevel(cmd.cfg.Stdio, cmd.cfg.LogLevel.String()) {
+		cmd.cfg.LogLevel = server.StringLevel(log.Warn)
+	}
+
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,7 +115,7 @@ func NewCommand(opts ...Option) *Command {
 	flags.BoolVar(&cmd.cfg.TelemetryGCP, "telemetry-gcp", false, "Enable exporting directly to Google Cloud Monitoring.")
 	flags.StringVar(&cmd.cfg.TelemetryOTLP, "telemetry-otlp", "", "Enable exporting using OpenTelemetry Protocol (OTLP) to the specified endpoint (e.g. 'http://127.0.0.1:4318')")
 	flags.StringVar(&cmd.cfg.TelemetryServiceName, "telemetry-service-name", "toolbox", "Sets the value of the service.name resource attribute for telemetry data.")
-	flags.BoolVar(&cmd.cfg.Stdio, "stdio", false, "Support MCP stdio transport protocol.")
+	flags.BoolVar(&cmd.cfg.Stdio, "stdio", false, "Listens via MCP STDIO instead of acting as a remote HTTP server.")
 
 	// wrap RunE command so that we have access to original Command object
 	cmd.RunE = func(*cobra.Command, []string) error { return run(cmd) }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -163,6 +163,13 @@ func TestServerConfigFlags(t *testing.T) {
 				TelemetryServiceName: "toolbox-custom",
 			}),
 		},
+		{
+			desc: "stdio",
+			args: []string{"--stdio"},
+			want: withDefaults(server.ServerConfig{
+				Stdio: true,
+			}),
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -857,4 +864,52 @@ func TestEnvVarReplacement(t *testing.T) {
 		})
 	}
 
+}
+
+func TestUpdateLogLevel(t *testing.T) {
+	tcs := []struct {
+		desc     string
+		stdio    bool
+		logLevel string
+		want     bool
+	}{
+		{
+			desc:     "no stdio",
+			stdio:    false,
+			logLevel: "info",
+			want:     false,
+		},
+		{
+			desc:     "stdio with info log",
+			stdio:    true,
+			logLevel: "info",
+			want:     true,
+		},
+		{
+			desc:     "stdio with debug log",
+			stdio:    true,
+			logLevel: "debug",
+			want:     true,
+		},
+		{
+			desc:     "stdio with warn log",
+			stdio:    true,
+			logLevel: "warn",
+			want:     false,
+		},
+		{
+			desc:     "stdio with error log",
+			stdio:    true,
+			logLevel: "error",
+			want:     false,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := updateLogLevel(tc.stdio, tc.logLevel)
+			if got != tc.want {
+				t.Fatalf("incorrect indication to update log level: got %t, want %t", got, tc.want)
+			}
+		})
+	}
 }

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -81,6 +81,8 @@ type ServerConfig struct {
 	TelemetryOTLP string
 	// TelemetryServiceName defines the value of service.name resource attribute.
 	TelemetryServiceName string
+	// Stdio indicates if toolbox is running support for MCP studio transport protocol.
+	Stdio bool
 }
 
 type logFormat string

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -81,7 +81,7 @@ type ServerConfig struct {
 	TelemetryOTLP string
 	// TelemetryServiceName defines the value of service.name resource attribute.
 	TelemetryServiceName string
-	// Stdio indicates if toolbox is running support for MCP studio transport protocol.
+	// Stdio indicates if Toolbox is listening via MCP stdio.
 	Stdio bool
 }
 


### PR DESCRIPTION
Toolbox sends `debug` and `info` logs to `stdout`. However, in order to stupport stdio, Toolbox **should not** log messages to `stdout` as this will interfere with protocol operations. `stderr` are fine.

If `--stdio`, Toolbox will not send any `debug` and `info` logs, `warn` and `error` logs will still work as usual.