### PR TITLE
fix(tools/mysqlsql): handled the null value for string case in mysqlsql tools

### DIFF
--- a/internal/tools/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysqlsql/mysqlsql.go
@@ -139,7 +139,11 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 			// we'll need to cast it back to string
 			switch colTypes[i].DatabaseTypeName() {
 			case "TEXT", "VARCHAR", "NVARCHAR":
-				vMap[name] = string(rawValues[i].([]byte))
+				if rawValues[i] != nil {
+					vMap[name] = string(rawValues[i].([]byte))
+				} else {
+					vMap[name] = nil
+				}
 			default:
 				vMap[name] = rawValues[i]
 			}


### PR DESCRIPTION
@Yuan325  please review and merge this if all looks ok.
In existing code, for the character field with null values it will panic with error:
"panic: interface conversion: interface {} is nil, not []uint8"