### PR TITLE
fix: optional parameter int type conversion

### DIFF
--- a/internal/tools/parameters.go
+++ b/internal/tools/parameters.go
@@ -319,6 +319,13 @@ func parseParamFromDelayedUnmarshaler(ctx context.Context, u *util.DelayedUnmars
 		if err := dec.DecodeContext(ctx, a); err != nil {
 			return nil, fmt.Errorf("unable to parse as %q: %w", t, err)
 		}
+		if a.Default != nil {
+			intD, ok := a.Default.(uint64)
+			if !ok {
+				return nil, fmt.Errorf("default value fail to assert to type int64")
+			}
+			a.Default = int(intD)
+		}
 		if a.AuthSources != nil {
 			logger.WarnContext(ctx, "`authSources` is deprecated, use `authServices` for parameters instead")
 			a.AuthServices = append(a.AuthServices, a.AuthSources...)

--- a/internal/tools/parameters_test.go
+++ b/internal/tools/parameters_test.go
@@ -150,7 +150,7 @@ func TestParametersMarshal(t *testing.T) {
 				},
 			},
 			want: tools.Parameters{
-				tools.NewIntParameterWithDefault("my_integer", uint64(5), "this param is an int"),
+				tools.NewIntParameterWithDefault("my_integer", 5, "this param is an int"),
 			},
 		},
 		{


### PR DESCRIPTION
When `go-yaml` decode into `CommonParameter` with `Default` being an `any` type, int will be converted into []uint64.

It will fail the `Parse()` when the value is being used since it does not belong to either of the `int` types. Hence we will have to manually convert type uint64 into int during `Unmarshal`.

Fixes #771