### PR TITLE
docs: add llamaindex integration to js quickstart

### DIFF
--- a/docs/en/getting-started/local_quickstart_js.md
+++ b/docs/en/getting-started/local_quickstart_js.md
@@ -3,7 +3,7 @@ title: "JS Quickstart (Local)"
 type: docs
 weight: 3
 description: >
-  How to get started running Toolbox locally with [JavaScript](https://github.com/googleapis/mcp-toolbox-sdk-python), PostgreSQL, and orchestration frameworks such as [LangChain](https://js.langchain.com/docs/introduction/) and [GenkitJS](https://genkit.dev/docs/get-started/).
+  How to get started running Toolbox locally with [JavaScript](https://github.com/googleapis/mcp-toolbox-sdk-js), PostgreSQL, and orchestration frameworks such as [LangChain](https://js.langchain.com/docs/introduction/), [GenkitJS](https://genkit.dev/docs/get-started/), and [LlamaIndex](https://ts.llamaindex.ai/).
 ---
 
 ## Before you begin
@@ -489,6 +489,7 @@ import { createMemory, staticBlock, tool } from "llamaindex";
 import { ToolboxClient } from "@toolbox-sdk/core";
 
 const TOOLBOX_URL = "http://127.0.0.1:5000"; // Update if needed
+process.env.GOOGLE_API_KEY = 'your-api-key'; // Replace it with your API key
 
 const prompt = `
 
@@ -512,22 +513,19 @@ async function main() {
   // Connect to MCP Toolbox
   const client = new ToolboxClient(TOOLBOX_URL);
   const toolboxTools = await client.loadToolset("my-toolset");
-  const wrappedTools = toolboxTools.map((mcpTool) => {
+  const tools = toolboxTools.map((toolboxTool) => {
     return tool({
-      name: mcpTool.getName(),
-      description: mcpTool.getDescription(),
-      parameters: mcpTool.getParamSchema(),
-      execute: mcpTool,
+      name: toolboxTool.getName(),
+      description: toolboxTool.getDescription(),
+      parameters: toolboxTool.getParamSchema(),
+      execute: toolboxTool,
     });
   });
 
   // Initialize LLM
   const llm = gemini({
     model: GEMINI_MODEL.GEMINI_2_0_FLASH,
-    vertex: {
-      project: "my-project-id", // Replace with yours
-      location: "us-central1",
-    },
+    apiKey: process.env.GOOGLE_API_KEY,
   });
 
   const memory = createMemory({
@@ -540,7 +538,7 @@ async function main() {
 
   // Create the Agent
   const myAgent = agent({
-    tools: wrappedTools,
+    tools: tools,
     llm,
     memory,
     systemPrompt: prompt,
@@ -563,7 +561,7 @@ async function main() {
   console.log("Agent run finished.");
 }
 
-void main();
+main();
 
 {{< /tab >}}
 

--- a/docs/en/getting-started/local_quickstart_js.md
+++ b/docs/en/getting-started/local_quickstart_js.md
@@ -285,7 +285,7 @@ from Toolbox.
 1. In a new terminal, install the [SDK](https://www.npmjs.com/package/@toolbox-sdk/core).
 
     ```bash
-    npm install langchain @toolbox-sdk/core
+    npm install @toolbox-sdk/core
     ```
 
 1. Install other required dependencies

--- a/docs/en/getting-started/local_quickstart_js.md
+++ b/docs/en/getting-started/local_quickstart_js.md
@@ -297,6 +297,9 @@ npm install langchain @langchain/google-vertexai
 {{< tab header="GenkitJS" lang="bash" >}}
 npm install genkit @genkit-ai/vertexai
 {{< /tab >}}
+{{< tab header="LlamaIndex" lang="bash" >}}
+npm install llamaindex @llamaindex/google @llamaindex/workflow
+{{< /tab >}}
 {{< /tabpane >}}
 
 1. Create a new file named `hotelAgent.js` and copy the following code to create an agent:
@@ -477,6 +480,93 @@ async function run() {
 
 run();
 {{< /tab >}}
+
+{{< tab header="LlamaIndex" lang="js" >}}
+
+import { gemini, GEMINI_MODEL } from "@llamaindex/google";
+import { agent } from "@llamaindex/workflow";
+import { createMemory, staticBlock, tool } from "llamaindex";
+import { ToolboxClient } from "@toolbox-sdk/core";
+
+const TOOLBOX_URL = "http://127.0.0.1:5000"; // Update if needed
+
+const prompt = `
+
+You're a helpful hotel assistant. You handle hotel searching, booking and cancellations.
+When the user searches for a hotel, mention its name, id, location and price tier.
+Always mention hotel ids while performing any searches â€” this is very important for operations.
+For any bookings or cancellations, please provide the appropriate confirmation.
+Update check-in or check-out dates if mentioned by the user.
+Don't ask for confirmations from the user.
+
+`;
+
+const queries = [
+  "Find hotels in Basel with Basel in its name.",
+  "Can you book the Hilton Basel for me?",
+  "Oh wait, this is too expensive. Please cancel it and book the Hyatt Regency instead.",
+  "My check in dates would be from April 10, 2024 to April 19, 2024.",
+];
+
+async function main() {
+  // Connect to MCP Toolbox
+  const client = new ToolboxClient(TOOLBOX_URL);
+  const toolboxTools = await client.loadToolset("my-toolset");
+  const wrappedTools = toolboxTools.map((mcpTool) => {
+    return tool({
+      name: mcpTool.getName(),
+      description: mcpTool.getDescription(),
+      parameters: mcpTool.getParamSchema(),
+      execute: mcpTool,
+    });
+  });
+
+  // Initialize LLM
+  const llm = gemini({
+    model: GEMINI_MODEL.GEMINI_2_0_FLASH,
+    vertex: {
+      project: "my-project-id", // Replace with yours
+      location: "us-central1",
+    },
+  });
+
+  const memory = createMemory({
+    memoryBlocks: [
+      staticBlock({
+        content: prompt,
+      }),
+    ],
+  });
+
+  // Create the Agent
+  const myAgent = agent({
+    tools: wrappedTools,
+    llm,
+    memory,
+    systemPrompt: prompt,
+  });
+
+  for (const query of queries) {
+    const result = await myAgent.run(query);
+    const output = result.data.result;
+
+    console.log(`\nUser: ${query}`);
+    if (typeof output === "string") {
+      console.log(output.trim());
+    } else if (typeof output === "object" && "text" in output) {
+      console.log(output.text.trim());
+    } else {
+      console.log(JSON.stringify(output));
+    }
+  }
+  //You may observe some extra logs during execution due to the run method provided by Llama.
+  console.log("Agent run finished.");
+}
+
+void main();
+
+{{< /tab >}}
+
 {{< /tabpane >}}
 
 1. Run your agent, and observe the results:


### PR DESCRIPTION
### Description

Enhance the [JavaScript Quickstart](https://googleapis.github.io/genai-toolbox/getting-started/local_quickstart_js/) by adding a new tab dedicated to integrating the MCP Toolbox with LlamaIndex. This provides users with a direct, runnable example of how to utilize Toolbox's capabilities within a LlamaIndex-powered LLM agent for hotel search and booking operations.

The changes include:
- Addition of a new `LlamaIndex` tab in `docs/quickstarts/js-local.md`.
- Corresponding `hotelAgent.js` code snippet for LlamaIndex integration.

### Related Issue

This PR addresses and resolves #930.
