### PR TITLE
fix: trigger reload on additional fsnotify operations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -488,13 +488,14 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 				return
 			}
 
-			// only check for write events which indicate user saved a new tools file
-			if !e.Has(fsnotify.Write) {
+			// only check for events which indicate user saved a new tools file
+			// multiple operations checked due to various file update methods across editors
+			if !e.Has(fsnotify.Write | fsnotify.Create | fsnotify.Rename) {
 				continue
 			}
 
 			cleanedFilename := filepath.Clean(e.Name)
-			logger.DebugContext(ctx, fmt.Sprintf("WRITE event detected in %s", cleanedFilename))
+			logger.DebugContext(ctx, fmt.Sprintf("%s event detected in %s", e.Op, cleanedFilename))
 
 			folderChanged := watchingFolder &&
 				(strings.HasSuffix(cleanedFilename, ".yaml") || strings.HasSuffix(cleanedFilename, ".yml"))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1152,7 +1152,8 @@ func TestSingleEdit(t *testing.T) {
 		t.Fatalf("error writing to file: %v", err)
 	}
 
-	detectedFileChange := regexp.MustCompile(fmt.Sprintf(`DEBUG "WRITE event detected in %s"`, regexEscapedPathFile))
+	// only check substring of DEBUG message due to some OS/editors firing different operations
+	detectedFileChange := regexp.MustCompile(fmt.Sprintf(`event detected in %s"`, regexEscapedPathFile))
 	_, err = testutils.WaitForString(ctx, detectedFileChange, pr)
 	if err != nil {
 		t.Fatalf("timeout or error waiting for file to detect write: %s", err)


### PR DESCRIPTION
Allow fsnotify `CREATE` and `RENAME` events to trigger dynamic reload, instead of requiring `WRITE`.

This is due to some cases with specific editors/OS, (ex: vim on Mac), where file writes can potentially occur without ever triggering a `WRITE` operation on the watched tools file, but solely through creation and renaming of .swp files.