### PR TITLE
feat: dynamic reloading for toolbox config

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ execute `toolbox` to start the server:
 ```sh
 ./toolbox --tools-file "tools.yaml"
 ```
+> [!NOTE]
+> Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
 
 You can use `toolbox help` for a full list of flags! To stop the server, send a
 terminate signal (`ctrl+c` on most platforms).

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -489,7 +489,7 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 			}
 
 			// only check for write events which indicate user saved a new tools file
-			if e.Op != fsnotify.Write {
+			if !e.Has(fsnotify.Write) {
 				continue
 			}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,6 +182,7 @@ func NewCommand(opts ...Option) *Command {
 	flags.StringVar(&cmd.cfg.TelemetryServiceName, "telemetry-service-name", "toolbox", "Sets the value of the service.name resource attribute for telemetry data.")
 	flags.StringVar(&cmd.prebuiltConfig, "prebuilt", "", "Use a prebuilt tool configuration by source type. Cannot be used with --tools-file. Allowed: 'alloydb-postgres', 'bigquery', 'cloud-sql-mysql', 'cloud-sql-postgres', 'cloud-sql-mssql', 'postgres', 'spanner', 'spanner-postgres'.")
 	flags.BoolVar(&cmd.cfg.Stdio, "stdio", false, "Listens via MCP STDIO instead of acting as a remote HTTP server.")
+	flags.BoolVar(&cmd.cfg.DisableReload, "disable-reload", false, "Disables dynamic reloading of tools file.")
 
 	// wrap RunE command so that we have access to original Command object
 	cmd.RunE = func(*cobra.Command, []string) error { return run(cmd) }
@@ -707,8 +708,10 @@ func run(cmd *Command) error {
 		}()
 	}
 
-	// start watching for file changes to trigger dynamic reloading
-	go watchFile(ctx, cmd.tools_file, s)
+	if !cmd.cfg.DisableReload {
+		// start watching for file changes to trigger dynamic reloading
+		go watchFile(ctx, cmd.tools_file, s)
+	}
 
 	// wait for either the server to error out or the command's context to be canceled
 	select {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -494,7 +494,7 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 			}
 
 			cleanedFilename := filepath.Clean(e.Name)
-			logger.DebugContext(ctx, fmt.Sprintf("%s event detected in %s", e.Op, cleanedFilename))
+			logger.DebugContext(ctx, fmt.Sprintf("WRITE event detected in %s", cleanedFilename))
 
 			folderChanged := watchingFolder &&
 				(strings.HasSuffix(cleanedFilename, ".yaml") || strings.HasSuffix(cleanedFilename, ".yml"))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -183,6 +183,13 @@ func TestServerConfigFlags(t *testing.T) {
 				Stdio: true,
 			}),
 		},
+		{
+			desc: "disable reload",
+			args: []string{"--disable-reload"},
+			want: withDefaults(server.ServerConfig{
+				DisableReload: true,
+			}),
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -981,6 +982,103 @@ func TestEnvVarReplacement(t *testing.T) {
 
 }
 
+// normalizeFilepaths is a helper function to allow same filepath formats for Mac and Windows.
+// this prevents needing multiple "want" cases for TestResolveWatcherInputs
+func normalizeFilepaths(m map[string]bool) map[string]bool {
+	newMap := make(map[string]bool)
+	for k, v := range m {
+		newMap[filepath.ToSlash(k)] = v
+	}
+	return newMap
+}
+
+func TestResolveWatcherInputs(t *testing.T) {
+	tcs := []struct {
+		description      string
+		toolsFile        string
+		toolsFiles       []string
+		toolsFolder      string
+		wantWatchDirs    map[string]bool
+		wantWatchedFiles map[string]bool
+	}{
+		{
+			description:      "single tools file",
+			toolsFile:        "tools_folder/example_tools.yaml",
+			toolsFiles:       []string{},
+			toolsFolder:      "",
+			wantWatchDirs:    map[string]bool{"tools_folder": true},
+			wantWatchedFiles: map[string]bool{"tools_folder/example_tools.yaml": true},
+		},
+		{
+			description:      "default tools file (root dir)",
+			toolsFile:        "tools.yaml",
+			toolsFiles:       []string{},
+			toolsFolder:      "",
+			wantWatchDirs:    map[string]bool{".": true},
+			wantWatchedFiles: map[string]bool{"tools.yaml": true},
+		},
+		{
+			description:   "multiple files in different folders",
+			toolsFile:     "",
+			toolsFiles:    []string{"tools_folder/example_tools.yaml", "tools_folder2/example_tools.yaml"},
+			toolsFolder:   "",
+			wantWatchDirs: map[string]bool{"tools_folder": true, "tools_folder2": true},
+			wantWatchedFiles: map[string]bool{
+				"tools_folder/example_tools.yaml":  true,
+				"tools_folder2/example_tools.yaml": true,
+			},
+		},
+		{
+			description:   "multiple files in same folder",
+			toolsFile:     "",
+			toolsFiles:    []string{"tools_folder/example_tools.yaml", "tools_folder/example_tools2.yaml"},
+			toolsFolder:   "",
+			wantWatchDirs: map[string]bool{"tools_folder": true},
+			wantWatchedFiles: map[string]bool{
+				"tools_folder/example_tools.yaml":  true,
+				"tools_folder/example_tools2.yaml": true,
+			},
+		},
+		{
+			description: "multiple files in different levels",
+			toolsFile:   "",
+			toolsFiles: []string{
+				"tools_folder/example_tools.yaml",
+				"tools_folder/special_tools/example_tools2.yaml"},
+			toolsFolder:   "",
+			wantWatchDirs: map[string]bool{"tools_folder": true, "tools_folder/special_tools": true},
+			wantWatchedFiles: map[string]bool{
+				"tools_folder/example_tools.yaml":                true,
+				"tools_folder/special_tools/example_tools2.yaml": true,
+			},
+		},
+		{
+			description:      "tools folder",
+			toolsFile:        "",
+			toolsFiles:       []string{},
+			toolsFolder:      "tools_folder",
+			wantWatchDirs:    map[string]bool{"tools_folder": true},
+			wantWatchedFiles: map[string]bool{},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			gotWatchDirs, gotWatchedFiles := resolveWatcherInputs(tc.toolsFile, tc.toolsFiles, tc.toolsFolder)
+
+			normalizedGotWatchDirs := normalizeFilepaths(gotWatchDirs)
+			normalizedGotWatchedFiles := normalizeFilepaths(gotWatchedFiles)
+
+			if diff := cmp.Diff(tc.wantWatchDirs, normalizedGotWatchDirs); diff != "" {
+				t.Errorf("incorrect watchDirs: diff %v", diff)
+			}
+			if diff := cmp.Diff(tc.wantWatchedFiles, normalizedGotWatchedFiles); diff != "" {
+				t.Errorf("incorrect watchedFiles: diff %v", diff)
+			}
+
+		})
+	}
+}
+
 // helper function for testing file detection in dynamic reloading
 func tmpFileWithCleanup(content []byte) (string, func(), error) {
 	f, err := os.CreateTemp("", "*")
@@ -1028,14 +1126,23 @@ func TestSingleEdit(t *testing.T) {
 
 	mockServer := &server.Server{}
 
-	go watchFile(ctx, fileToWatch, mockServer)
+	cleanFileToWatch := filepath.Clean(fileToWatch)
+	watchDir := filepath.Dir(cleanFileToWatch)
+
+	watchedFiles := map[string]bool{cleanFileToWatch: true}
+	watchDirs := map[string]bool{watchDir: true}
+
+	go watchChanges(ctx, watchDirs, watchedFiles, mockServer)
 
 	// escape backslash so regex doesn't fail on windows filepaths
-	regexEscapedPath := strings.ReplaceAll(fileToWatch, `\`, `\\\\*\\`)
-	regexEscapedPath = path.Clean(regexEscapedPath)
+	regexEscapedPathFile := strings.ReplaceAll(cleanFileToWatch, `\`, `\\\\*\\`)
+	regexEscapedPathFile = path.Clean(regexEscapedPathFile)
 
-	begunWatchingFile := regexp.MustCompile(fmt.Sprintf(`DEBUG "Now watching tools file %s"`, regexEscapedPath))
-	_, err = testutils.WaitForString(ctx, begunWatchingFile, pr)
+	regexEscapedPathDir := strings.ReplaceAll(watchDir, `\`, `\\\\*\\`)
+	regexEscapedPathDir = path.Clean(regexEscapedPathDir)
+
+	begunWatchingDir := regexp.MustCompile(fmt.Sprintf(`DEBUG "Added directory %s to watcher\."`, regexEscapedPathDir))
+	_, err = testutils.WaitForString(ctx, begunWatchingDir, pr)
 	if err != nil {
 		t.Fatalf("timeout or error waiting for watcher to start: %s", err)
 	}
@@ -1045,7 +1152,7 @@ func TestSingleEdit(t *testing.T) {
 		t.Fatalf("error writing to file: %v", err)
 	}
 
-	detectedFileChange := regexp.MustCompile(fmt.Sprintf(`DEBUG "WRITE event detected in tools file: %s"`, regexEscapedPath))
+	detectedFileChange := regexp.MustCompile(fmt.Sprintf(`DEBUG "WRITE event detected in %s"`, regexEscapedPathFile))
 	_, err = testutils.WaitForString(ctx, detectedFileChange, pr)
 	if err != nil {
 		t.Fatalf("timeout or error waiting for file to detect write: %s", err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1141,7 +1141,7 @@ func TestSingleEdit(t *testing.T) {
 	regexEscapedPathDir := strings.ReplaceAll(watchDir, `\`, `\\\\*\\`)
 	regexEscapedPathDir = path.Clean(regexEscapedPathDir)
 
-	begunWatchingDir := regexp.MustCompile(fmt.Sprintf(`DEBUG "Added directory %s to watcher\."`, regexEscapedPathDir))
+	begunWatchingDir := regexp.MustCompile(fmt.Sprintf(`DEBUG "Added directory %s to watcher."`, regexEscapedPathDir))
 	_, err = testutils.WaitForString(ctx, begunWatchingDir, pr)
 	if err != nil {
 		t.Fatalf("timeout or error waiting for watcher to start: %s", err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	_ "embed"
@@ -992,67 +991,6 @@ func tmpFileWithCleanup(content []byte) (string, func(), error) {
 	return f.Name(), cleanup, err
 }
 
-// WaitForString is a helper function that waits for a string in the server log that matches the provided regex.
-func WaitForString(ctx context.Context, re *regexp.Regexp, pr *io.PipeReader) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-
-	in := bufio.NewReader(pr)
-
-	type result struct {
-		s   string
-		err error
-	}
-
-	output := make(chan result)
-	go func() {
-		defer close(output)
-		for {
-			select {
-			case <-ctx.Done():
-				// if the context is canceled, the orig thread will send back the error
-				// so we can just exit the goroutine here
-				return
-			default:
-				// otherwise read a line from the output
-				s, err := in.ReadString('\n')
-				if err != nil {
-					output <- result{err: err}
-					return
-				}
-				output <- result{s: s}
-				// if that last string matched, exit the goroutine
-				if re.MatchString(s) {
-					return
-				} else {
-					fmt.Printf("Actual logs: %s did not match pattern %s\n", s, re)
-				}
-			}
-		}
-	}()
-
-	// collect the output until the ctx is canceled, an error was hit,
-	// or match was found (which is indicated the channel is closed)
-	var sb strings.Builder
-	for {
-		select {
-		case <-ctx.Done():
-			// if ctx is done, return that error
-			return sb.String(), ctx.Err()
-		case o, ok := <-output:
-			if !ok {
-				// match was found!
-				return sb.String(), nil
-			}
-			if o.err != nil {
-				// error was found!
-				return sb.String(), o.err
-			}
-			sb.WriteString(o.s)
-		}
-	}
-}
-
 func TestSingleEdit(t *testing.T) {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelCtx()
@@ -1077,9 +1015,9 @@ func TestSingleEdit(t *testing.T) {
 	go watchFile(ctx, fileToWatch)
 
 	begunWatchingFile := regexp.MustCompile(fmt.Sprintf("DEBUG \"Now watching tools file %s\"", fileToWatch))
-	_, err = WaitForString(ctx, begunWatchingFile, pr)
+	_, err = testutils.WaitForString(ctx, begunWatchingFile, pr)
 	if err != nil {
-		t.Fatalf("timeout or error waiting for watcher to start")
+		t.Fatalf("timeout or error waiting for watcher to start: %s", err)
 	}
 
 	err = os.WriteFile(fileToWatch, []byte("modification"), 0777)
@@ -1088,9 +1026,9 @@ func TestSingleEdit(t *testing.T) {
 	}
 
 	detectedFileChange := regexp.MustCompile(fmt.Sprintf("DEBUG \"WRITE event detected in tools file: %s", fileToWatch))
-	_, err = WaitForString(ctx, detectedFileChange, pr)
+	_, err = testutils.WaitForString(ctx, detectedFileChange, pr)
 	if err != nil {
-		t.Fatalf("timeout or error waiting for file to detect write %v", err)
+		t.Fatalf("timeout or error waiting for file to detect write: %s", err)
 	}
 }
 

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -123,6 +123,9 @@ execute `toolbox` to start the server:
 ```sh
 ./toolbox --tools-file "tools.yaml"
 ```
+{{< notice note >}}
+Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+{{< /notice >}}
 
 You can use `toolbox help` for a full list of flags! To stop the server, send a
 terminate signal (`ctrl+c` on most platforms).

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -257,6 +257,9 @@ In this section, we will download Toolbox, configure our tools in a
     ```bash
     ./toolbox --tools-file "tools.yaml"
     ```
+    {{< notice note >}}
+    Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+    {{< /notice >}}
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/docs/en/how-to/connect_via_mcp.md
+++ b/docs/en/how-to/connect_via_mcp.md
@@ -63,6 +63,10 @@ When running with stdio, Toolbox will listen via stdio instead of acting as a
 remote HTTP server. Logs will be set to the `warn` level by default. `debug` and
 `info` logs are not supported with stdio.
 
+{{< notice note >}}
+Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+{{< /notice >}}
+
 ### Connecting via HTTP
 
 Toolbox supports the HTTP transport protocol with and without SSE.

--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -292,6 +292,9 @@ to use BigQuery, and then run the Toolbox server.
     ```bash
     ./toolbox --tools-file "tools.yaml"
     ```
+    {{< notice note >}}
+    Toolbox enables dynamic reloading by default. To disable, use the `--disable-reload` flag.
+    {{< /notice >}}
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.29.0
 	github.com/couchbase/gocb/v2 v2.10.0
 	github.com/couchbase/tools-common/http v1.0.9
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/httplog/v2 v2.1.1
 	github.com/go-chi/render v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -765,6 +765,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -75,7 +75,7 @@ func toolsetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		)
 	}()
 
-	toolset, ok := s.resourceMgr.GetToolset(toolsetName)
+	toolset, ok := s.ResourceMgr.GetToolset(toolsetName)
 	if !ok {
 		err = fmt.Errorf("toolset %q does not exist", toolsetName)
 		s.logger.DebugContext(ctx, err.Error())
@@ -111,7 +111,7 @@ func toolGetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 			metric.WithAttributes(attribute.String("toolbox.operation.status", status)),
 		)
 	}()
-	tool, ok := s.resourceMgr.GetTool(toolName)
+	tool, ok := s.ResourceMgr.GetTool(toolName)
 	if !ok {
 		err = fmt.Errorf("invalid tool name: tool with name %q does not exist", toolName)
 		s.logger.DebugContext(ctx, err.Error())
@@ -156,7 +156,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		)
 	}()
 
-	tool, ok := s.resourceMgr.GetTool(toolName)
+	tool, ok := s.ResourceMgr.GetTool(toolName)
 	if !ok {
 		err = fmt.Errorf("invalid tool name: tool with name %q does not exist", toolName)
 		s.logger.DebugContext(ctx, err.Error())
@@ -167,7 +167,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	// Tool authentication
 	// claimsFromAuth maps the name of the authservice to the claims retrieved from it.
 	claimsFromAuth := make(map[string]map[string]any)
-	for _, aS := range s.resourceMgr.GetAuthServiceMap() {
+	for _, aS := range s.ResourceMgr.GetAuthServiceMap() {
 		claims, err := aS.GetClaimsFromHeader(ctx, r.Header)
 		if err != nil {
 			s.logger.DebugContext(ctx, err.Error())

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -75,7 +75,7 @@ func toolsetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		)
 	}()
 
-	toolset, ok := s.toolsets[toolsetName]
+	toolset, ok := s.resourceMgr.GetToolset(toolsetName)
 	if !ok {
 		err = fmt.Errorf("toolset %q does not exist", toolsetName)
 		s.logger.DebugContext(ctx, err.Error())
@@ -111,7 +111,7 @@ func toolGetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 			metric.WithAttributes(attribute.String("toolbox.operation.status", status)),
 		)
 	}()
-	tool, ok := s.tools[toolName]
+	tool, ok := s.resourceMgr.GetTool(toolName)
 	if !ok {
 		err = fmt.Errorf("invalid tool name: tool with name %q does not exist", toolName)
 		s.logger.DebugContext(ctx, err.Error())
@@ -156,7 +156,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		)
 	}()
 
-	tool, ok := s.tools[toolName]
+	tool, ok := s.resourceMgr.GetTool(toolName)
 	if !ok {
 		err = fmt.Errorf("invalid tool name: tool with name %q does not exist", toolName)
 		s.logger.DebugContext(ctx, err.Error())
@@ -167,7 +167,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	// Tool authentication
 	// claimsFromAuth maps the name of the authservice to the claims retrieved from it.
 	claimsFromAuth := make(map[string]map[string]any)
-	for _, aS := range s.authServices {
+	for _, aS := range s.resourceMgr.GetAuthServiceMap() {
 		claims, err := aS.GetClaimsFromHeader(ctx, r.Header)
 		if err != nil {
 			s.logger.DebugContext(ctx, err.Error())

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -154,7 +154,16 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 
 	sseManager := newSseManager(ctx)
 
-	server := Server{version: fakeVersionString, logger: testLogger, instrumentation: instrumentation, sseManager: sseManager, tools: tools, toolsets: toolsets}
+	resourceManager := NewResourceManager(nil, nil, tools, toolsets)
+
+	server := Server{
+		version:         fakeVersionString,
+		logger:          testLogger,
+		instrumentation: instrumentation,
+		sseManager:      sseManager,
+		resourceMgr:     resourceManager,
+	}
+
 	var r chi.Router
 	switch router {
 	case "api":

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -147,7 +147,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 		t.Fatalf("unable to setup otel: %s", err)
 	}
 
-	instrumentation, err := CreateTelemetryInstrumentation(fakeVersionString)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(fakeVersionString)
 	if err != nil {
 		t.Fatalf("unable to create custom metrics: %s", err)
 	}

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -161,7 +161,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 		logger:          testLogger,
 		instrumentation: instrumentation,
 		sseManager:      sseManager,
-		resourceMgr:     resourceManager,
+		ResourceMgr:     resourceManager,
 	}
 
 	var r chi.Router

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -53,6 +53,8 @@ type ServerConfig struct {
 	TelemetryServiceName string
 	// Stdio indicates if Toolbox is listening via MCP stdio.
 	Stdio bool
+	// DisableReload indicates if the user has disabled dynamic reloading for Toolbox.
+	DisableReload bool
 }
 
 type logFormat string

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -479,12 +479,12 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 		}
 		return v, res, err
 	default:
-		toolset, ok := s.toolsets[toolsetName]
+		toolset, ok := s.resourceMgr.GetToolset(toolsetName)
 		if !ok {
 			err = fmt.Errorf("toolset does not exist")
 			return "", jsonrpc.NewError(baseMessage.Id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 		}
-		res, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, s.tools, body)
+		res, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, s.resourceMgr.GetToolsMap(), body)
 		return "", res, err
 	}
 }

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -479,12 +479,12 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 		}
 		return v, res, err
 	default:
-		toolset, ok := s.resourceMgr.GetToolset(toolsetName)
+		toolset, ok := s.ResourceMgr.GetToolset(toolsetName)
 		if !ok {
 			err = fmt.Errorf("toolset does not exist")
 			return "", jsonrpc.NewError(baseMessage.Id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 		}
-		res, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, s.resourceMgr.GetToolsMap(), body)
+		res, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, s.ResourceMgr.GetToolsMap(), body)
 		return "", res, err
 	}
 }

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -693,7 +693,7 @@ func TestStdioSession(t *testing.T) {
 		}
 	}()
 
-	instrumentation, err := CreateTelemetryInstrumentation(fakeVersionString)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(fakeVersionString)
 	if err != nil {
 		t.Fatalf("unable to create custom metrics: %s", err)
 	}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -707,7 +707,7 @@ func TestStdioSession(t *testing.T) {
 		logger:          testLogger,
 		instrumentation: instrumentation,
 		sseManager:      sseManager,
-		resourceMgr:     resourceManager,
+		ResourceMgr:     resourceManager,
 	}
 
 	in := bufio.NewReader(pr)

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -700,7 +700,15 @@ func TestStdioSession(t *testing.T) {
 
 	sseManager := newSseManager(ctx)
 
-	server := &Server{version: fakeVersionString, logger: testLogger, instrumentation: instrumentation, sseManager: sseManager, tools: toolsMap, toolsets: toolsets}
+	resourceManager := NewResourceManager(nil, nil, toolsMap, toolsets)
+
+	server := &Server{
+		version:         fakeVersionString,
+		logger:          testLogger,
+		instrumentation: instrumentation,
+		sseManager:      sseManager,
+		resourceMgr:     resourceManager,
+	}
 
 	in := bufio.NewReader(pr)
 	stdioSession := NewStdioSession(server, in, pw)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,7 +46,7 @@ type Server struct {
 	logger          log.Logger
 	instrumentation *telemetry.Instrumentation
 	sseManager      *sseManager
-	resourceMgr     *ResourceManager
+	ResourceMgr     *ResourceManager
 }
 
 // ResourceManager contains available resources for the server. Should be initialized with NewResourceManager().
@@ -133,12 +133,12 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	ctx = util.WithUserAgent(ctx, cfg.Version)
 	instrumentation, err := util.InstrumentationFromContext(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		panic(err)
 	}
 
 	l, err := util.LoggerFromContext(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		panic(err)
 	}
 
 	// initialize and validate the sources from configs
@@ -317,7 +317,7 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*Server, error) {
 		logger:          l,
 		instrumentation: instrumentation,
 		sseManager:      sseManager,
-		resourceMgr:     resourceManager,
+		ResourceMgr:     resourceManager,
 	}
 	// control plane
 	apiR, err := apiRouter(s)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestServe(t *testing.T) {
@@ -54,8 +55,16 @@ func TestServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+	ctx = util.WithLogger(ctx, testLogger)
 
-	s, err := server.NewServer(ctx, cfg, testLogger)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(cfg.Version)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+
+	s, err := server.NewServer(ctx, cfg)
 	if err != nil {
 		t.Fatalf("unable to initialize server: %v", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,9 +23,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/auth"
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
@@ -100,5 +106,69 @@ func TestServe(t *testing.T) {
 	}
 	if got := string(raw); strings.Contains(got, "0.0.0") {
 		t.Fatalf("version missing from output: %q", got)
+	}
+}
+
+func TestUpdateServer(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("error setting up logger: %s", err)
+	}
+
+	addr, port := "127.0.0.1", 5000
+	cfg := server.ServerConfig{
+		Version: "0.0.0",
+		Address: addr,
+		Port:    port,
+	}
+
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(cfg.Version)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+
+	s, err := server.NewServer(ctx, cfg)
+	if err != nil {
+		t.Fatalf("error setting up server: %s", err)
+	}
+
+	newSources := map[string]sources.Source{
+		"example-source": &alloydbpg.Source{
+			Name: "example-alloydb-source",
+			Kind: "alloydb-postgres",
+		},
+	}
+	newAuth := map[string]auth.AuthService{"example-auth": nil}
+	newTools := map[string]tools.Tool{"example-tool": nil}
+	newToolsets := map[string]tools.Toolset{
+		"example-toolset": {
+			Name: "example-toolset", Tools: []*tools.Tool{},
+		},
+	}
+	s.ResourceMgr.SetResources(newSources, newAuth, newTools, newToolsets)
+	if err != nil {
+		t.Errorf("error updating server: %s", err)
+	}
+
+	gotSource, _ := s.ResourceMgr.GetSource("example-source")
+	if diff := cmp.Diff(gotSource, newSources["example-source"]); diff != "" {
+		t.Errorf("error updating server, sources (-want +got):\n%s", diff)
+	}
+
+	gotAuthService, _ := s.ResourceMgr.GetAuthService("example-auth")
+	if diff := cmp.Diff(gotAuthService, newAuth["example-auth"]); diff != "" {
+		t.Errorf("error updating server, authServices (-want +got):\n%s", diff)
+	}
+
+	gotTool, _ := s.ResourceMgr.GetTool("example-tool")
+	if diff := cmp.Diff(gotTool, newTools["example-tool"]); diff != "" {
+		t.Errorf("error updating server, tools (-want +got):\n%s", diff)
+	}
+
+	gotToolset, _ := s.ResourceMgr.GetToolset("example-toolset")
+	if diff := cmp.Diff(gotToolset, newToolsets["example-toolset"]); diff != "" {
+		t.Errorf("error updating server, toolset (-want +got):\n%s", diff)
 	}
 }

--- a/internal/telemetry/instrumentation.go
+++ b/internal/telemetry/instrumentation.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package telemetry
 
 import (
 	"fmt"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/log"
+	"github.com/googleapis/genai-toolbox/internal/telemetry"
 )
 
 // DecodeJSON decodes a given reader into an interface using the json decoder.
@@ -98,10 +99,25 @@ func WithLogger(ctx context.Context, logger log.Logger) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)
 }
 
-// LoggerFromContext retreives the logger or return an error
+// LoggerFromContext retrieves the logger or return an error
 func LoggerFromContext(ctx context.Context) (log.Logger, error) {
 	if logger, ok := ctx.Value(loggerKey).(log.Logger); ok {
 		return logger, nil
 	}
 	return nil, fmt.Errorf("unable to retrieve logger")
+}
+
+const instrumentationKey contextKey = "instrumentation"
+
+// WithInstrumentation adds an instrumentation into the context as a value
+func WithInstrumentation(ctx context.Context, instrumentation *telemetry.Instrumentation) context.Context {
+	return context.WithValue(ctx, instrumentationKey, instrumentation)
+}
+
+// InstrumentationFromContext retrieves the instrumentation or return an error
+func InstrumentationFromContext(ctx context.Context) (*telemetry.Instrumentation, error) {
+	if instrumentation, ok := ctx.Value(instrumentationKey).(*telemetry.Instrumentation); ok {
+		return instrumentation, nil
+	}
+	return nil, fmt.Errorf("unable to retrieve instrumentation")
 }

--- a/tests/alloydbainl/alloydb_ai_nl_integration_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/googleapis/genai-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -90,7 +91,7 @@ func TestAlloyDBAINLToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	"cloud.google.com/go/alloydbconn"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -157,7 +158,7 @@ func TestAlloyDBPgToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -29,6 +29,7 @@ import (
 
 	bigqueryapi "cloud.google.com/go/bigquery"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"
@@ -124,7 +125,7 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/bigtable/bigtable_integration_test.go
+++ b/tests/bigtable/bigtable_integration_test.go
@@ -29,6 +29,7 @@ import (
 
 	"cloud.google.com/go/bigtable"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/tests"
 )
@@ -104,7 +105,7 @@ func TestBigtableToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
+++ b/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"cloud.google.com/go/cloudsqlconn"
 	"cloud.google.com/go/cloudsqlconn/sqlserver/mssql"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -151,7 +152,7 @@ func TestCloudSQLMSSQLToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
+++ b/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"cloud.google.com/go/cloudsqlconn"
 	"cloud.google.com/go/cloudsqlconn/mysql/mysql"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -138,7 +139,7 @@ func TestCloudSQLMySQLToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	"cloud.google.com/go/cloudsqlconn"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -142,7 +143,7 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/couchbase/couchbase_integration_test.go
+++ b/tests/couchbase/couchbase_integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/couchbase/gocb/v2"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -128,7 +129,7 @@ func TestCouchbaseToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/dgraph/dgraph_integration_test.go
+++ b/tests/dgraph/dgraph_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -78,7 +79,7 @@ func TestDgraphToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/http/http_integration_test.go
+++ b/tests/http/http_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/tests"
 )
@@ -277,7 +278,7 @@ func TestHttpToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/mssql/mssql_integration_test.go
+++ b/tests/mssql/mssql_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -124,7 +125,7 @@ func TestMSSQLToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/mysql/mysql_integration_test.go
+++ b/tests/mysql/mysql_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -115,7 +116,7 @@ func TestMySQLToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/neo4j/neo4j_integration_test.go
+++ b/tests/neo4j/neo4j_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -87,7 +88,7 @@ func TestNeo4jToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/postgres/postgres_integration_test.go
+++ b/tests/postgres/postgres_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -121,7 +122,7 @@ func TestPostgres(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/redis/redis_test.go
+++ b/tests/redis/redis_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 	"github.com/redis/go-redis/v9"
 )
@@ -90,7 +91,7 @@ func TestRedisToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/server.go
+++ b/tests/server.go
@@ -15,13 +15,10 @@
 package tests
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"regexp"
-	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 
@@ -131,65 +128,5 @@ func (c *CmdExec) Close() {
 	c.cancel()
 	for _, c := range c.closers {
 		c.Close()
-	}
-}
-
-// WaitForString waits until the server logs a single line that matches the provided regex.
-// returns the output of whatever the server sent so far.
-func (c *CmdExec) WaitForString(ctx context.Context, re *regexp.Regexp) (string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	in := bufio.NewReader(c.Out)
-
-	// read lines in background, sending result of each read over a channel
-	// this allows us to use in.ReadString without blocking
-	type result struct {
-		s   string
-		err error
-	}
-	output := make(chan result)
-	go func() {
-		defer close(output)
-		for {
-			select {
-			case <-ctx.Done():
-				// if the context is canceled, the orig thread will send back the error
-				// so we can just exit the goroutine here
-				return
-			default:
-				// otherwise read a line from the output
-				s, err := in.ReadString('\n')
-				if err != nil {
-					output <- result{err: err}
-					return
-				}
-				output <- result{s: s}
-				// if that last string matched, exit the goroutine
-				if re.MatchString(s) {
-					return
-				}
-			}
-		}
-	}()
-
-	// collect the output until the ctx is canceled, an error was hit,
-	// or match was found (which is indicated the channel is closed)
-	var sb strings.Builder
-	for {
-		select {
-		case <-ctx.Done():
-			// if ctx is done, return that error
-			return sb.String(), ctx.Err()
-		case o, ok := <-output:
-			if !ok {
-				// match was found!
-				return sb.String(), nil
-			}
-			if o.err != nil {
-				// error was found!
-				return sb.String(), o.err
-			}
-			sb.WriteString(o.s)
-		}
 	}
 }

--- a/tests/source.go
+++ b/tests/source.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 )
 
 // RunSourceConnection test for source connection
@@ -57,7 +58,7 @@ func RunSourceConnectionTest(t *testing.T, sourceConfig map[string]any, toolKind
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		return fmt.Errorf("toolbox didn't start successfully: %s", err)

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -31,6 +31,7 @@ import (
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/tests"
 )
@@ -141,7 +142,7 @@ func TestSpannerToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/sqlite/sqlite_integration_test.go
+++ b/tests/sqlite/sqlite_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 )
 
@@ -144,7 +145,7 @@ func TestSQLiteToolEndpoint(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)

--- a/tests/valkey/valkey_test.go
+++ b/tests/valkey/valkey_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/tests"
 	"github.com/valkey-io/valkey-go"
 )
@@ -93,7 +94,7 @@ func TestValkeyToolEndpoints(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	out, err := cmd.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`))
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)
 		t.Fatalf("toolbox didn't start successfully: %s", err)


### PR DESCRIPTION
Allow Toolbox to automatically update when users modify their tool configuration file(s), instead of requiring a restart.

This feature is automatically enabled, but can be turned off with the flag `--disable-reload`.