### PR TITLE
docs: Add Go SDK samples to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ For more detailed instructions on using the Toolbox Core SDK, see the
 
   <details open>
     <summary>Core</summary>
+
 1. Install [Toolbox Go SDK][toolbox-go]:
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -370,7 +370,272 @@ For more detailed instructions on using the Toolbox Core SDK, see the
   </details>
 </details>
 </blockquote>
-  
+<details>
+  <summary>Go (<a href="https://github.com/googleapis/mcp-toolbox-sdk-go">Github</a>)</summary>
+  <br>
+  <blockquote>
+
+  <details open>
+    <summary>Core</summary>
+1. Install [Toolbox Go SDK][toolbox-go]:
+
+    ```bash
+    go get github.com/googleapis/mcp-toolbox-sdk-go
+    ```
+
+1. Load tools:
+
+    ```go
+    package main
+
+    import (
+      "github.com/googleapis/mcp-toolbox-sdk-go/core"
+      "context"
+    )
+
+    func main() {
+      // Make sure to add the error checks
+      // update the url to point to your server
+      URL := "http://127.0.0.1:5000";
+      ctx := context.Background()
+
+      client, err := core.NewToolboxClient(URL)
+
+      // Framework agnostic tools
+      tools, err := client.LoadToolset("toolsetName", ctx)
+    }
+    ```
+
+    For more detailed instructions on using the Toolbox Go SDK, see the
+    [project's README][toolbox-core-go-readme].
+
+    [toolbox-go]: https://pkg.go.dev/github.com/googleapis/mcp-toolbox-sdk-go/core
+    [toolbox-core-go-readme]: https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/core/README.md
+
+  </details>
+  <details>
+    <summary>LangChain Go</summary>
+
+1. Install [Toolbox Go SDK][toolbox-go]:
+
+    ```bash
+    go get github.com/googleapis/mcp-toolbox-sdk-go
+    ```
+
+2. Load tools:
+
+    ```go
+    package main
+
+    import (
+      "context"
+      "encoding/json"
+
+      "github.com/googleapis/mcp-toolbox-sdk-go/core"
+      "github.com/tmc/langchaingo/llms"
+    )
+
+    func main() {
+      // Make sure to add the error checks
+      // update the url to point to your server
+      URL := "http://127.0.0.1:5000"
+      ctx := context.Background()
+
+      client, err := core.NewToolboxClient(URL)
+
+      // Framework agnostic tool
+      tool, err := client.LoadTool("toolName", ctx)
+
+      // Fetch the tool's input schema
+      inputschema, err := tool.InputSchema()
+
+      var paramsSchema map[string]any
+      _ = json.Unmarshal(inputschema, &paramsSchema)
+
+      // Use this tool with LangChainGo
+      langChainTool := llms.Tool{
+        Type: "function",
+        Function: &llms.FunctionDefinition{
+          Name:        tool.Name(),
+          Description: tool.Description(),
+          Parameters:  paramsSchema,
+        },
+      }
+    }
+
+    ```
+
+  </details>
+  <details>
+    <summary>Genkit</summary>
+
+1. Install [Toolbox Go SDK][toolbox-go]:
+
+    ```bash
+    go get github.com/googleapis/mcp-toolbox-sdk-go
+    ```
+
+2. Load tools:
+
+    ```go
+    package main
+    import (
+      "context"
+      "encoding/json"
+
+      "github.com/firebase/genkit/go/ai"
+      "github.com/firebase/genkit/go/genkit"
+      "github.com/googleapis/mcp-toolbox-sdk-go/core"
+      "github.com/invopop/jsonschema"
+    )
+
+    func main() {
+      // Make sure to add the error checks
+      // Update the url to point to your server
+      URL := "http://127.0.0.1:5000"
+      ctx := context.Background()
+      g, err := genkit.Init(ctx)
+
+      client, err := core.NewToolboxClient(URL)
+
+      // Framework agnostic tool
+      tool, err := client.LoadTool("toolName", ctx)
+
+      // Fetch the tool's input schema
+      inputschema, err := tool.InputSchema()
+
+      var schema *jsonschema.Schema
+      _ = json.Unmarshal(inputschema, &schema)
+
+      executeFn := func(ctx *ai.ToolContext, input any) (string, error) {
+        result, err := tool.Invoke(ctx, input.(map[string]any))
+        if err != nil {
+          // Propagate errors from the tool invocation.
+          return "", err
+        }
+
+        return result.(string), nil
+      }
+
+      // Use this tool with Genkit Go
+      genkitTool := genkit.DefineToolWithInputSchema(
+        g,
+        tool.Name(),
+        tool.Description(),
+        schema,
+        executeFn,
+      )
+    }
+    ```
+
+  </details>
+  <details>
+    <summary>Go GenAI</summary>
+
+1. Install [Toolbox Go SDK][toolbox-go]:
+
+    ```bash
+    go get github.com/googleapis/mcp-toolbox-sdk-go
+    ```
+
+2. Load tools:
+
+    ```go
+    package main
+
+    import (
+      "context"
+      "encoding/json"
+
+      "github.com/googleapis/mcp-toolbox-sdk-go/core"
+      "google.golang.org/genai"
+    )
+
+    func main() {
+      // Make sure to add the error checks
+      // Update the url to point to your server
+      URL := "http://127.0.0.1:5000"
+      ctx := context.Background()
+
+      client, err := core.NewToolboxClient(URL)
+
+      // Framework agnostic tool
+      tool, err := client.LoadTool("toolName", ctx)
+
+      // Fetch the tool's input schema
+      inputschema, err := tool.InputSchema()
+
+      var schema *genai.Schema
+      _ = json.Unmarshal(inputschema, &schema)
+
+      funcDeclaration := &genai.FunctionDeclaration{
+        Name:        tool.Name(),
+        Description: tool.Description(),
+        Parameters:  schema,
+      }
+
+      // Use this tool with Go GenAI
+      genAITool := &genai.Tool{
+        FunctionDeclarations: []*genai.FunctionDeclaration{funcDeclaration},
+      }
+    }
+    ```
+
+  </details>
+  <details>
+    <summary>OpenAI Go</summary>
+
+1. Install [Toolbox Go SDK][toolbox-go]:
+
+    ```bash
+    go get github.com/googleapis/mcp-toolbox-sdk-go
+    ```
+
+2. Load tools:
+
+    ```go
+    package main
+
+    import (
+      "context"
+      "encoding/json"
+
+      "github.com/googleapis/mcp-toolbox-sdk-go/core"
+      openai "github.com/openai/openai-go"
+    )
+
+    func main() {
+      // Make sure to add the error checks
+      // Update the url to point to your server
+      URL := "http://127.0.0.1:5000"
+      ctx := context.Background()
+
+      client, err := core.NewToolboxClient(URL)
+
+      // Framework agnostic tool
+      tool, err := client.LoadTool("toolName", ctx)
+
+      // Fetch the tool's input schema
+      inputschema, err := tool.InputSchema()
+
+      var paramsSchema openai.FunctionParameters
+      _ = json.Unmarshal(inputschema, &paramsSchema)
+
+      // Use this tool with OpenAI Go
+      openAITool := openai.ChatCompletionToolParam{
+        Function: openai.FunctionDefinitionParam{
+          Name:        tool.Name(),
+          Description: openai.String(tool.Description()),
+          Parameters:  paramsSchema,
+        },
+      }
+
+    }
+    ```
+
+  </details>
+</details>
+</blockquote>
 </details>
 
 ## Configuration


### PR DESCRIPTION
This PR adds the Go SDK code snippets to the README, following the same pattern as Python and JS.

The code snippets are for:
 - Core usage
 - LangChain Go
 - Genkit Go
 - Go GenAI
 - OpenAI Go 