### PR TITLE
docs: add example tools section to each source

### DIFF
--- a/docs/en/resources/sources/alloydb-pg.md
+++ b/docs/en/resources/sources/alloydb-pg.md
@@ -122,3 +122,14 @@ instead of hardcoding your secrets into the configuration file.
 | user      |  string  |    false     | Name of the Postgres user to connect as (e.g. "my-pg-user"). Defaults to IAM auth using [ADC][adc] email if unspecified. |
 | password  |  string  |    false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
 | ipType    |  string  |    false     | IP Type of the AlloyDB instance; must be one of `public` or `private`. Default: `public`.                                |
+
+## Example Tools
+
+- [`alloydb-ai-nl`](../tools/alloydbainl/alloydb-ai-nl.md)  
+  Use natural language queries on AlloyDB, powered by AlloyDB AI.
+
+- [`postgres-sql`](../tools/postgres/postgres-sql.md)  
+  Execute SQL queries as prepared statements in AlloyDB Postgres.
+
+- [`postgres-execute-sql`](../tools/postgres/postgres-execute-sql.md)  
+  Run parameterized SQL statements in AlloyDB Postgres.

--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -71,3 +71,23 @@ sources:
 | kind      |  string  |     true     | Must be "bigquery".                                                           |
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id"). |
 | location  |  string  |    false     | Specifies the location (e.g., 'us', 'asia-northeast1') in which to run the query job. This location must match the location of any tables referenced in the query. The default behavior is for it to be executed in the US multi-region |
+
+## Example Tools
+
+- [`bigquery-sql`](../tools/bigquery/bigquery-sql.md)  
+  Run SQL queries directly against BigQuery datasets.
+
+- [`bigquery-execute-sql`](../tools/bigquery/bigquery-execute-sql.md)  
+  Execute structured queries using parameters.
+
+- [`bigquery-get-dataset-info`](../tools/bigquery/bigquery-get-dataset-info.md)  
+  Retrieve metadata for a specific dataset.
+
+- [`bigquery-get-table-info`](../tools/bigquery/bigquery-get-table-info.md)  
+  Retrieve metadata for a specific table.
+
+- [`bigquery-list-dataset-ids`](../tools/bigquery/bigquery-list-dataset-ids.md)  
+  List available dataset IDs.
+
+- [`bigquery-list-table-ids`](../tools/bigquery/bigquery-list-table-ids.md)  
+  List tables in a given dataset.

--- a/docs/en/resources/sources/bigtable.md
+++ b/docs/en/resources/sources/bigtable.md
@@ -68,3 +68,8 @@ sources:
 | kind      |  string  |     true     | Must be "bigtable".                                                           |
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id"). |
 | instance  |  string  |     true     | Name of the Bigtable instance.                                                |
+
+## Example Tools
+
+- [`bigtable-sql`](../tools/bigtable/bigtable-sql.md)
+  Run SQL-like queries over Bigtable rows.

--- a/docs/en/resources/sources/cloud-sql-mssql.md
+++ b/docs/en/resources/sources/cloud-sql-mssql.md
@@ -102,3 +102,11 @@ instead of hardcoding your secrets into the configuration file.
 | user      |  string  |     true     | Name of the SQL Server user to connect as (e.g. "my-pg-user").                              |
 | password  |  string  |     true     | Password of the SQL Server user (e.g. "my-password").                                       |
 | ipType    |  string  |    false     | IP Type of the Cloud SQL instance, must be either `public` or `private`. Default: `public`. |
+
+## Example Tools
+
+- [`mssql-sql`](../tools/mssql/mssql-sql.md)  
+  Execute pre-defined SQL Server queries with placeholder parameters.
+
+- [`mssql-execute-sql`](../tools/mssql/mssql-execute-sql.md)  
+  Run parameterized SQL Server queries in Cloud SQL for SQL Server.

--- a/docs/en/resources/sources/cloud-sql-mysql.md
+++ b/docs/en/resources/sources/cloud-sql-mysql.md
@@ -101,3 +101,11 @@ instead of hardcoding your secrets into the configuration file.
 | user      |  string  |     true     | Name of the MySQL user to connect as (e.g. "my-pg-user").                                   |
 | password  |  string  |     true     | Password of the MySQL user (e.g. "my-password").                                            |
 | ipType    |  string  |    false     | IP Type of the Cloud SQL instance; must be one of `public` or `private`. Default: `public`. |
+
+## Example Tools
+
+- [`mysql-sql`](../tools/mysql/mysql-sql.md)  
+  Execute pre-defined prepared SQL queries in MySQL.
+
+- [`mysql-execute-sql`](../tools/mysql/mysql-execute-sql.md)  
+  Run parameterized SQL queries in Cloud SQL for MySQL.

--- a/docs/en/resources/sources/cloud-sql-pg.md
+++ b/docs/en/resources/sources/cloud-sql-pg.md
@@ -125,3 +125,11 @@ instead of hardcoding your secrets into the configuration file.
 | user      |  string  |     false    | Name of the Postgres user to connect as (e.g. "my-pg-user"). Defaults to IAM auth using [ADC][adc] email if unspecified. |
 | password  |  string  |     false    | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
 | ipType    |  string  |     false    | IP Type of the Cloud SQL instance; must be one of `public` or `private`. Default: `public`.                              |
+
+## Example Tools
+
+- [`postgres-sql`](../tools/postgres/postgres-sql.md)  
+  Execute SQL queries as prepared statements in PostgreSQL.
+
+- [`postgres-execute-sql`](../tools/postgres/postgres-execute-sql.md)  
+  Run parameterized SQL statements in PostgreSQL.

--- a/docs/en/resources/sources/couchbase.md
+++ b/docs/en/resources/sources/couchbase.md
@@ -42,3 +42,8 @@ sources:
 | noSslVerify          | boolean  |    false     | If true, skip server certificate verification. **Warning:** This option should only be used in development or testing environments. Disabling SSL verification poses significant security risks in production as it makes your connection vulnerable to man-in-the-middle attacks. |
 | profile              | string   |    false     | Name of the connection profile to apply.                |
 | queryScanConsistency | integer  |    false     | Query scan consistency. Controls the consistency guarantee for index scanning. Values: 1 for "not_bounded" (fastest option, but results may not include the most recent operations), 2 for "request_plus" (highest consistency level, includes all operations up until the query started, but incurs a performance penalty). If not specified, defaults to the Couchbase Go SDK default. |
+
+## Example Tools
+
+- [`couchbase-sql`](../tools/couchbase/couchbase-sql.md)  
+  Run SQL++ statements on Couchbase with parameterized input.

--- a/docs/en/resources/sources/dgraph.md
+++ b/docs/en/resources/sources/dgraph.md
@@ -60,3 +60,8 @@ instead of hardcoding your secrets into the configuration file.
 | password    |  string  |     false    | Password of the Dgraph user (e.g., "password").                                                  |
 | apiKey      |  string  |     false    | API key to connect to a Dgraph Cloud instance.                                                   |
 | namespace   |  uint64  |     false    | Dgraph namespace (not required for Dgraph Cloud Shared Clusters).                                |
+
+## Example Tools
+
+- [`dgraph-dql`](../tools/dgraph/dgraph-dql.md)  
+  Run DQL (Dgraph Query Language) queries.

--- a/docs/en/resources/sources/http.md
+++ b/docs/en/resources/sources/http.md
@@ -47,3 +47,8 @@ instead of hardcoding your secrets into the configuration file.
 | disableSslVerification |       bool        |    false     | Disable SSL certificate verification. This should only be used for local development. Defaults to `false`.                         |
 
 [parse-duration-doc]: https://pkg.go.dev/time#ParseDuration
+
+## Example Tools
+
+- [`http`](../tools/http/http.md)  
+  Make HTTP requests to REST APIs or other web services.

--- a/docs/en/resources/sources/mssql.md
+++ b/docs/en/resources/sources/mssql.md
@@ -52,3 +52,11 @@ instead of hardcoding your secrets into the configuration file.
 | database  |  string  |     true     | Name of the SQL Server database to connect to (e.g. "my_db").          |
 | user      |  string  |     true     | Name of the SQL Server user to connect as (e.g. "my-user").            |
 | password  |  string  |     true     | Password of the SQL Server user (e.g. "my-password").                  |
+
+## Example Tools
+
+- [`mssql-sql`](../tools/mssql/mssql-sql.md)  
+  Execute pre-defined SQL Server queries with placeholder parameters.
+
+- [`mssql-execute-sql`](../tools/mssql/mssql-execute-sql.md)  
+  Run parameterized SQL Server queries in SQL Server.

--- a/docs/en/resources/sources/mysql.md
+++ b/docs/en/resources/sources/mysql.md
@@ -53,3 +53,11 @@ instead of hardcoding your secrets into the configuration file.
 | user         |  string  |     true     | Name of the MySQL user to connect as (e.g. "my-mysql-user").                                    |
 | password     |  string  |     true     | Password of the MySQL user (e.g. "my-password").                                                |
 | queryTimeout |  string  |    false     | Maximum time to wait for query execution (e.g. "30s", "2m"). By default, no timeout is applied. |
+
+## Example Tools
+
+- [`mysql-sql`](../tools/mysql/mysql-sql.md)  
+  Execute pre-defined prepared SQL queries in MySQL.
+
+- [`mysql-execute-sql`](../tools/mysql/mysql-execute-sql.md)  
+  Run parameterized SQL queries in MySQL.

--- a/docs/en/resources/sources/neo4j.md
+++ b/docs/en/resources/sources/neo4j.md
@@ -49,3 +49,8 @@ instead of hardcoding your secrets into the configuration file.
 | user      |  string  |     true     | Name of the Neo4j user to connect as (e.g. "neo4j").                 |
 | password  |  string  |     true     | Password of the Neo4j user (e.g. "my-password").                     |
 | database  |  string  |     true     | Name of the Neo4j database to connect to (e.g. "neo4j").             |
+
+## Example Tools
+
+- [`neo4j-cypher`](../tools/neo4j/neo4j-cypher.md)  
+  Run Cypher queries against your Neo4j graph database.

--- a/docs/en/resources/sources/postgres.md
+++ b/docs/en/resources/sources/postgres.md
@@ -52,3 +52,11 @@ instead of hardcoding your secrets into the configuration file.
 | database  |  string  |     true     | Name of the Postgres database to connect to (e.g. "my_db").            |
 | user      |  string  |     true     | Name of the Postgres user to connect as (e.g. "my-pg-user").           |
 | password  |  string  |     true     | Password of the Postgres user (e.g. "my-password").                    |
+
+## Example Tools
+
+- [`postgres-sql`](../tools/postgres/postgres-sql.md)  
+  Execute SQL queries as prepared statements in PostgreSQL.
+
+- [`postgres-execute-sql`](../tools/postgres/postgres-execute-sql.md)  
+  Run parameterized SQL statements in PostgreSQL.

--- a/docs/en/resources/sources/redis.md
+++ b/docs/en/resources/sources/redis.md
@@ -94,3 +94,8 @@ sources:
 | useGCPIAM      |  string  |    false     | Set it to `true` if you are using GCP's IAM authentication. Defaults to `false`.                                                |
 
 [auth]: https://cloud.google.com/memorystore/docs/redis/about-redis-auth
+
+## Example Tools
+
+- [`redis`](../tools/redis/redis.md)  
+  Run Redis commands and interact with key-value pairs.

--- a/docs/en/resources/sources/spanner.md
+++ b/docs/en/resources/sources/spanner.md
@@ -63,3 +63,11 @@ sources:
 | instance  |  string  |     true     | Name of the Spanner instance.                                                                                       |
 | database  |  string  |     true     | Name of the database on the Spanner instance                                                                        |
 | dialect   |  string  |    false     | Name of the dialect type of the Spanner database, must be either `googlesql` or `postgresql`. Default: `googlesql`. |
+
+## Example Tools
+
+- [`spanner-sql`](../tools/spanner/spanner-sql.md)  
+  Execute SQL on Google Cloud Spanner.
+
+- [`spanner-execute-sql`](../tools/spanner/spanner-execute-sql.md)  
+  Run structured and parameterized queries on Spanner.

--- a/docs/en/resources/sources/sqlite.md
+++ b/docs/en/resources/sources/sqlite.md
@@ -65,3 +65,8 @@ SQLite connections are configured with these defaults for optimal performance:
 
 - `MaxOpenConns`: 1 (SQLite only supports one writer at a time)
 - `MaxIdleConns`: 1
+
+## Example Tools
+
+- [`sqlite-sql`](../tools/sqlite/sqlite-sql.md)  
+  Run SQL queries against a local SQLite database.

--- a/docs/en/resources/sources/valkey.md
+++ b/docs/en/resources/sources/valkey.md
@@ -67,3 +67,8 @@ sources:
 | database     |   int    |    false     | The Valkey database to connect to. Not applicable for cluster enabled instances. The default database is `0`.                    |
 | useGCPIAM    |   bool   |    false     | Set it to `true` if you are using GCP's IAM authentication. Defaults to `false`.                                                 |
 | disableCache |   bool   |    false     | Set it to `true` if you want to enable client-side caching. Defaults to `false`.                                                 |
+
+## Example Tools
+
+- [`valkey`](../tools/valkey/valkey.md)  
+  Issue Valkey (Redis-compatible) commands.


### PR DESCRIPTION
- This PR adds an `"Example Tools"` section under each source page in the [documentation](https://googleapis.github.io/genai-toolbox/resources/sources/). 
- The purpose is to help users quickly identify relevant tools compatible with each data source, improving discoverability and developer experience.