### PR TITLE
fix: fix docs preview deployment pipeline

### DIFF
--- a/.github/workflows/docs_preview_deploy.yaml
+++ b/.github/workflows/docs_preview_deploy.yaml
@@ -51,6 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo


### PR DESCRIPTION
The code for the preview build is now sourced from the target branch, whereas it was previously sourced from the main branch.