### PR TITLE
refactor: move config initialization out of NewServer

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,115 @@ type Server struct {
 	toolsets     map[string]tools.Toolset
 }
 
+func InitializeConfigs(ctx context.Context, cfg ServerConfig, l log.Logger, instrumentation *Instrumentation) (map[string]sources.Source, map[string]auth.AuthService, map[string]tools.Tool, map[string]tools.Toolset, error) {
+	// initialize and validate the sources from configs
+	sourcesMap := make(map[string]sources.Source)
+	for name, sc := range cfg.SourceConfigs {
+		s, err := func() (sources.Source, error) {
+			childCtx, span := instrumentation.Tracer.Start(
+				ctx,
+				"toolbox/server/source/init",
+				trace.WithAttributes(attribute.String("source_kind", sc.SourceConfigKind())),
+				trace.WithAttributes(attribute.String("source_name", name)),
+			)
+			defer span.End()
+			s, err := sc.Initialize(childCtx, instrumentation.Tracer)
+			if err != nil {
+				return nil, fmt.Errorf("unable to initialize source %q: %w", name, err)
+			}
+			return s, nil
+		}()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		sourcesMap[name] = s
+	}
+	l.InfoContext(ctx, fmt.Sprintf("Initialized %d sources.", len(sourcesMap)))
+
+	// initialize and validate the auth services from configs
+	authServicesMap := make(map[string]auth.AuthService)
+	for name, sc := range cfg.AuthServiceConfigs {
+		a, err := func() (auth.AuthService, error) {
+			_, span := instrumentation.Tracer.Start(
+				ctx,
+				"toolbox/server/auth/init",
+				trace.WithAttributes(attribute.String("auth_kind", sc.AuthServiceConfigKind())),
+				trace.WithAttributes(attribute.String("auth_name", name)),
+			)
+			defer span.End()
+			a, err := sc.Initialize()
+			if err != nil {
+				return nil, fmt.Errorf("unable to initialize auth service %q: %w", name, err)
+			}
+			return a, nil
+		}()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		authServicesMap[name] = a
+	}
+	l.InfoContext(ctx, fmt.Sprintf("Initialized %d authServices.", len(authServicesMap)))
+
+	// initialize and validate the tools from configs
+	toolsMap := make(map[string]tools.Tool)
+	for name, tc := range cfg.ToolConfigs {
+		t, err := func() (tools.Tool, error) {
+			_, span := instrumentation.Tracer.Start(
+				ctx,
+				"toolbox/server/tool/init",
+				trace.WithAttributes(attribute.String("tool_kind", tc.ToolConfigKind())),
+				trace.WithAttributes(attribute.String("tool_name", name)),
+			)
+			defer span.End()
+			t, err := tc.Initialize(sourcesMap)
+			if err != nil {
+				return nil, fmt.Errorf("unable to initialize tool %q: %w", name, err)
+			}
+			return t, nil
+		}()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		toolsMap[name] = t
+	}
+	l.InfoContext(ctx, fmt.Sprintf("Initialized %d tools.", len(toolsMap)))
+
+	// create a default toolset that contains all tools
+	allToolNames := make([]string, 0, len(toolsMap))
+	for name := range toolsMap {
+		allToolNames = append(allToolNames, name)
+	}
+	if cfg.ToolsetConfigs == nil {
+		cfg.ToolsetConfigs = make(ToolsetConfigs)
+	}
+	cfg.ToolsetConfigs[""] = tools.ToolsetConfig{Name: "", ToolNames: allToolNames}
+
+	// initialize and validate the toolsets from configs
+	toolsetsMap := make(map[string]tools.Toolset)
+	for name, tc := range cfg.ToolsetConfigs {
+		t, err := func() (tools.Toolset, error) {
+			_, span := instrumentation.Tracer.Start(
+				ctx,
+				"toolbox/server/toolset/init",
+				trace.WithAttributes(attribute.String("toolset_name", name)),
+			)
+			defer span.End()
+			t, err := tc.Initialize(cfg.Version, toolsMap)
+			if err != nil {
+				return tools.Toolset{}, fmt.Errorf("unable to initialize toolset %q: %w", name, err)
+			}
+			return t, err
+		}()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		toolsetsMap[name] = t
+	}
+	l.InfoContext(ctx, fmt.Sprintf("Initialized %d toolsets.", len(toolsetsMap)))
+
+	return sourcesMap, authServicesMap, toolsMap, toolsetsMap, nil
+}
+
 // NewServer returns a Server object based on provided Config.
 func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, error) {
 	instrumentation, err := CreateTelemetryInstrumentation(cfg.Version)
@@ -98,110 +207,10 @@ func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, er
 	httpLogger := httplog.NewLogger("httplog", httpOpts)
 	r.Use(httplog.RequestLogger(httpLogger))
 
-	// initialize and validate the sources from configs
-	sourcesMap := make(map[string]sources.Source)
-	for name, sc := range cfg.SourceConfigs {
-		s, err := func() (sources.Source, error) {
-			childCtx, span := instrumentation.Tracer.Start(
-				ctx,
-				"toolbox/server/source/init",
-				trace.WithAttributes(attribute.String("source_kind", sc.SourceConfigKind())),
-				trace.WithAttributes(attribute.String("source_name", name)),
-			)
-			defer span.End()
-			s, err := sc.Initialize(childCtx, instrumentation.Tracer)
-			if err != nil {
-				return nil, fmt.Errorf("unable to initialize source %q: %w", name, err)
-			}
-			return s, nil
-		}()
-		if err != nil {
-			return nil, err
-		}
-		sourcesMap[name] = s
+	sourcesMap, authServicesMap, toolsMap, toolsetsMap, err := InitializeConfigs(ctx, cfg, l, instrumentation)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize configs: %w", err)
 	}
-	l.InfoContext(ctx, fmt.Sprintf("Initialized %d sources.", len(sourcesMap)))
-
-	// initialize and validate the auth services from configs
-	authServicesMap := make(map[string]auth.AuthService)
-	for name, sc := range cfg.AuthServiceConfigs {
-		a, err := func() (auth.AuthService, error) {
-			_, span := instrumentation.Tracer.Start(
-				ctx,
-				"toolbox/server/auth/init",
-				trace.WithAttributes(attribute.String("auth_kind", sc.AuthServiceConfigKind())),
-				trace.WithAttributes(attribute.String("auth_name", name)),
-			)
-			defer span.End()
-			a, err := sc.Initialize()
-			if err != nil {
-				return nil, fmt.Errorf("unable to initialize auth service %q: %w", name, err)
-			}
-			return a, nil
-		}()
-		if err != nil {
-			return nil, err
-		}
-		authServicesMap[name] = a
-	}
-	l.InfoContext(ctx, fmt.Sprintf("Initialized %d authServices.", len(authServicesMap)))
-
-	// initialize and validate the tools from configs
-	toolsMap := make(map[string]tools.Tool)
-	for name, tc := range cfg.ToolConfigs {
-		t, err := func() (tools.Tool, error) {
-			_, span := instrumentation.Tracer.Start(
-				ctx,
-				"toolbox/server/tool/init",
-				trace.WithAttributes(attribute.String("tool_kind", tc.ToolConfigKind())),
-				trace.WithAttributes(attribute.String("tool_name", name)),
-			)
-			defer span.End()
-			t, err := tc.Initialize(sourcesMap)
-			if err != nil {
-				return nil, fmt.Errorf("unable to initialize tool %q: %w", name, err)
-			}
-			return t, nil
-		}()
-		if err != nil {
-			return nil, err
-		}
-		toolsMap[name] = t
-	}
-	l.InfoContext(ctx, fmt.Sprintf("Initialized %d tools.", len(toolsMap)))
-
-	// create a default toolset that contains all tools
-	allToolNames := make([]string, 0, len(toolsMap))
-	for name := range toolsMap {
-		allToolNames = append(allToolNames, name)
-	}
-	if cfg.ToolsetConfigs == nil {
-		cfg.ToolsetConfigs = make(ToolsetConfigs)
-	}
-	cfg.ToolsetConfigs[""] = tools.ToolsetConfig{Name: "", ToolNames: allToolNames}
-
-	// initialize and validate the toolsets from configs
-	toolsetsMap := make(map[string]tools.Toolset)
-	for name, tc := range cfg.ToolsetConfigs {
-		t, err := func() (tools.Toolset, error) {
-			_, span := instrumentation.Tracer.Start(
-				ctx,
-				"toolbox/server/toolset/init",
-				trace.WithAttributes(attribute.String("toolset_name", name)),
-			)
-			defer span.End()
-			t, err := tc.Initialize(cfg.Version, toolsMap)
-			if err != nil {
-				return tools.Toolset{}, fmt.Errorf("unable to initialize toolset %q: %w", name, err)
-			}
-			return t, err
-		}()
-		if err != nil {
-			return nil, err
-		}
-		toolsetsMap[name] = t
-	}
-	l.InfoContext(ctx, fmt.Sprintf("Initialized %d toolsets.", len(toolsetsMap)))
 
 	addr := net.JoinHostPort(cfg.Address, strconv.Itoa(cfg.Port))
 	srv := &http.Server{Addr: addr, Handler: r}


### PR DESCRIPTION
Move config initialization (sources, authServices, tools, and toolsets) from within NewServer to a separate function, to allow reuse within dynamic reloading.