### PR TITLE
feat: add disable-reload flag and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,8 @@ execute `toolbox` to start the server:
 ```sh
 ./toolbox --tools-file "tools.yaml"
 ```
-
-Toolbox also supports dynamic reloading of the tools configuration file, which
-is enabled by default. To disable this, please run with the `--disable-reload`
-flag.
-
-```sh
-./toolbox --tools-file "tools.yaml" --disable-reload
-```
+> [!NOTE]
+> Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
 
 You can use `toolbox help` for a full list of flags! To stop the server, send a
 terminate signal (`ctrl+c` on most platforms).

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ execute `toolbox` to start the server:
 ./toolbox --tools-file "tools.yaml"
 ```
 
+Toolbox also supports dynamic reloading of the tools configuration file, which
+is enabled by default. To disable this, please run with the `--disable-reload`
+flag.
+
+```sh
+./toolbox --tools-file "tools.yaml" --disable-reload
+```
+
 You can use `toolbox help` for a full list of flags! To stop the server, send a
 terminate signal (`ctrl+c` on most platforms).
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,6 +178,7 @@ func NewCommand(opts ...Option) *Command {
 	flags.StringVar(&cmd.cfg.TelemetryServiceName, "telemetry-service-name", "toolbox", "Sets the value of the service.name resource attribute for telemetry data.")
 	flags.StringVar(&cmd.prebuiltConfig, "prebuilt", "", "Use a prebuilt tool configuration by source type. Cannot be used with --tools-file. Allowed: 'alloydb-postgres', 'bigquery', 'cloud-sql-mysql', 'cloud-sql-postgres', 'cloud-sql-mssql', 'postgres', 'spanner', 'spanner-postgres'.")
 	flags.BoolVar(&cmd.cfg.Stdio, "stdio", false, "Listens via MCP STDIO instead of acting as a remote HTTP server.")
+	flags.BoolVar(&cmd.cfg.DisableReload, "disable-reload", false, "Disables dynamic reloading of tools file.")
 
 	// wrap RunE command so that we have access to original Command object
 	cmd.RunE = func(*cobra.Command, []string) error { return run(cmd) }
@@ -530,8 +531,10 @@ func run(cmd *Command) error {
 		}()
 	}
 
-	// start watching for file changes to trigger dynamic reloading
-	go watchFile(ctx, cmd.tools_file, s)
+	if !cmd.cfg.DisableReload {
+		// start watching for file changes to trigger dynamic reloading
+		go watchFile(ctx, cmd.tools_file, s)
+	}
 
 	// wait for either the server to error out or the command's context to be canceled
 	select {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -183,6 +183,13 @@ func TestServerConfigFlags(t *testing.T) {
 				Stdio: true,
 			}),
 		},
+		{
+			desc: "disable reload",
+			args: []string{"--disable-reload"},
+			want: withDefaults(server.ServerConfig{
+				DisableReload: true,
+			}),
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -110,14 +110,9 @@ execute `toolbox` to start the server:
 ```sh
 ./toolbox --tools-file "tools.yaml"
 ```
-
-Toolbox also supports dynamic reloading of the tools configuration file, which
-is enabled by default. To disable this, please run with the `--disable-reload`
-flag.
-
-```sh
-./toolbox --disable-reload
-```
+{{< notice note >}}
+Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+{{< /notice >}}
 
 You can use `toolbox help` for a full list of flags! To stop the server, send a
 terminate signal (`ctrl+c` on most platforms).

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -111,6 +111,14 @@ execute `toolbox` to start the server:
 ./toolbox --tools-file "tools.yaml"
 ```
 
+Toolbox also supports dynamic reloading of the tools configuration file, which
+is enabled by default. To disable this, please run with the `--disable-reload`
+flag.
+
+```sh
+./toolbox --disable-reload
+```
+
 You can use `toolbox help` for a full list of flags! To stop the server, send a
 terminate signal (`ctrl+c` on most platforms).
 

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -238,13 +238,9 @@ In this section, we will download Toolbox, configure our tools in a
     ```bash
     ./toolbox --tools-file "tools.yaml"
     ```
-    
-    Toolbox also supports dynamic reloading of the tools configuration file, which
-    is enabled by default. To disable this, please run with the `--disable-reload`
-    flag.
-    ```sh
-    ./toolbox --tools-file "tools.yaml" --disable-reload
-    ```
+    {{< notice note >}}
+    Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+    {{< /notice >}}
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -238,6 +238,13 @@ In this section, we will download Toolbox, configure our tools in a
     ```bash
     ./toolbox --tools-file "tools.yaml"
     ```
+    
+    Toolbox also supports dynamic reloading of the tools configuration file, which
+    is enabled by default. To disable this, please run with the `--disable-reload`
+    flag.
+    ```sh
+    ./toolbox --tools-file "tools.yaml" --disable-reload
+    ```
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/docs/en/how-to/connect_via_mcp.md
+++ b/docs/en/how-to/connect_via_mcp.md
@@ -50,13 +50,9 @@ When running with stdio, Toolbox will listen via stdio instead of acting as a
 remote HTTP server. Logs will be set to the `warn` level by default. `debug` and `info` logs are not
 supported with stdio.
 
-Toolbox also supports dynamic reloading of the tools configuration file, which
-is enabled by default. To disable this, please run with the `--disable-reload`
-flag.
-
-```sh
-./toolbox --disable-reload
-```
+{{< notice note >}}
+Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+{{< /notice >}}
 
 ### Connecting via HTTP
 Toolbox supports the HTTP transport protocol with and without SSE.

--- a/docs/en/how-to/connect_via_mcp.md
+++ b/docs/en/how-to/connect_via_mcp.md
@@ -50,6 +50,14 @@ When running with stdio, Toolbox will listen via stdio instead of acting as a
 remote HTTP server. Logs will be set to the `warn` level by default. `debug` and `info` logs are not
 supported with stdio.
 
+Toolbox also supports dynamic reloading of the tools configuration file, which
+is enabled by default. To disable this, please run with the `--disable-reload`
+flag.
+
+```sh
+./toolbox --disable-reload
+```
+
 ### Connecting via HTTP
 Toolbox supports the HTTP transport protocol with and without SSE.
 

--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -238,13 +238,9 @@ In this section, we will download Toolbox, configure our tools in a `tools.yaml`
     ```bash
     ./toolbox --tools-file "tools.yaml"
     ```
-    Toolbox also supports dynamic reloading of the tools configuration file, which
-    is enabled by default. To disable this, please run with the `--disable-reload`
-    flag.
-    
-    ```sh
-    ./toolbox --tools-file "tools.yaml" --disable-reload
-    ```
+    {{< notice note >}}
+    Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+    {{< /notice >}}
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -238,6 +238,13 @@ In this section, we will download Toolbox, configure our tools in a `tools.yaml`
     ```bash
     ./toolbox --tools-file "tools.yaml"
     ```
+    Toolbox also supports dynamic reloading of the tools configuration file, which
+    is enabled by default. To disable this, please run with the `--disable-reload`
+    flag.
+    
+    ```sh
+    ./toolbox --tools-file "tools.yaml" --disable-reload
+    ```
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -53,6 +53,8 @@ type ServerConfig struct {
 	TelemetryServiceName string
 	// Stdio indicates if Toolbox is listening via MCP stdio.
 	Stdio bool
+	// DisableReload indicates if the user has disabled dynamic reloading for Toolbox.
+	DisableReload bool
 }
 
 type logFormat string


### PR DESCRIPTION
Add flag `--disable-reload` to allow user to disable dynamic reloading for tools configuration file. 

If the flag is not included, dynamic reloading is enabled by default.