### PR TITLE
chore: add docs readme badge and update discord to match style

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # MCP Toolbox for Databases
 
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
+[![Docs](https://img.shields.io/badge/docs-MCP_Toolbox-blue)](https://googleapis.github.io/genai-toolbox/)
+[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=plastic&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/genai-toolbox)](https://goreportcard.com/report/github.com/googleapis/genai-toolbox)
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # MCP Toolbox for Databases
 
 [![Docs](https://img.shields.io/badge/docs-MCP_Toolbox-blue)](https://googleapis.github.io/genai-toolbox/)
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=flat&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
+[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badges&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/genai-toolbox)](https://goreportcard.com/report/github.com/googleapis/genai-toolbox)
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # MCP Toolbox for Databases
 
 [![Docs](https://img.shields.io/badge/docs-MCP_Toolbox-blue)](https://googleapis.github.io/genai-toolbox/)
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=plastic&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
+[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=flat&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/genai-toolbox)](https://goreportcard.com/report/github.com/googleapis/genai-toolbox)
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # MCP Toolbox for Databases
 
 [![Docs](https://img.shields.io/badge/docs-MCP_Toolbox-blue)](https://googleapis.github.io/genai-toolbox/)
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badges&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
+[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=flat&logo=discord&logoColor=white)](https://discord.gg/Dmm69peqjh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/genai-toolbox)](https://goreportcard.com/report/github.com/googleapis/genai-toolbox)
 
 > [!NOTE]


### PR DESCRIPTION
Adding badge that links to docs to make them more easily discoverable from README.

Updating discord badge to match other two with "flat" style.


## Before
<img width="633" height="180" alt="image" src="https://github.com/user-attachments/assets/1a001698-672a-41dd-bb14-c42f57cd8209" />


## After

<img width="608" height="160" alt="image" src="https://github.com/user-attachments/assets/79a0df21-808b-4e33-84c9-1f7f7aaaa3ed" />
