### PR TITLE
docs: Add toolbox-core examples to quickstart guide

### DIFF
--- a/docs/en/resources/authServices/_index.md
+++ b/docs/en/resources/authServices/_index.md
@@ -141,7 +141,7 @@ tools = await toolbox.load_toolset()
 
 # for a single token
 
-auth_tools = [tool.add_auth_token_getter("my_auth", get_auth_token) for tool in tools]
+authorized_tool = tools[0].add_auth_token_getter("my_auth", get_auth_token)
 
 # OR, if multiple tokens are needed
 
@@ -155,7 +155,7 @@ tools = toolbox.load_toolset()
 
 # for a single token
 
-auth_tools = [tool.add_auth_token_getter("my_auth", get_auth_token) for tool in tools]
+authorized_tool = tools[0].add_auth_token_getter("my_auth", get_auth_token)
 
 # OR, if multiple tokens are needed
 
@@ -169,7 +169,7 @@ tools = toolbox.load_toolset()
 
 # for a single token
 
-auth_tools = [tool.add_auth_token_getter("my_auth", get_auth_token) for tool in tools]
+authorized_tool = tools[0].add_auth_token_getter("my_auth", get_auth_token)
 
 # OR, if multiple tokens are needed
 

--- a/docs/en/resources/authServices/_index.md
+++ b/docs/en/resources/authServices/_index.md
@@ -62,52 +62,104 @@ token you will provide a function (that returns an id). This function is called
 when the tool is invoked. This allows you to cache and refresh the ID token as
 needed.
 
+The primary method for providing these getters is via the `auth_token_getters` parameter when loading tools, or the `add_auth_token_getter`() / `add_auth_token_getters()` methods on a loaded tool object.
+
 ### Specifying tokens during load
 
 {{< tabpane persist=header >}}
-{{< tab header="LangChain" lang="Python" >}}
+{{< tab header="Core" lang="Python" >}}
+import asyncio
+from toolbox_core import ToolboxClient
+
 async def get_auth_token():
     # ... Logic to retrieve ID token (e.g., from local storage, OAuth flow)
     # This example just returns a placeholder. Replace with your actual token retrieval.
     return "YOUR_ID_TOKEN" # Placeholder
 
-# for a single tool use
+async def main():
+    async with ToolboxClient("http://127.0.0.1:5000") as toolbox:
+        auth_tool = await toolbox.load_tool(
+            "get_sensitive_data",
+            auth_token_getters={"my_auth_app_1": get_auth_token}
+        )
+        result = await auth_tool(param="value")
+        print(result)
 
-authorized_tool = toolbox.load_tool("my-tool-name", auth_tokens={"my_auth": get_auth_token})
+if __name__ == "__main__":
+    asyncio.run(main())
+{{< /tab >}}
+{{< tab header="LangChain" lang="Python" >}}
+import asyncio
+from toolbox_langchain import ToolboxClient
 
-# for a toolset use
+async def get_auth_token():
+    # ... Logic to retrieve ID token (e.g., from local storage, OAuth flow)
+    # This example just returns a placeholder. Replace with your actual token retrieval.
+    return "YOUR_ID_TOKEN" # Placeholder
 
-authorized_tools = toolbox.load_toolset("my-toolset-name", auth_tokens={"my_auth": get_auth_token})
+async def main():
+    toolbox = ToolboxClient("http://127.0.0.1:5000")
+
+    auth_tool = await toolbox.aload_tool(
+        "get_sensitive_data",
+        auth_token_getters={"my_auth_app_1": get_auth_token}
+    )
+    result = await auth_tool.ainvoke({"param": "value"})
+    print(result)
+
+if __name__ == "__main__":
+    asyncio.run(main())
 {{< /tab >}}
 {{< tab header="Llamaindex" lang="Python" >}}
+import asyncio
+from toolbox_llamaindex import ToolboxClient
+
 async def get_auth_token():
     # ... Logic to retrieve ID token (e.g., from local storage, OAuth flow)
     # This example just returns a placeholder. Replace with your actual token retrieval.
     return "YOUR_ID_TOKEN" # Placeholder
 
-# for a single tool use
+async def main():
+    toolbox = ToolboxClient("http://127.0.0.1:5000")
 
-authorized_tool = toolbox.load_tool("my-tool-name", auth_tokens={"my_auth": get_auth_token})
+    auth_tool = await toolbox.aload_tool(
+        "get_sensitive_data",
+        auth_token_getters={"my_auth_app_1": get_auth_token}
+    )
+    # result = await auth_tool.acall(param="value")
+    # print(result.content)
 
-# for a toolset use
-
-authorized_tools = toolbox.load_toolset("my-toolset-name", auth_tokens={"my_auth": get_auth_token})
-{{< /tab >}}
+if __name__ == "__main__":
+    asyncio.run(main()){{< /tab >}}
 {{< /tabpane >}}
 
 ### Specifying tokens for existing tools
 
 {{< tabpane persist=header >}}
+{{< tab header="Core" lang="Python" >}}
+tools = await toolbox.load_toolset()
+
+# for a single token
+
+auth_tools = [tool.add_auth_token_getter("my_auth", get_auth_token) for tool in tools]
+
+# OR, if multiple tokens are needed
+
+authorized_tool = tools[0].add_auth_token_getters({
+  "my_auth1": get_auth1_token,
+  "my_auth2": get_auth2_token,
+})
+{{< /tab >}}
 {{< tab header="LangChain" lang="Python" >}}
 tools = toolbox.load_toolset()
 
 # for a single token
 
-auth_tools = [tool.add_auth_token("my_auth", get_auth_token) for tool in tools]
+auth_tools = [tool.add_auth_token_getter("my_auth", get_auth_token) for tool in tools]
 
 # OR, if multiple tokens are needed
 
-authorized_tool = tools[0].add_auth_tokens({
+authorized_tool = tools[0].add_auth_token_getters({
   "my_auth1": get_auth1_token,
   "my_auth2": get_auth2_token,
 })
@@ -117,11 +169,11 @@ tools = toolbox.load_toolset()
 
 # for a single token
 
-auth_tools = [tool.add_auth_token("my_auth", get_auth_token) for tool in tools]
+auth_tools = [tool.add_auth_token_getter("my_auth", get_auth_token) for tool in tools]
 
 # OR, if multiple tokens are needed
 
-authorized_tool = tools[0].add_auth_tokens({
+authorized_tool = tools[0].add_auth_token_getters({
   "my_auth1": get_auth1_token,
   "my_auth2": get_auth2_token,
 })

--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -306,51 +306,113 @@ pip install toolbox-core
 {{< tab header="Core" lang="python" >}}
 
 import asyncio
-from langgraph.prebuilt import create_react_agent
-# TODO(developer): replace this with another import if needed
-from langchain_google_vertexai import ChatVertexAI
-# from langchain_google_genai import ChatGoogleGenerativeAI
-# from langchain_anthropic import ChatAnthropic
-from langgraph.checkpoint.memory import MemorySaver
+
+from google import genai
+from google.genai.types import (
+    Content,
+    FunctionDeclaration,
+    GenerateContentConfig,
+    Part,
+    Tool,
+)
 
 from toolbox_core import ToolboxClient
 
 prompt = """
   You're a helpful hotel assistant. You handle hotel searching, booking and
-  cancellations. When the user searches for a hotel, mention it's name, id, 
-  location and price tier. Always mention hotel ids while performing any 
-  searches. This is very important for any operations. For any bookings or 
-  cancellations, please provide the appropriate confirmation. Be sure to 
+  cancellations. When the user searches for a hotel, mention it's name, id,
+  location and price tier. Always mention hotel id while performing any
+  searches. This is very important for any operations. For any bookings or
+  cancellations, please provide the appropriate confirmation. Be sure to
   update checkin or checkout dates if mentioned by the user.
   Don't ask for confirmations from the user.
 """
 
 queries = [
     "Find hotels in Basel with Basel in it's name.",
-    "Can you book the Hilton Basel for me?",
-    "Oh wait, this is too expensive. Please cancel it and book the Hyatt Regency instead.",
-    "My check in dates would be from April 10, 2024 to April 19, 2024.",
+    "Please book the hotel Hilton Basel for me.",
+    "This is too expensive. Please cancel it.",
+    "Please book Hyatt Regency for me",
+    "My check in dates for my booking would be from April 10, 2024 to April 19, 2024.",
 ]
 
-async def main():
-    # TODO(developer): replace this with another model if needed
-    model = ChatVertexAI(model_name="gemini-2.0-flash-001")
-    # model = ChatGoogleGenerativeAI(model="gemini-2.0-flash-001")
-    # model = ChatAnthropic(model="claude-3-5-sonnet-20240620")
-    
-    # Load the tools from the Toolbox server
-    async with ToolboxClient("http://127.0.0.1:5000") as client:
-        tools = await client.load_toolset()
+async def run_application():
+    async with ToolboxClient("http://127.0.0.1:5000") as toolbox_client:
 
-        agent = create_react_agent(model, tools, checkpointer=MemorySaver())
+        # The toolbox_tools list contains Python callables (functions/methods) designed for LLM tool-use
+        # integration. While this example uses Google's genai client, these callables can be adapted for
+        # various function-calling or agent frameworks. For easier integration with supported frameworks
+        # (https://github.com/googleapis/mcp-toolbox-python-sdk/tree/main/packages), use the
+        # provided wrapper packages, which handle framework-specific boilerplate.
+        toolbox_tools = await toolbox_client.load_toolset("my-toolset")
+        genai_client = genai.Client(
+            vertexai=True, project="project-id", location="us-central1"
+        )
 
-        config = {"configurable": {"thread_id": "thread-1"}}
+        genai_tools = [
+            Tool(
+                function_declarations=[
+                    FunctionDeclaration.from_callable_with_api_option(callable=tool)
+                ]
+            )
+            for tool in toolbox_tools
+        ]
+        history = []
         for query in queries:
-            inputs = {"messages": [("user", prompt + query)]}
-            response = await agent.ainvoke(inputs, stream_mode="values", config=config)
-            print(response["messages"][-1].content)
+            user_prompt_content = Content(
+                role="user",
+                parts=[Part.from_text(text=query)],
+            )
+            history.append(user_prompt_content)
 
-asyncio.run(main())
+            response = genai_client.models.generate_content(
+                model="gemini-2.0-flash-001",
+                contents=history,
+                config=GenerateContentConfig(
+                    system_instruction=prompt,
+                    tools=genai_tools,
+                ),
+            )
+            history.append(response.candidates[0].content)
+            function_response_parts = []
+            for function_call in response.function_calls:
+                fn_name = function_call.name
+                # The tools are sorted alphabetically
+                if fn_name == "search-hotels-by-name":
+                    function_result = await toolbox_tools[3](**function_call.args)
+                elif fn_name == "search-hotels-by-location":
+                    function_result = await toolbox_tools[2](**function_call.args)
+                elif fn_name == "book-hotel":
+                    function_result = await toolbox_tools[0](**function_call.args)
+                elif fn_name == "update-hotel":
+                    function_result = await toolbox_tools[4](**function_call.args)
+                elif fn_name == "cancel-hotel":
+                    function_result = await toolbox_tools[1](**function_call.args)
+                else:
+                    raise ValueError("Function name not present.")
+                function_response = {"result": function_result}
+                function_response_part = Part.from_function_response(
+                    name=function_call.name,
+                    response=function_response,
+                )
+                function_response_parts.append(function_response_part)
+
+            if function_response_parts:
+                tool_response_content = Content(role="tool", parts=function_response_parts)
+                history.append(tool_response_content)
+
+            response2 = genai_client.models.generate_content(
+                model="gemini-2.0-flash-001",
+                contents=history,
+                config=GenerateContentConfig(
+                    tools=genai_tools,
+                ),
+            )
+            final_model_response_content = response2.candidates[0].content
+            history.append(final_model_response_content)
+            print(response2.text)
+
+asyncio.run(run_application())
 {{< /tab >}}
 {{< tab header="LangChain" lang="python" >}}
 


### PR DESCRIPTION
## Description
This PR enhances our documentation by integrating `toolbox-core` code snippets into the quickstart examples on the docsite.

## Context
Previously, our client-facing documentation primarily showcased agent implementations using third-party frameworks like LangChain, LlamaIndex, and ADK. This created a documentation gap, as there were no baseline examples demonstrating how to use our foundational `toolbox-core` SDK directly. Users who wanted to build a custom integration without a specific framework had no direct reference in the guides.

## Changes
This PR introduces a new "Core" tab to all relevant code examples within the auth services and local quickstart (with BigQuery) documentations.