### PR TITLE
fix: Fix array param in BigQuery and MSSQL

### DIFF
--- a/internal/tools/bigquery/bigquery.go
+++ b/internal/tools/bigquery/bigquery.go
@@ -119,17 +119,17 @@ type Tool struct {
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
 	namedArgs := make([]bigqueryapi.QueryParameter, 0, len(params))
-	paramsMap := params.AsReversedMap()
-	for _, v := range params.AsSlice() {
-		paramName := paramsMap[v]
-		if strings.Contains(t.Statement, "@"+paramName) {
+	paramNames, paramValues := params.AsNameAndValueSlices()
+	for i, name := range paramNames {
+		value := paramValues[i]
+		if strings.Contains(t.Statement, "@"+name) {
 			namedArgs = append(namedArgs, bigqueryapi.QueryParameter{
-				Name:  paramName,
-				Value: v,
+				Name:  name,
+				Value: value,
 			})
 		} else {
 			namedArgs = append(namedArgs, bigqueryapi.QueryParameter{
-				Value: v,
+				Value: value,
 			})
 		}
 	}

--- a/internal/tools/mssqlsql/mssqlsql.go
+++ b/internal/tools/mssqlsql/mssqlsql.go
@@ -138,16 +138,19 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 	}
 
 	namedArgs := make([]any, 0, len(newParams))
-	newParamsMap := newParams.AsReversedMap()
-	// To support both named args (e.g @id) and positional args (e.g @p1), check if arg name is contained in the statement.
-	for _, v := range newParams.AsSlice() {
-		paramName := newParamsMap[v]
-		if strings.Contains(newStatement, "@"+paramName) {
-			namedArgs = append(namedArgs, sql.Named(paramName, v))
+	// To support both named args (e.g @id) and positional args (e.g @p1), check
+	// if arg name is contained in the statement.
+	paramNames, paramValues := newParams.AsNameAndValueSlices()
+	for i, name := range paramNames {
+		value := paramValues[i]
+		if strings.Contains(newStatement, "@"+name) {
+			namedArgs = append(namedArgs, sql.Named(name, value))
 		} else {
-			namedArgs = append(namedArgs, v)
+			namedArgs = append(namedArgs, value)
 		}
+
 	}
+
 	rows, err := t.Db.QueryContext(ctx, newStatement, namedArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to execute query: %w", err)

--- a/internal/tools/parameters.go
+++ b/internal/tools/parameters.go
@@ -62,13 +62,15 @@ func (p ParamValues) AsMap() map[string]interface{} {
 	return params
 }
 
-// AsReversedMap returns a map of ParamValue's values to names.
-func (p ParamValues) AsReversedMap() map[any]string {
-	params := make(map[any]string)
+// AsNameAndValueSlices returns a slice of param names and a slice of values
+func (p ParamValues) AsNameAndValueSlices() ([]string, []any) {
+	names := []string{}
+	values := []any{}
 	for _, p := range p {
-		params[p.Value] = p.Name
+		names = append(names, p.Name)
+		values = append(values, p.Value)
 	}
-	return params
+	return names, values
 }
 
 // AsMapByOrderedKeys returns a map of a key's position to it's value, as necessary for Spanner PSQL.


### PR DESCRIPTION
Fix: https://github.com/googleapis/genai-toolbox/issues/701

Things done:
1. Replace the `AsReversedMap()` helper with `AsNameAndValueSlices()` because arrays cannot be hashed as keys
2. BigQuery's QueryParameter only accepts typed slices as input, but our arrays are passed in as []any. Therefore, add a logic to convert []any to a typed array based on the item type.

Tested on MCP inspector:
<img width="409" alt="Screenshot 2025-06-16 at 5 15 55 PM" src="https://github.com/user-attachments/assets/8053cad5-270e-4d82-b97c-856238c42154" />
