### PR TITLE
chore: update httplog to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/couchbase/gocb/v2 v2.10.0
 	github.com/couchbase/tools-common/http v1.0.9
 	github.com/go-chi/chi/v5 v5.2.1
-	github.com/go-chi/httplog/v2 v2.1.1
+	github.com/go-chi/httplog/v3 v3.0.0
 	github.com/go-chi/render v1.0.3
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sql-driver/mysql v1.9.2

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrP
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
-github.com/go-chi/httplog/v2 v2.1.1 h1:ojojiu4PIaoeJ/qAO4GWUxJqvYUTobeo7zmuHQJAxRk=
-github.com/go-chi/httplog/v2 v2.1.1/go.mod h1:/XXdxicJsp4BA5fapgIC3VuTD+z0Z/VzukoB3VDc1YE=
+github.com/go-chi/httplog/v3 v3.0.0 h1:9wa4p9+s2YGDBdpWETd2kK5D/ApQg90TnwdYhgyBdgk=
+github.com/go-chi/httplog/v3 v3.0.0/go.mod h1:N/J1l5l1fozUrqIVuT8Z/HzNeSy8TF2EFyokPLe6y2w=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/go-chi/httplog/v2"
+	"github.com/go-chi/httplog/v3"
 	"github.com/googleapis/genai-toolbox/internal/auth"
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/sources"


### PR DESCRIPTION
Update version in library imports. Ref: #654



Updates: Updating to v3 might not be an option for our use cases. 
1. It's missing the `SourceFieldName`. Though, httplog team does mentioned that they're open to add it to the schema ([ref](https://github.com/go-chi/httplog/issues/53)). 
2. Another biggest reason why it's not an option: httplog.v3 `RequestLogger()` (https://pkg.go.dev/github.com/go-chi/httplog/v3#RequestLogger) only takes in logger of type `*slog.Logger`. In Toolbox, we created a [custom logger](https://github.com/googleapis/genai-toolbox/blob/v0.6.0/internal/log/logger.go) in order to log different levels to different writer (stdout vs stderr). Due to this, httplog.v3's RequestLogger() is **not** compatible with our custom Logger.