### PR TITLE
fix(tools/mysqlsql): unmarshal json data from database during invoke

### DIFF
--- a/internal/tools/mysql/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysql/mysqlsql/mysqlsql.go
@@ -17,6 +17,7 @@ package mysqlsql
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 
 	yaml "github.com/goccy/go-yaml"
@@ -177,6 +178,14 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error)
 			// mysql driver return []uint8 type for "TEXT", "VARCHAR", and "NVARCHAR"
 			// we'll need to cast it back to string
 			switch colTypes[i].DatabaseTypeName() {
+			case "JSON":
+				// unmarshal JSON data before storing to prevent double marshaling
+				var unmarshaledData any
+				err := json.Unmarshal(val.([]byte), &unmarshaledData)
+				if err != nil {
+					return nil, fmt.Errorf("unable to unmarshal json data %s", val)
+				}
+				vMap[name] = unmarshaledData
 			case "TEXT", "VARCHAR", "NVARCHAR":
 				vMap[name] = string(val.([]byte))
 			default:


### PR DESCRIPTION
mysql driver return []uint8 types for "JSON", hence we will need to cast it.

Toolbox will unmarshal JSON data retrieved from database during invocation. If directly convert results into string, it will be marshaled again when returning results to the user (causing double marshaling). 

Fixes #840