### PR TITLE
feat(metrics): add user agent for prebuilt tools

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -305,6 +305,8 @@ func run(cmd *Command) error {
 		}
 		logMsg := fmt.Sprint("Using prebuilt tool configuration for ", cmd.prebuiltConfig)
 		cmd.logger.InfoContext(ctx, logMsg)
+		// Append prebuilt.source to Version string for the User Agent
+		cmd.cfg.Version += "+prebuilt." + cmd.prebuiltConfig
 	} else {
 		// Set default value of tools-file flag to tools.yaml
 		if cmd.tools_file == "" {


### PR DESCRIPTION
Append "+prebuilt.<source>" to the user agent for tracking the prebuilt tools usage. This is set before the server is initialized and the user agent is set on the client.