### PR TITLE
docs: clarify Bigtable GoogleSQL DML support for SELECT only

### DIFF
--- a/docs/en/resources/tools/bigtable/bigtable-sql.md
+++ b/docs/en/resources/tools/bigtable/bigtable-sql.md
@@ -19,11 +19,11 @@ instance. It's compatible with any of the following sources:
 ### GoogleSQL
 
 Bigtable supports SQL queries. The integration with Toolbox supports `googlesql`
-dialect, the specified SQL statement is executed as a [data manipulation
-language (DML)][bigtable-googlesql] statements, and specified parameters will
-inserted according to their name: e.g. `@name`.
+dialect. The specified SQL statement is executed as a [data manipulation
+language (DML)][bigtable-googlesql] statement. **It's important to note that GoogleSQL for Bigtable currently only supports `SELECT` DML statements; `INSERT`, `UPDATE`, and `DELETE` are not supported.** Specified parameters will be inserted according to their name: e.g. `@name`. For more details, refer to the [Google Cloud Bigtable GoogleSQL overview][bigtable-googlesql#usecase].
 
 [bigtable-googlesql]: https://cloud.google.com/bigtable/docs/googlesql-overview
+[bigtable-googlesql#usecase]: https://cloud.google.com/bigtable/docs/googlesql-overview#use-cases
 
 ## Example
 


### PR DESCRIPTION
feat(docs): Enhance Bigtable GoogleSQL DML clarity

**Description:**
This PR updates the `bigtable-sql` tool documentation to provide a clearer understanding of GoogleSQL's DML capabilities within Bigtable.

**Changes Made:**
- Added a note indicating that Bigtable's GoogleSQL dialect only supports `SELECT` DML operations.
- Explicitly states that `INSERT`, `UPDATE`, and `DELETE` DML statements are not supported.
- Updated the external link to directly reference the "Use cases" section in the official Google Cloud Bigtable GoogleSQL overview, where this limitation is detailed.

**Reasoning:**
The previous documentation, while linking to the overview, did not explicitly highlight the DML limitations. This clarification will prevent potential confusion for users expecting full DML support, ensuring the documentation accurately reflects Bigtable's capabilities with GoogleSQL.