### PR TITLE
feat: validate reloaded edits to tools file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -226,17 +226,35 @@ func parseToolsFile(ctx context.Context, raw []byte) (ToolsFile, error) {
 	return toolsFile, nil
 }
 
-func validateReloadEdits(ctx context.Context, toolsFile ToolsFile, logger log.Logger) (map[string]sources.Source, map[string]auth.AuthService, map[string]tools.Tool, map[string]tools.Toolset, error) {
-	logger.DebugContext(ctx, "Attempting to parse and validate reloaded tools file.")
-
-	instrumentation, err := server.CreateTelemetryInstrumentation(versionString)
+// validateReloadEdits checks that the reloaded tools file configs can initialized without failing
+func validateReloadEdits(
+	ctx context.Context, toolsFile ToolsFile,
+) (map[string]sources.Source, map[string]auth.AuthService, map[string]tools.Tool, map[string]tools.Toolset, error,
+) {
+	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
-		errMsg := fmt.Errorf("unable to create telemetry instrumentation for reload: %w", err)
-		logger.WarnContext(ctx, errMsg.Error())
-		return nil, nil, nil, nil, err
+		panic(err)
 	}
 
-	sourcesMap, authServicesMap, toolsMap, toolsetsMap, err := server.InitializeConfigs(ctx, versionString, toolsFile.Sources, toolsFile.AuthServices, toolsFile.Tools, toolsFile.Toolsets, logger, instrumentation)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	logger.DebugContext(ctx, "Attempting to parse and validate reloaded tools file.")
+
+	ctx, span := instrumentation.Tracer.Start(ctx, "toolbox/server/reload")
+	defer span.End()
+
+	reloadedConfig := server.ServerConfig{
+		Version:            versionString,
+		SourceConfigs:      toolsFile.Sources,
+		AuthServiceConfigs: toolsFile.AuthServices,
+		ToolConfigs:        toolsFile.Tools,
+		ToolsetConfigs:     toolsFile.Toolsets,
+	}
+
+	sourcesMap, authServicesMap, toolsMap, toolsetsMap, err := server.InitializeConfigs(ctx, reloadedConfig)
 	if err != nil {
 		errMsg := fmt.Errorf("unable to initialize reloaded configs: %w", err)
 		logger.WarnContext(ctx, errMsg.Error())
@@ -246,18 +264,11 @@ func validateReloadEdits(ctx context.Context, toolsFile ToolsFile, logger log.Lo
 	return sourcesMap, authServicesMap, toolsMap, toolsetsMap, nil
 }
 
-func updateServer(ctx context.Context, l log.Logger, sourcesMap map[string]sources.Source, authServicesMap map[string]auth.AuthService, toolsMap map[string]tools.Tool, toolsetsMap map[string]tools.Toolset) error {
-	l.DebugContext(ctx, "Attempting to update the server with reloaded configs")
-
-	// TODO: handle updating logic
-	return nil
-}
-
 // watchFile checks for changes in the provided yaml tools file.
 func watchFile(ctx context.Context, toolsFileName string) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
-		panic(fmt.Errorf("unable to extract logger from context %w", err))
+		panic(err)
 	}
 
 	w, err := fsnotify.NewWatcher()
@@ -303,7 +314,7 @@ func watchFile(ctx context.Context, toolsFileName string) {
 			}
 
 			if e.Op == fsnotify.Write && filepath.Clean(e.Name) == cleanedFilename {
-				logger.DebugContext(ctx, fmt.Sprintf("%s event detected in tools file: %s", e.Op, e.Name))
+				logger.DebugContext(ctx, fmt.Sprintf("%s event detected in tools file: %s", e.Op, cleanedFilename))
 				debounce.Reset(debounceDelay)
 			}
 		case <-debounce.C:
@@ -313,28 +324,22 @@ func watchFile(ctx context.Context, toolsFileName string) {
 			if err != nil {
 				errMsg := fmt.Errorf("unable to read reloaded tools file at %q: %w", toolsFileName, err)
 				logger.WarnContext(ctx, errMsg.Error())
-				return
+				continue
 			}
 
 			toolsFile, err := parseToolsFile(ctx, buf)
 			if err != nil {
 				errMsg := fmt.Errorf("unable to parse reloaded tools file at %q: %w", toolsFileName, err)
 				logger.WarnContext(ctx, errMsg.Error())
-				return
+				continue
 			}
 
-			sourcesMap, authServicesMap, toolsMap, toolsetsMap, err := validateReloadEdits(ctx, toolsFile, logger)
+			// TODO: will update when updateServer() function is added to use return values
+			_, _, _, _, err = validateReloadEdits(ctx, toolsFile)
 			if err != nil {
 				errMsg := fmt.Errorf("unable to validate reloaded edits: %w", err)
 				logger.WarnContext(ctx, errMsg.Error())
-				return
-			}
-
-			err = updateServer(ctx, logger, sourcesMap, authServicesMap, toolsMap, toolsetsMap)
-			if err != nil {
-				errMsg := fmt.Errorf("unable to update server after reload: %w", err)
-				logger.WarnContext(ctx, errMsg.Error())
-				return
+				continue
 			}
 		}
 	}
@@ -463,8 +468,17 @@ func run(cmd *Command) error {
 		return errMsg
 	}
 
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(versionString)
+	if err != nil {
+		errMsg := fmt.Errorf("unable to create telemetry instrumentation: %w", err)
+		cmd.logger.ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+
 	// start server
-	s, err := server.NewServer(ctx, cmd.cfg, cmd.logger)
+	s, err := server.NewServer(ctx, cmd.cfg)
 	if err != nil {
 		errMsg := fmt.Errorf("toolbox failed to initialize: %w", err)
 		cmd.logger.ErrorContext(ctx, errMsg.Error())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"regexp"
 	"runtime"
 	"strings"
@@ -944,12 +945,15 @@ func TestSingleEdit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to setup logger %s", err)
 	}
-
 	ctx = util.WithLogger(ctx, logger)
 
 	go watchFile(ctx, fileToWatch)
 
-	begunWatchingFile := regexp.MustCompile(fmt.Sprintf("DEBUG \"Now watching tools file %s\"", fileToWatch))
+	// escape backslash so regex doesn't fail on windows filepaths
+	regexEscapedPath := strings.ReplaceAll(fileToWatch, `\`, `\\\\*\\`)
+	regexEscapedPath = path.Clean(regexEscapedPath)
+
+	begunWatchingFile := regexp.MustCompile(fmt.Sprintf(`DEBUG "Now watching tools file %s"`, regexEscapedPath))
 	_, err = testutils.WaitForString(ctx, begunWatchingFile, pr)
 	if err != nil {
 		t.Fatalf("timeout or error waiting for watcher to start: %s", err)
@@ -960,7 +964,7 @@ func TestSingleEdit(t *testing.T) {
 		t.Fatalf("error writing to file: %v", err)
 	}
 
-	detectedFileChange := regexp.MustCompile(fmt.Sprintf("DEBUG \"WRITE event detected in tools file: %s", fileToWatch))
+	detectedFileChange := regexp.MustCompile(fmt.Sprintf(`DEBUG "WRITE event detected in tools file: %s"`, regexEscapedPath))
 	_, err = testutils.WaitForString(ctx, detectedFileChange, pr)
 	if err != nil {
 		t.Fatalf("timeout or error waiting for file to detect write: %s", err)

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -148,7 +148,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 		t.Fatalf("unable to setup otel: %s", err)
 	}
 
-	instrumentation, err := CreateTelemetryInstrumentation(fakeVersionString)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(fakeVersionString)
 	if err != nil {
 		t.Fatalf("unable to create custom metrics: %s", err)
 	}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -414,7 +414,7 @@ func TestStdioSession(t *testing.T) {
 		}
 	}()
 
-	instrumentation, err := CreateTelemetryInstrumentation(fakeVersionString)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(fakeVersionString)
 	if err != nil {
 		t.Fatalf("unable to create custom metrics: %s", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/auth"
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/telemetry"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util"
 	"go.opentelemetry.io/otel/attribute"
@@ -43,7 +44,7 @@ type Server struct {
 	listener        net.Listener
 	root            chi.Router
 	logger          log.Logger
-	instrumentation *Instrumentation
+	instrumentation *telemetry.Instrumentation
 	sseManager      *sseManager
 
 	sources      map[string]sources.Source
@@ -52,12 +53,27 @@ type Server struct {
 	toolsets     map[string]tools.Toolset
 }
 
-func InitializeConfigs(ctx context.Context, VersionIn string, SourceConfigsIn SourceConfigs, AuthServiceConfigsIn AuthServiceConfigs, ToolConfigsIn ToolConfigs, ToolsetConfigsIn ToolsetConfigs, l log.Logger, instrumentation *Instrumentation) (map[string]sources.Source, map[string]auth.AuthService, map[string]tools.Tool, map[string]tools.Toolset, error) {
-	ctx = util.WithUserAgent(ctx, VersionIn)
+func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
+	map[string]sources.Source,
+	map[string]auth.AuthService,
+	map[string]tools.Tool,
+	map[string]tools.Toolset,
+	error,
+) {
+	ctx = util.WithUserAgent(ctx, cfg.Version)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	l, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 
 	// initialize and validate the sources from configs
 	sourcesMap := make(map[string]sources.Source)
-	for name, sc := range SourceConfigsIn {
+	for name, sc := range cfg.SourceConfigs {
 		s, err := func() (sources.Source, error) {
 			childCtx, span := instrumentation.Tracer.Start(
 				ctx,
@@ -81,7 +97,7 @@ func InitializeConfigs(ctx context.Context, VersionIn string, SourceConfigsIn So
 
 	// initialize and validate the auth services from configs
 	authServicesMap := make(map[string]auth.AuthService)
-	for name, sc := range AuthServiceConfigsIn {
+	for name, sc := range cfg.AuthServiceConfigs {
 		a, err := func() (auth.AuthService, error) {
 			_, span := instrumentation.Tracer.Start(
 				ctx,
@@ -105,7 +121,7 @@ func InitializeConfigs(ctx context.Context, VersionIn string, SourceConfigsIn So
 
 	// initialize and validate the tools from configs
 	toolsMap := make(map[string]tools.Tool)
-	for name, tc := range ToolConfigsIn {
+	for name, tc := range cfg.ToolConfigs {
 		t, err := func() (tools.Tool, error) {
 			_, span := instrumentation.Tracer.Start(
 				ctx,
@@ -132,14 +148,14 @@ func InitializeConfigs(ctx context.Context, VersionIn string, SourceConfigsIn So
 	for name := range toolsMap {
 		allToolNames = append(allToolNames, name)
 	}
-	if ToolsetConfigsIn == nil {
-		ToolsetConfigsIn = make(ToolsetConfigs)
+	if cfg.ToolsetConfigs == nil {
+		cfg.ToolsetConfigs = make(ToolsetConfigs)
 	}
-	ToolsetConfigsIn[""] = tools.ToolsetConfig{Name: "", ToolNames: allToolNames}
+	cfg.ToolsetConfigs[""] = tools.ToolsetConfig{Name: "", ToolNames: allToolNames}
 
 	// initialize and validate the toolsets from configs
 	toolsetsMap := make(map[string]tools.Toolset)
-	for name, tc := range ToolsetConfigsIn {
+	for name, tc := range cfg.ToolsetConfigs {
 		t, err := func() (tools.Toolset, error) {
 			_, span := instrumentation.Tracer.Start(
 				ctx,
@@ -147,7 +163,7 @@ func InitializeConfigs(ctx context.Context, VersionIn string, SourceConfigsIn So
 				trace.WithAttributes(attribute.String("toolset_name", name)),
 			)
 			defer span.End()
-			t, err := tc.Initialize(VersionIn, toolsMap)
+			t, err := tc.Initialize(cfg.Version, toolsMap)
 			if err != nil {
 				return tools.Toolset{}, fmt.Errorf("unable to initialize toolset %q: %w", name, err)
 			}
@@ -164,14 +180,19 @@ func InitializeConfigs(ctx context.Context, VersionIn string, SourceConfigsIn So
 }
 
 // NewServer returns a Server object based on provided Config.
-func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, error) {
-	instrumentation, err := CreateTelemetryInstrumentation(cfg.Version)
+func NewServer(ctx context.Context, cfg ServerConfig) (*Server, error) {
+	instrumentation, err := util.InstrumentationFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create telemetry instrumentation: %w", err)
+		return nil, err
 	}
 
 	ctx, span := instrumentation.Tracer.Start(ctx, "toolbox/server/init")
 	defer span.End()
+
+	l, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// set up http serving
 	r := chi.NewRouter()
@@ -207,7 +228,7 @@ func NewServer(ctx context.Context, cfg ServerConfig, l log.Logger) (*Server, er
 	httpLogger := httplog.NewLogger("httplog", httpOpts)
 	r.Use(httplog.RequestLogger(httpLogger))
 
-	sourcesMap, authServicesMap, toolsMap, toolsetsMap, err := InitializeConfigs(ctx, cfg.Version, cfg.SourceConfigs, cfg.AuthServiceConfigs, cfg.ToolConfigs, cfg.ToolsetConfigs, l, instrumentation)
+	sourcesMap, authServicesMap, toolsMap, toolsetsMap, err := InitializeConfigs(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize configs: %w", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestServe(t *testing.T) {
@@ -54,8 +55,16 @@ func TestServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+	ctx = util.WithLogger(ctx, testLogger)
 
-	s, err := server.NewServer(ctx, cfg, testLogger)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(cfg.Version)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+
+	s, err := server.NewServer(ctx, cfg)
 	if err != nil {
 		t.Fatalf("unable to initialize server: %v", err)
 	}

--- a/internal/telemetry/instrumentation.go
+++ b/internal/telemetry/instrumentation.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package telemetry
 
 import (
 	"fmt"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/log"
+	"github.com/googleapis/genai-toolbox/internal/telemetry"
 )
 
 var _ yaml.InterfaceUnmarshalerContext = &DelayedUnmarshaler{}
@@ -86,10 +87,25 @@ func WithLogger(ctx context.Context, logger log.Logger) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)
 }
 
-// LoggerFromContext retreives the logger or return an error
+// LoggerFromContext retrieves the logger or return an error
 func LoggerFromContext(ctx context.Context) (log.Logger, error) {
 	if logger, ok := ctx.Value(loggerKey).(log.Logger); ok {
 		return logger, nil
 	}
 	return nil, fmt.Errorf("unable to retrieve logger")
+}
+
+const instrumentationKey contextKey = "instrumentation"
+
+// WithInstrumentation adds an instrumentation into the context as a value
+func WithInstrumentation(ctx context.Context, instrumentation *telemetry.Instrumentation) context.Context {
+	return context.WithValue(ctx, instrumentationKey, instrumentation)
+}
+
+// InstrumentationFromContext retrieves the instrumentation or return an error
+func InstrumentationFromContext(ctx context.Context) (*telemetry.Instrumentation, error) {
+	if instrumentation, ok := ctx.Value(instrumentationKey).(*telemetry.Instrumentation); ok {
+		return instrumentation, nil
+	}
+	return nil, fmt.Errorf("unable to retrieve instrumentation")
 }


### PR DESCRIPTION
Re-parse and initialize configs after an edit is detected in the tools file.

Any parsing/initialization errors are logged as warnings to prevent crashing the existing toolbox server.