### PR TITLE
docs: fix valkey doc broken link

### DIFF
--- a/docs/en/resources/sources/valkey.md
+++ b/docs/en/resources/sources/valkey.md
@@ -17,7 +17,7 @@ sets, sorted sets with range queries, bitmaps, hyperloglogs, and geospatial
 indexes with radius queries.
 
 If you're new to Valkey, you can find installation and getting started guides on
-the [official Valkey website](https://valkey.io/docs/getting-started/).
+the [official Valkey website](https://valkey.io/topics/).
 
 ## Example
 

--- a/docs/en/resources/sources/valkey.md
+++ b/docs/en/resources/sources/valkey.md
@@ -17,7 +17,7 @@ sets, sorted sets with range queries, bitmaps, hyperloglogs, and geospatial
 indexes with radius queries.
 
 If you're new to Valkey, you can find installation and getting started guides on
-the [official Valkey website](https://valkey.io/topics/).
+the [official Valkey website](https://valkey.io/topics/quickstart/).
 
 ## Example
 


### PR DESCRIPTION
In [genai-toolbox](https://googleapis.github.io/genai-toolbox/resources/sources/valkey/) Official Documentation of valkey URL is broken.
