### PR TITLE
fix: update fsnotify comparison

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -489,7 +489,7 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 			}
 
 			// only check for write events which indicate user saved a new tools file
-			if e.Op != fsnotify.Write {
+			if !e.Has(fsnotify.Write) {
 				continue
 			}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1141,7 +1141,7 @@ func TestSingleEdit(t *testing.T) {
 	regexEscapedPathDir := strings.ReplaceAll(watchDir, `\`, `\\\\*\\`)
 	regexEscapedPathDir = path.Clean(regexEscapedPathDir)
 
-	begunWatchingDir := regexp.MustCompile(fmt.Sprintf(`DEBUG "Added directory %s to watcher\."`, regexEscapedPathDir))
+	begunWatchingDir := regexp.MustCompile(fmt.Sprintf(`DEBUG "Added directory %s to watcher."`, regexEscapedPathDir))
 	_, err = testutils.WaitForString(ctx, begunWatchingDir, pr)
 	if err != nil {
 		t.Fatalf("timeout or error waiting for watcher to start: %s", err)


### PR DESCRIPTION
Update fsnotify comparison to check for WRITE events using the built-in `Event.Has()` method instead of `==` comparison (used in older versions). 

This is because fsnotify's `Op` type is a bit mask, and some systems may send multiple operations at once, which could be rejected by a standard `==` check. Previously this was causing the `TestSingleEdit` unit test to be flaky on Mac os.