### PR TITLE
chore: remove sources and authServices links

### DIFF
--- a/internal/server/static/css/style.css
+++ b/internal/server/static/css/style.css
@@ -92,7 +92,7 @@ body {
 
 .nav-logo {
     width: 90%;
-    margin-bottom: 20px;
+    margin-bottom: 40px;
     flex-shrink: 0;
 
     img {

--- a/internal/server/static/js/navbar.js
+++ b/internal/server/static/js/navbar.js
@@ -30,8 +30,8 @@ function renderNavbar(containerId, activePath) {
                 <img src="/ui/assets/mcptoolboxlogo.png" alt="App Logo">
             </div>
             <ul>
-                <li><a href="/ui/sources">Sources</a></li>
-                <li><a href="/ui/authservices">Auth Services</a></li>
+                <!--<li><a href="/ui/sources">Sources</a></li>-->
+                <!--<li><a href="/ui/authservices">Auth Services</a></li>-->
                 <li><a href="/ui/tools">Tools</a></li>
                 <li><a href="/ui/toolsets">Toolsets</a></li>
             </ul>


### PR DESCRIPTION
Remove links for `sources` and `authServices` tab from navbar.

Inspecting sources and auth services will not be allowed through
 Toolbox UI due to lack of existing endpoints, proper handling is
awaiting Toolbox Control Plane implementation.