### PR TITLE
docs: update render-heading hook

### DIFF
--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -17,7 +17,7 @@ enableRobotsTXT = true
   proxy = "direct"
   [module.hugoVersion]
     extended = true
-    min = "0.73.0"
+    min = "0.146.0"
   [[module.mounts]]
     source = "../docs/en"
     target = 'content'

--- a/.hugo/layouts/_default/_markup/render-heading.html
+++ b/.hugo/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,0 @@
-{{ template "_default/_markup/td-render-heading.html" . }}

--- a/.hugo/layouts/partials/td/render-heading.html
+++ b/.hugo/layouts/partials/td/render-heading.html
@@ -1,0 +1,1 @@
+{{ template "partials/td/render-heading.html" . }}

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -132,7 +132,7 @@
 
 ## Developing Documentation
 
-1. [Install Hugo](https://gohugo.io/installation/macos/) version 0.145.0. This version is currently required due to breaking changes.
+1. [Install Hugo](https://gohugo.io/installation/macos/) version 0.146.0+.
 1. Move into the `.hugo` directory
 
     ```bash


### PR DESCRIPTION
There's a `no such template "_default/_markup/td-render-heading.html"` error when running `hugo server` locally. This is due to a breaking change in [Hugo v0.146.0](https://github.com/gohugoio/hugo/releases/tag/v0.146.0). This PR updates the render-heading file according to https://github.com/google/docsy/pull/2223.