### PR TITLE
fix: fix document preview pipeline for forked PRs

### DIFF
--- a/.github/workflows/docs_preview_deploy.yaml
+++ b/.github/workflows/docs_preview_deploy.yaml
@@ -51,6 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          # Checkout the PR's HEAD commit (supports forks).
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
 

--- a/.github/workflows/docs_preview_deploy.yaml
+++ b/.github/workflows/docs_preview_deploy.yaml
@@ -51,6 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo


### PR DESCRIPTION
The checkout actions uses ref as `github.sha` by default. For forked repos, this refers to the last commit on the main branch ([ref](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#fork)).

This means that the docs preview pipeline when run on forked PRs does not allow us to preview changes made in the PR.

`github.event.pull_request.head.sha` allows to to checkout the latest commit on the forked PR.