### PR TITLE
fix: update log to ensure consistent debug messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -494,7 +494,7 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 			}
 
 			cleanedFilename := filepath.Clean(e.Name)
-			logger.DebugContext(ctx, fmt.Sprintf("%s event detected in %s", e.Op, cleanedFilename))
+			logger.DebugContext(ctx, fmt.Sprintf("WRITE event detected in %s", cleanedFilename))
 
 			folderChanged := watchingFolder &&
 				(strings.HasSuffix(cleanedFilename, ".yaml") || strings.HasSuffix(cleanedFilename, ".yml"))


### PR DESCRIPTION
As long as the detected event's `e.Op` contains a write operation, only `WRITE` will be logged instead of the entire `e.Op` value. 

This ensures consistency for test cases across different operating systems. (Previously caused flaky `TestSingleEdit` as Mac os would occasionally count file-write events as `WRITE|CHMOD`