### PR TITLE
docs: Add links to the Client SDKs

### DIFF
--- a/docs/en/sdks/_index.md
+++ b/docs/en/sdks/_index.md
@@ -1,0 +1,7 @@
+---
+title: "SDKs"
+type: docs
+weight: 6
+description: >
+  Client SDKs to connect to the MCP Toolbox server.
+---

--- a/docs/en/sdks/go-sdk.md
+++ b/docs/en/sdks/go-sdk.md
@@ -1,0 +1,8 @@
+---
+title: "Go SDK"
+weight: 2
+description: Go lang client SDK
+icon: fa-brands fa-golang
+manualLink: "https://github.com/googleapis/mcp-toolbox-sdk-go"
+manualLinkTarget: _blank
+---

--- a/docs/en/sdks/js-sdk.md
+++ b/docs/en/sdks/js-sdk.md
@@ -1,0 +1,8 @@
+---
+title: "JS SDK"
+weight: 2
+description: Javascript client SDK
+icon: fa-brands fa-node-js
+manualLink: "https://github.com/googleapis/mcp-toolbox-sdk-js"
+manualLinkTarget: _blank
+---

--- a/docs/en/sdks/python-sdk.md
+++ b/docs/en/sdks/python-sdk.md
@@ -1,0 +1,8 @@
+---
+title: "Python SDK"
+weight: 2
+description: Python client SDK
+icon: fa-brands fa-python
+manualLink: "https://github.com/googleapis/mcp-toolbox-sdk-python"
+manualLinkTarget: _blank
+---


### PR DESCRIPTION
This PR adds links to the Client SDKs into the docsite.

All the 3 Client SDKs are added:
 - Go
 - JS
 - Python