### PR TITLE
docs: Correct link for Cloud Run datasource setup

### DIFF
--- a/docs/en/how-to/deploy_toolbox.md
+++ b/docs/en/how-to/deploy_toolbox.md
@@ -79,7 +79,7 @@ database are in the same VPC network.
 
 Create a `tools.yaml` file that contains your configuration for Toolbox. For
 details, see the
-[configuration](https://github.com/googleapis/genai-toolbox/blob/main/README.md#configuration)
+[configuration](https://googleapis.github.io/genai-toolbox/resources/sources/)
 section.
 
 ## Deploy to Cloud Run


### PR DESCRIPTION
Updated the link in the Cloud Run deployment guide for `tools.yaml` setup. The previous link incorrectly pointed to a `localhost` source example, which causes confusion and deployment failures. The new link directs users to the guide for configuring cloud-based sources, ensuring a correct setup.