### PR TITLE
fix(server/stdio): notifications should not return a response

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -106,8 +106,12 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 			// server can continue to run.
 			s.server.logger.ErrorContext(ctx, err.Error())
 		}
-		if err = s.write(ctx, res); err != nil {
-			return err
+
+		// no responses for notifications
+		if res != nil {
+			if err = s.write(ctx, res); err != nil {
+				return err
+			}
 		}
 	}
 }


### PR DESCRIPTION
Currently the `stdio` transport protocol will throw a `ZodError` during initialization. This is due to Toolbox writing `null` to stdout when it received a notification. This is not expected hence the `ZodError` occurs. Per the MCP protocol, notifications do not expect any response.

This fix added a condition to check if the responses is `nil` before writing to stdout.