### PR TITLE
Fix: panic: interface conversion: interface {} is nil, not []uint8

### DIFF
--- a/internal/tools/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysqlexecutesql/mysqlexecutesql.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/cloudsqlmysql"
@@ -138,12 +139,11 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 		}
 		vMap := make(map[string]any)
 		for i, name := range cols {
-			// mysql driver return []uint8 type for "TEXT", "VARCHAR", and "NVARCHAR"
-			// we'll need to cast it back to string
-			switch colTypes[i].DatabaseTypeName() {
-			case "TEXT", "VARCHAR", "NVARCHAR":
+			if rawValues[i] != nil && slices.Contains([]string{"TEXT", "VARCHAR", "NVARCHAR"}, colTypes[i].DatabaseTypeName()) {
+				// mysql driver return []uint8 type for "TEXT", "VARCHAR", and "NVARCHAR"
+				// we'll need to cast it back to string
 				vMap[name] = string(rawValues[i].([]byte))
-			default:
+			} else {
 				vMap[name] = rawValues[i]
 			}
 		}

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -378,6 +378,14 @@ func RunExecuteSqlToolInvokeTest(t *testing.T, createTableStatement string, sele
 			requestBody:   bytes.NewBuffer([]byte(`{"sql":"SELECT 1"}`)),
 			isErr:         true,
 		},
+		{
+			name:          "invoke my-exec-sql-tool with null varchar",
+			api:           "http://127.0.0.1:5000/api/tool/my-exec-sql-tool/invoke",
+			requestHeader: map[string]string{},
+			requestBody:   bytes.NewBuffer([]byte(`{"sql":"CREATE TABLE test_nulls (id INT, name VARCHAR(255), description TEXT); INSERT INTO test_nulls VALUES (1, NULL, 'test'), (2, 'Alice', NULL); SELECT * FROM test_nulls;"}`)),
+			want:          `[{"description":"test","id":1,"name":null},{"description":null,"id":2,"name":"Alice"}]`,
+			isErr:         false,
+		},
 	}
 	for _, tc := range invokeTcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -89,7 +89,7 @@ func SetupMsSQLTable(t *testing.T, ctx context.Context, pool *sql.DB, create_sta
 }
 
 // SetupMySQLTable creates and inserts data into a table of tool
-// compatible with mssql-sql tool
+// compatible with mysql-sql tool
 func SetupMySQLTable(t *testing.T, ctx context.Context, pool *sql.DB, create_statement, insert_statement, tableName string, params []any) func(*testing.T) {
 	err := pool.PingContext(ctx)
 	if err != nil {


### PR DESCRIPTION
Fixes a bug with the mysql-execute-sql tool which causes a panic: interface conversion: interface {} is nil, not []uint8

I added an integration test case but did not go through the effort of setting it up locally since an admin can run the test suite against the PR.

FYI I didn't realize https://github.com/googleapis/genai-toolbox/pull/641 fixes the same issue so only of these should be merged