### PR TITLE
chore(tools): invoke return type any instead of []any

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -42,7 +42,7 @@ type MockTool struct {
 	manifest    tools.Manifest
 }
 
-func (t MockTool) Invoke(context.Context, tools.ParamValues) ([]any, error) {
+func (t MockTool) Invoke(context.Context, tools.ParamValues) (any, error) {
 	mock := []any{t.Name}
 	return mock, nil
 }

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -122,7 +122,13 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, tools map[strin
 	}
 
 	content := make([]TextContent, 0)
-	for _, d := range results {
+
+	sliceRes, ok := results.([]any)
+	if !ok {
+		sliceRes = []any{results}
+	}
+
+	for _, d := range sliceRes {
 		text := TextContent{Type: "text"}
 		dM, err := json.Marshal(d)
 		if err != nil {

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -122,7 +122,13 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, tools map[strin
 	}
 
 	content := make([]TextContent, 0)
-	for _, d := range results {
+
+	sliceRes, ok := results.([]any)
+	if !ok {
+		sliceRes = []any{results}
+	}
+
+	for _, d := range sliceRes {
 		text := TextContent{Type: "text"}
 		dM, err := json.Marshal(d)
 		if err != nil {

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -122,7 +122,13 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, tools map[strin
 	}
 
 	content := make([]TextContent, 0)
-	for _, d := range results {
+
+	sliceRes, ok := results.([]any)
+	if !ok {
+		sliceRes = []any{results}
+	}
+
+	for _, d := range sliceRes {
 		text := TextContent{Type: "text"}
 		dM, err := json.Marshal(d)
 		if err != nil {

--- a/internal/tools/alloydbainl/alloydbainl.go
+++ b/internal/tools/alloydbainl/alloydbainl.go
@@ -156,7 +156,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	sliceParams := params.AsSlice()
 	allParamValues := make([]any, len(sliceParams)+1)
 	allParamValues[0] = fmt.Sprintf("%s", sliceParams[0]) // nl_question

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -114,7 +114,7 @@ type Tool struct {
 	mcpManifest  tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	sliceParams := params.AsSlice()
 	sql, ok := sliceParams[0].(string)
 	if !ok {

--- a/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
+++ b/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
@@ -118,7 +118,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	mapParams := params.AsMap()
 	projectId, ok := mapParams[projectKey].(string)
 	if !ok {
@@ -137,7 +137,7 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 		return nil, fmt.Errorf("failed to get metadata for dataset %s (in project %s): %w", datasetId, t.Client.Project(), err)
 	}
 
-	return []any{metadata}, nil
+	return metadata, nil
 }
 
 func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {

--- a/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
+++ b/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
@@ -120,7 +120,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	mapParams := params.AsMap()
 	projectId, ok := mapParams[projectKey].(string)
 	if !ok {
@@ -145,7 +145,7 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 		return nil, fmt.Errorf("failed to get metadata for table %s.%s.%s: %w", projectId, datasetId, tableId, err)
 	}
 
-	return []any{metadata}, nil
+	return metadata, nil
 }
 
 func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {

--- a/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
+++ b/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
@@ -118,7 +118,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	mapParams := params.AsMap()
 	projectId, ok := mapParams[projectKey].(string)
 	if !ok {

--- a/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
+++ b/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
@@ -119,7 +119,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	mapParams := params.AsMap()
 	projectId, ok := mapParams[projectKey].(string)
 	if !ok {

--- a/internal/tools/bigquery/bigquerysql/bigquerysql.go
+++ b/internal/tools/bigquery/bigquerysql/bigquerysql.go
@@ -124,7 +124,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	namedArgs := make([]bigqueryapi.QueryParameter, 0, len(params))
 	paramsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, paramsMap)

--- a/internal/tools/bigtable/bigtable.go
+++ b/internal/tools/bigtable/bigtable.go
@@ -161,7 +161,7 @@ func getMapParamsType(tparams tools.Parameters, params tools.ParamValues) (map[s
 	return btParamTypes, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/couchbase/couchbase.go
+++ b/internal/tools/couchbase/couchbase.go
@@ -125,7 +125,7 @@ type Tool struct {
 	mcpManifest          tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	namedParamsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, namedParamsMap)
 	if err != nil {

--- a/internal/tools/dgraph/dgraph.go
+++ b/internal/tools/dgraph/dgraph.go
@@ -120,7 +120,7 @@ type Tool struct {
 	mcpManifest  tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMapWithDollarPrefix()
 
 	resp, err := t.DgraphClient.ExecuteQuery(t.Statement, paramsMap, t.IsQuery, t.Timeout)
@@ -132,7 +132,6 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 		return nil, err
 	}
 
-	var out []any
 	var result struct {
 		Data map[string]interface{} `json:"data"`
 	}
@@ -140,9 +139,8 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 	if err := json.Unmarshal(resp, &result); err != nil {
 		return nil, fmt.Errorf("error parsing JSON: %v", err)
 	}
-	out = append(out, result.Data)
 
-	return out, nil
+	return result.Data, nil
 }
 
 func (t Tool) ParseParams(data map[string]any, claimsMap map[string]map[string]any) (tools.ParamValues, error) {

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -303,7 +303,7 @@ func getHeaders(headerParams tools.Parameters, defaultHeaders map[string]string,
 	return allHeaders, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 
 	// Calculate request body
@@ -349,15 +349,9 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 	var data any
 	if err = json.Unmarshal(body, &data); err != nil {
 		// if unable to unmarshal data, return result as string.
-		return []any{string(body)}, nil
+		return string(body), nil
 	}
-	// if data is a list, return as is.
-	dataList, ok := data.([]any)
-	if ok {
-		return dataList, nil
-	}
-	// if data is not a list (e.g. single map), return data in list.
-	return []any{data}, nil
+	return data, nil
 }
 
 func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {

--- a/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
+++ b/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
@@ -116,7 +116,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	sliceParams := params.AsSlice()
 	sql, ok := sliceParams[0].(string)
 	if !ok {

--- a/internal/tools/mssql/mssqlsql/mssqlsql.go
+++ b/internal/tools/mssql/mssqlsql/mssqlsql.go
@@ -125,7 +125,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
@@ -116,7 +116,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	sliceParams := params.AsSlice()
 	sql, ok := sliceParams[0].(string)
 	if !ok {

--- a/internal/tools/mysql/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysql/mysqlsql/mysqlsql.go
@@ -124,7 +124,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/neo4j/neo4j.go
+++ b/internal/tools/neo4j/neo4j.go
@@ -119,7 +119,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 
 	config := neo4j.ExecuteQueryWithDatabase(t.Database)

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
@@ -118,7 +118,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	sliceParams := params.AsSlice()
 	sql, ok := sliceParams[0].(string)
 	if !ok {

--- a/internal/tools/postgres/postgressql/postgressql.go
+++ b/internal/tools/postgres/postgressql/postgressql.go
@@ -126,7 +126,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/redis/redis.go
+++ b/internal/tools/redis/redis.go
@@ -115,7 +115,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	cmds, err := replaceCommandsParams(t.Commands, t.Parameters, params)
 	if err != nil {
 		return nil, fmt.Errorf("error replacing commands' parameters: %s", err)

--- a/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
+++ b/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
@@ -144,7 +144,7 @@ func processRows(iter *spanner.RowIterator) ([]any, error) {
 	return out, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	sliceParams := params.AsSlice()
 	sql, ok := sliceParams[0].(string)
 	if !ok {

--- a/internal/tools/spanner/spannersql/spannersql.go
+++ b/internal/tools/spanner/spannersql/spannersql.go
@@ -164,7 +164,7 @@ func processRows(iter *spanner.RowIterator) ([]any, error) {
 	return out, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/sqlitesql/sqlitesql.go
+++ b/internal/tools/sqlitesql/sqlitesql.go
@@ -122,7 +122,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 	newStatement, err := tools.ResolveTemplateParams(t.TemplateParameters, t.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -64,7 +64,7 @@ type ToolConfig interface {
 }
 
 type Tool interface {
-	Invoke(context.Context, ParamValues) ([]any, error)
+	Invoke(context.Context, ParamValues) (any, error)
 	ParseParams(map[string]any, map[string]map[string]any) (ParamValues, error)
 	Manifest() Manifest
 	McpManifest() McpManifest

--- a/internal/tools/utility/wait/wait.go
+++ b/internal/tools/utility/wait/wait.go
@@ -85,7 +85,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	paramsMap := params.AsMap()
 
 	durationStr, ok := paramsMap["duration"].(string)
@@ -100,7 +100,7 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, erro
 
 	time.Sleep(totalDuration)
 
-	return []any{fmt.Sprintf("Wait for %v completed successfully.", totalDuration)}, nil
+	return fmt.Sprintf("Wait for %v completed successfully.", totalDuration), nil
 }
 
 func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {

--- a/internal/tools/valkey/valkey.go
+++ b/internal/tools/valkey/valkey.go
@@ -114,7 +114,7 @@ type Tool struct {
 	mcpManifest tools.McpManifest
 }
 
-func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) ([]any, error) {
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
 	// Replace parameters
 	commands, err := replaceCommandsParams(t.Commands, t.Parameters, params)
 	if err != nil {

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -137,7 +137,7 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	// Partial message; the full error message is too long.
 	failInvocationWant := `{"jsonrpc":"2.0","id":"invoke-fail-tool","result":{"content":[{"type":"text","text":"unable to execute query: googleapi: Error 400: Syntax error: Unexpected identifier \"SELEC\" at [1:1]`
 	datasetInfoWant := "\"Location\":\"US\",\"DefaultTableExpiration\":0,\"Labels\":null,\"Access\":"
-	tableInfoWant := "[{\"Name\":\"\",\"Location\":\"US\",\"Description\":\"\",\"Schema\":[{\"Name\":\"id\""
+	tableInfoWant := "{\"Name\":\"\",\"Location\":\"US\",\"Description\":\"\",\"Schema\":[{\"Name\":\"id\""
 	invokeParamWant, invokeParamWantNull, mcpInvokeParamWant := tests.GetNonSpannerInvokeParamWant()
 	tests.RunToolInvokeTest(t, select1Want, invokeParamWant, invokeParamWantNull, true)
 	tests.RunMCPToolCallMethod(t, mcpInvokeParamWant, failInvocationWant)

--- a/tests/dgraph/dgraph_integration_test.go
+++ b/tests/dgraph/dgraph_integration_test.go
@@ -141,7 +141,7 @@ func TestDgraphToolEndpoints(t *testing.T) {
 			name:        "invoke my-simple-dql-tool",
 			api:         "http://127.0.0.1:5000/api/tool/my-simple-dql-tool/invoke",
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
-			want:        "[{\"result\":[{\"constant\":1}]}]",
+			want:        "{\"result\":[{\"constant\":1}]}",
 		},
 	}
 	for _, tc := range invokeTcs {

--- a/tests/http/http_integration_test.go
+++ b/tests/http/http_integration_test.go
@@ -80,10 +80,7 @@ func handleTool0(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	response := []string{
-		"Hello",
-		"World",
-	}
+	response := "hello world"
 	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
@@ -164,7 +161,7 @@ func handleTool2(w http.ResponseWriter, r *http.Request) {
 	}
 	email := r.URL.Query().Get("email")
 	if email != "" {
-		response := `{"name":"Alice"}`
+		response := `[{"name":"Alice"}]`
 		_, err := w.Write([]byte(response))
 		if err != nil {
 			http.Error(w, "Failed to write response", http.StatusInternalServerError)
@@ -246,10 +243,7 @@ func handleTool3(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return a JSON array as the response
-	response := []any{
-		"Hello", "World",
-	}
+	response := "hello world"
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
 		http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
@@ -284,7 +278,7 @@ func TestHttpToolEndpoints(t *testing.T) {
 		t.Fatalf("toolbox didn't start successfully: %s", err)
 	}
 
-	select1Want := `["Hello","World"]`
+	select1Want := `"hello world"`
 	invokeParamWant, invokeParamWantNull, _ := tests.GetNonSpannerInvokeParamWant()
 	tests.RunToolGetTest(t)
 	tests.RunToolInvokeTest(t, select1Want, invokeParamWant, invokeParamWantNull, false)
@@ -307,7 +301,7 @@ func runAdvancedHTTPInvokeTest(t *testing.T) {
 			api:           "http://127.0.0.1:5000/api/tool/my-advanced-tool/invoke",
 			requestHeader: map[string]string{},
 			requestBody:   bytes.NewBuffer([]byte(`{"animalArray": ["rabbit", "ostrich", "whale"], "id": 3, "path": "tool3", "country": "US", "X-Other-Header": "test"}`)),
-			want:          `["Hello","World"]`,
+			want:          `"hello world"`,
 			isErr:         false,
 		},
 		{


### PR DESCRIPTION
Update `tool.Invoke()` to return type `any` instead of `[]any`.

Toolbox return a map with the `results` key, and the SDK reads the string from the key. So this won't break existing SDK implementation.

Fixes #870