### PR TITLE
feat: support multiple files for dynamic reloading

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -479,12 +479,12 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 		}
 		return v, res, err
 	default:
-		toolset, ok := s.resourceMgr.GetToolset(toolsetName)
+		toolset, ok := s.ResourceMgr.GetToolset(toolsetName)
 		if !ok {
 			err = fmt.Errorf("toolset does not exist")
 			return "", jsonrpc.NewError(baseMessage.Id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 		}
-		res, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, s.resourceMgr.GetToolsMap(), body)
+		res, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, s.ResourceMgr.GetToolsMap(), body)
 		return "", res, err
 	}
 }


### PR DESCRIPTION
Updates dynamic reloading to work for multiple forms of YAML config files.

This adjusts file-watching logic to account for the newly introduced changes in https://github.com/googleapis/genai-toolbox/pull/760.

