### PR TITLE
docs: Document correct syntax for array parameters in SQL queries

### DIFF
--- a/docs/en/resources/tools/_index.md
+++ b/docs/en/resources/tools/_index.md
@@ -96,11 +96,13 @@ in the list using the items field:
     parameters:
       - name: preferred_airlines
         type: array
-        description: A list of airline, ordered by preference. 
+        description: A list of airline, ordered by preference.
         items:
-          name: name 
+          name: name
           type: string
-          description: Name of the airline. 
+          description: Name of the airline.
+    statement: |
+      SELECT * FROM airlines WHERE preferred_airlines = ANY($1);
 ```
 
 | **field**   |     **type**     | **required** | **description**                                                             |


### PR DESCRIPTION
## Problem

Users attempting to filter results in a SQL query based on an array parameter from a tool may intuitively write a `statement` using the `IN` clause, like so:
```sql
SELECT * FROM flights WHERE preferred_airlines IN ($1);
```
When this query is executed with an array argument (e.g., `["Delta", "United"]`), it fails with a cryptic error message from the database driver:
```
Exception: error while invoking tool: unable to execute query: failed to encode args[0]: unable to encode []interface {}{"Delta", "United"} into text format for text (OID 25): cannot find encode plan
```
This error occurs because the driver does not automatically expand the single `$1` placeholder into a list of values `('Delta', 'United')`. Instead, it tries to encode the entire Go slice `[]interface{}` as a single text value, which fails. This creates a point of friction, as the correct syntax is not immediately obvious and can lead to user frustration and debugging time.

## Solution
This PR updates our documentation and example usage to demonstrate the correct SQL syntax for handling array parameters. The proper way to check for a value's existence in an array parameter is by using PostgreSQL's `ANY()` operator:

```sql
SELECT * FROM flights WHERE preferred_airlines = ANY($1);
```
When this syntax is used, the database driver correctly interprets the Go slice passed as `$1` as a PostgreSQL array, and the query executes as intended.

## Impact
Saves developers time they would otherwise spend troubleshooting a non-obvious database driver behavior.