### PR TITLE
chore: migrate golangci-lint to v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           go mod tidy && git diff --exit-code
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest
           args: --timeout 3m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,16 +21,8 @@ linters:
     - staticcheck
     - unused
   exclusions:
-    generated: lax
     presets:
-      - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 issues:
   fix: true
 formatters:
@@ -43,9 +35,3 @@ formatters:
           replacement: any
         - pattern: a[b:len(a)]
           replacement: a[b:]
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,21 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 linters:
   enable:
     - errcheck
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
-linters-settings:
-  gofmt:
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
-      - pattern: 'a[b:len(a)]'
-        replacement: 'a[b:]'
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   fix: true
+formatters:
+  enable:
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+        - pattern: a[b:len(a)]
+          replacement: a[b:]
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -228,13 +228,13 @@ func run(cmd *Command) error {
 		}
 		cmd.logger = logger
 	default:
-		return fmt.Errorf("logging format invalid.")
+		return fmt.Errorf("logging format invalid")
 	}
 
 	ctx = util.WithLogger(ctx, cmd.logger)
 
 	// Set up OpenTelemetry
-	otelShutdown, err := telemetry.SetupOTel(ctx, cmd.Command.Version, cmd.cfg.TelemetryOTLP, cmd.cfg.TelemetryGCP, cmd.cfg.TelemetryServiceName)
+	otelShutdown, err := telemetry.SetupOTel(ctx, cmd.Version, cmd.cfg.TelemetryOTLP, cmd.cfg.TelemetryGCP, cmd.cfg.TelemetryServiceName)
 	if err != nil {
 		errMsg := fmt.Errorf("error setting up OpenTelemetry: %w", err)
 		cmd.logger.ErrorContext(ctx, errMsg.Error())
@@ -339,7 +339,7 @@ func run(cmd *Command) error {
 		cmd.logger.WarnContext(shutdownContext, "Shutting down gracefully...")
 		err := s.Shutdown(shutdownContext)
 		if err == context.DeadlineExceeded {
-			return fmt.Errorf("graceful shutdown timed out... forcing exit.")
+			return fmt.Errorf("graceful shutdown timed out... forcing exit")
 		}
 	}
 

--- a/internal/auth/google/google.go
+++ b/internal/auth/google/google.go
@@ -74,7 +74,7 @@ func (a AuthService) GetClaimsFromHeader(ctx context.Context, h http.Header) (ma
 	if token := h.Get(a.Name + "_token"); token != "" {
 		payload, err := idtoken.Validate(ctx, token, a.ClientID)
 		if err != nil {
-			return nil, fmt.Errorf("Google ID token verification failure: %w", err)
+			return nil, fmt.Errorf("Google ID token verification failure: %w", err) //nolint:staticcheck
 		}
 		return payload.Claims, nil
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -77,7 +77,7 @@ func toolsetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 
 	toolset, ok := s.toolsets[toolsetName]
 	if !ok {
-		err = fmt.Errorf("Toolset %q does not exist", toolsetName)
+		err = fmt.Errorf("toolset %q does not exist", toolsetName)
 		s.logger.DebugContext(ctx, err.Error())
 		_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
 		return

--- a/internal/sources/neo4j/neo4j.go
+++ b/internal/sources/neo4j/neo4j.go
@@ -44,12 +44,12 @@ func (r Config) SourceConfigKind() string {
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
 	driver, err := initNeo4jDriver(ctx, tracer, r.Uri, r.User, r.Password, r.Name)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create driver: %w", err)
+		return nil, fmt.Errorf("unable to create driver: %w", err)
 	}
 
 	err = driver.VerifyConnectivity(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect successfully: %w", err)
+		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 
 	if r.Database == "" {

--- a/internal/sources/postgres/postgres.go
+++ b/internal/sources/postgres/postgres.go
@@ -45,12 +45,12 @@ func (r Config) SourceConfigKind() string {
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
 	pool, err := initPostgresConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create pool: %w", err)
+		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
 
 	err = pool.Ping(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect successfully: %w", err)
+		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 
 	s := &Source{
@@ -85,7 +85,7 @@ func initPostgresConnectionPool(ctx context.Context, tracer trace.Tracer, name, 
 	i := fmt.Sprintf("postgres://%s:%s@%s:%s/%s", user, pass, host, port, dbname)
 	pool, err := pgxpool.New(ctx, i)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create connection pool: %w", err)
+		return nil, fmt.Errorf("unable to create connection pool: %w", err)
 	}
 
 	return pool, nil

--- a/internal/tools/parameters.go
+++ b/internal/tools/parameters.go
@@ -262,7 +262,7 @@ func parseParamFromDelayedUnmarshaler(ctx context.Context, u *util.DelayedUnmars
 		}
 		return a, nil
 	}
-	return nil, fmt.Errorf("%q is not valid type for a parameter!", t)
+	return nil, fmt.Errorf("%q is not valid type for a parameter", t)
 }
 
 func (ps Parameters) Manifest() []ParameterManifest {

--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -129,8 +129,8 @@ func TestAlloyDBPgToolEndpoints(t *testing.T) {
 	}
 
 	// create table name with UUID
-	tableNameParam := "param_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
-	tableNameAuth := "auth_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
+	tableNameParam := "param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableNameAuth := "auth_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 
 	// set up data for param tool
 	create_statement1, insert_statement1, tool_statement1, params1 := tests.GetPostgresSQLParamToolInfo(tableNameParam)

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -82,8 +82,8 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	}
 
 	// create table name with UUID
-	datasetName := fmt.Sprintf("temp_toolbox_test_%s", strings.Replace(uuid.New().String(), "-", "", -1))
-	tableName := fmt.Sprintf("param_table_%s", strings.Replace(uuid.New().String(), "-", "", -1))
+	datasetName := fmt.Sprintf("temp_toolbox_test_%s", strings.ReplaceAll(uuid.New().String(), "-", ""))
+	tableName := fmt.Sprintf("param_table_%s", strings.ReplaceAll(uuid.New().String(), "-", ""))
 	tableNameParam := fmt.Sprintf("`%s.%s.%s`",
 		BIGQUERY_PROJECT,
 		datasetName,
@@ -92,7 +92,7 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	tableNameAuth := fmt.Sprintf("`%s.%s.auth_table_%s`",
 		BIGQUERY_PROJECT,
 		datasetName,
-		strings.Replace(uuid.New().String(), "-", "", -1),
+		strings.ReplaceAll(uuid.New().String(), "-", ""),
 	)
 	// set up data for param tool
 	create_statement1, insert_statement1, tool_statement1, params1 := getBigQueryParamToolInfo(tableNameParam)

--- a/tests/bigtable/bigtable_integration_test.go
+++ b/tests/bigtable/bigtable_integration_test.go
@@ -67,8 +67,8 @@ func TestBigtableToolEndpoints(t *testing.T) {
 
 	var args []string
 
-	tableName := "param_table" + strings.Replace(uuid.New().String(), "-", "", -1)
-	tableNameAuth := "auth_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
+	tableName := "param_table" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableNameAuth := "auth_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 
 	columnFamilyName := "cf"
 	muts, rowKeys := getTestData(columnFamilyName)

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -114,8 +114,8 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 	}
 
 	// create table name with UUID
-	tableNameParam := "param_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
-	tableNameAuth := "auth_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
+	tableNameParam := "param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableNameAuth := "auth_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 
 	// set up data for param tool
 	create_statement1, insert_statement1, tool_statement1, params1 := tests.GetPostgresSQLParamToolInfo(tableNameParam)

--- a/tests/couchbase/couchbase_integration_test.go
+++ b/tests/couchbase/couchbase_integration_test.go
@@ -98,8 +98,8 @@ func TestCouchbaseToolEndpoints(t *testing.T) {
 	defer cluster.Close(nil)
 
 	// Create collection names with UUID
-	collectionNameParam := "param_" + strings.Replace(uuid.New().String(), "-", "", -1)
-	collectionNameAuth := "auth_" + strings.Replace(uuid.New().String(), "-", "", -1)
+	collectionNameParam := "param_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	collectionNameAuth := "auth_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 
 	// Set up data for param tool
 	paramToolStatement, params1 := getCouchbaseParamToolInfo(collectionNameParam)

--- a/tests/postgres/postgres_integration_test.go
+++ b/tests/postgres/postgres_integration_test.go
@@ -87,8 +87,8 @@ func TestPostgres(t *testing.T) {
 	}
 
 	// create table name with UUID
-	tableNameParam := "param_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
-	tableNameAuth := "auth_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
+	tableNameParam := "param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableNameAuth := "auth_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 
 	// set up data for param tool
 	create_statement1, insert_statement1, tool_statement1, params1 := tests.GetPostgresSQLParamToolInfo(tableNameParam)

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -254,25 +254,25 @@ func addSpannerExecuteSqlConfig(t *testing.T, config map[string]any) map[string]
 }
 
 func addSpannerReadOnlyConfig(t *testing.T, config map[string]any) map[string]any {
-    tools, ok := config["tools"].(map[string]any)
-    if !ok {
-        t.Fatalf("unable to get tools from config")
-    }
-    tools["access-schema-read-only"] = map[string]any{
-        "kind":        "spanner-sql",
-        "source":      "my-instance",
-        "description": "Tool to access information schema in read-only mode.",
-        "statement":   "SELECT schema_name FROM `INFORMATION_SCHEMA`.SCHEMATA WHERE schema_name='INFORMATION_SCHEMA';",
-        "readOnly":    true,
-    }
-    tools["access-schema"] = map[string]any{
-        "kind":        "spanner-sql",
-        "source":      "my-instance",
-        "description": "Tool to access information schema.",
-        "statement":   "SELECT schema_name FROM `INFORMATION_SCHEMA`.SCHEMATA WHERE schema_name='INFORMATION_SCHEMA';",
-    }
-    config["tools"] = tools
-    return config
+	tools, ok := config["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get tools from config")
+	}
+	tools["access-schema-read-only"] = map[string]any{
+		"kind":        "spanner-sql",
+		"source":      "my-instance",
+		"description": "Tool to access information schema in read-only mode.",
+		"statement":   "SELECT schema_name FROM `INFORMATION_SCHEMA`.SCHEMATA WHERE schema_name='INFORMATION_SCHEMA';",
+		"readOnly":    true,
+	}
+	tools["access-schema"] = map[string]any{
+		"kind":        "spanner-sql",
+		"source":      "my-instance",
+		"description": "Tool to access information schema.",
+		"statement":   "SELECT schema_name FROM `INFORMATION_SCHEMA`.SCHEMATA WHERE schema_name='INFORMATION_SCHEMA';",
+	}
+	config["tools"] = tools
+	return config
 }
 
 func runSpannerExecuteSqlToolInvokeTest(t *testing.T, select_1_want, invokeParamWant, tableNameParam, tableNameAuth string) {
@@ -440,70 +440,70 @@ func runSpannerExecuteSqlToolInvokeTest(t *testing.T, select_1_want, invokeParam
 }
 
 func runSpannerSchemaToolInvokeTest(t *testing.T, accessSchemaWant string) {
-    invokeTcs := []struct {
-        name          string
-        api           string
-        requestHeader map[string]string
-        requestBody   io.Reader
-        want          string
-        isErr         bool
-    }{
-        {
-            name:          "invoke list-tables-read-only",
-            api:           "http://127.0.0.1:5000/api/tool/access-schema-read-only/invoke",
-            requestHeader: map[string]string{},
-            requestBody:   bytes.NewBuffer([]byte(`{}`)),
-            want:          accessSchemaWant,
-            isErr:         false,
-        },
-        {
-            name:          "invoke list-tables",
-            api:           "http://127.0.0.1:5000/api/tool/access-schema/invoke",
-            requestHeader: map[string]string{},
-            requestBody:   bytes.NewBuffer([]byte(`{}`)),
-            isErr:         true,
-        },
-    }
-    for _, tc := range invokeTcs {
-        t.Run(tc.name, func(t *testing.T) {
-            // Send Tool invocation request
-            req, err := http.NewRequest(http.MethodPost, tc.api, tc.requestBody)
-            if err != nil {
-                t.Fatalf("unable to create request: %s", err)
-            }
-            req.Header.Add("Content-type", "application/json")
-            for k, v := range tc.requestHeader {
-                req.Header.Add(k, v)
-            }
-            resp, err := http.DefaultClient.Do(req)
-            if err != nil {
-                t.Fatalf("unable to send request: %s", err)
-            }
-            defer resp.Body.Close()
+	invokeTcs := []struct {
+		name          string
+		api           string
+		requestHeader map[string]string
+		requestBody   io.Reader
+		want          string
+		isErr         bool
+	}{
+		{
+			name:          "invoke list-tables-read-only",
+			api:           "http://127.0.0.1:5000/api/tool/access-schema-read-only/invoke",
+			requestHeader: map[string]string{},
+			requestBody:   bytes.NewBuffer([]byte(`{}`)),
+			want:          accessSchemaWant,
+			isErr:         false,
+		},
+		{
+			name:          "invoke list-tables",
+			api:           "http://127.0.0.1:5000/api/tool/access-schema/invoke",
+			requestHeader: map[string]string{},
+			requestBody:   bytes.NewBuffer([]byte(`{}`)),
+			isErr:         true,
+		},
+	}
+	for _, tc := range invokeTcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Send Tool invocation request
+			req, err := http.NewRequest(http.MethodPost, tc.api, tc.requestBody)
+			if err != nil {
+				t.Fatalf("unable to create request: %s", err)
+			}
+			req.Header.Add("Content-type", "application/json")
+			for k, v := range tc.requestHeader {
+				req.Header.Add(k, v)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("unable to send request: %s", err)
+			}
+			defer resp.Body.Close()
 
-            if resp.StatusCode != http.StatusOK {
-                if tc.isErr {
-                    return
-                }
-                bodyBytes, _ := io.ReadAll(resp.Body)
-                t.Fatalf("response status code is not 200, got %d: %s", resp.StatusCode, string(bodyBytes))
-            }
+			if resp.StatusCode != http.StatusOK {
+				if tc.isErr {
+					return
+				}
+				bodyBytes, _ := io.ReadAll(resp.Body)
+				t.Fatalf("response status code is not 200, got %d: %s", resp.StatusCode, string(bodyBytes))
+			}
 
-            // Check response body
-            var body map[string]interface{}
-            err = json.NewDecoder(resp.Body).Decode(&body)
-            if err != nil {
-                t.Fatalf("error parsing response body")
-            }
+			// Check response body
+			var body map[string]interface{}
+			err = json.NewDecoder(resp.Body).Decode(&body)
+			if err != nil {
+				t.Fatalf("error parsing response body")
+			}
 
-            got, ok := body["result"].(string)
-            if !ok {
-                t.Fatalf("unable to find result in response body")
-            }
+			got, ok := body["result"].(string)
+			if !ok {
+				t.Fatalf("unable to find result in response body")
+			}
 
-            if got != tc.want {
-                t.Fatalf("unexpected value: got %q, want %q", got, tc.want)
-            }
-        })
-    }
+			if got != tc.want {
+				t.Fatalf("unexpected value: got %q, want %q", got, tc.want)
+			}
+		})
+	}
 }

--- a/tests/sqlite/sqlite_integration_test.go
+++ b/tests/sqlite/sqlite_integration_test.go
@@ -112,8 +112,8 @@ func TestSQLiteToolEndpoint(t *testing.T) {
 	var args []string
 
 	// create table name with UUID
-	tableNameParam := "param_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
-	tableNameAuth := "auth_table_" + strings.Replace(uuid.New().String(), "-", "", -1)
+	tableNameParam := "param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableNameAuth := "auth_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 
 	// set up data for param tool
 	create_statement1, insert_statement1, tool_statement1, params1 := getSQLiteParamToolInfo(tableNameParam)


### PR DESCRIPTION
gosimple had been deprecated in favor of staticcheck: https://github.com/golangci/golangci-lint/issues/357

Other requirements are all migrated.

`std-error-handling` exclusions is included because without that, it will ask to check all error returns from (`Close()`, or `os.Setenv`s, or `fmt.Fprint`s...