### PR TITLE
fix(prebuilt/cloud-sql-mysql): update list_table tool

### DIFF
--- a/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
@@ -154,9 +154,10 @@ tools:
           ) USING utf8mb4) AS object_details
       FROM
           INFORMATION_SCHEMA.TABLES T
+      CROSS JOIN (SELECT @table_names := ?) AS variables
       WHERE
           T.TABLE_SCHEMA NOT IN ('mysql', 'information_schema', 'performance_schema', 'sys')
-          AND (NULLIF(TRIM(?), '') IS NULL OR FIND_IN_SET(T.TABLE_NAME, ?))
+          AND (NULLIF(TRIM(@table_names), '') IS NULL OR FIND_IN_SET(T.TABLE_NAME, @table_names))
           AND T.TABLE_TYPE = 'BASE TABLE'
       ORDER BY
           T.TABLE_SCHEMA, T.TABLE_NAME;
@@ -164,6 +165,7 @@ tools:
       - name: table_names
         type: string
         description: "Optional: A comma-separated list of table names. If empty, details for all tables in user-accessible schemas will be listed."
+        default: ""
 toolsets:
   cloud-sql-mysql-database-tools:
     - execute_sql


### PR DESCRIPTION
This PR consist of two fixes: 
1. Added `default` to table_names parameter since the default value is an empty string.
2. Update the sql statement for reusing parameter within the statement.

Fixes partial #877