### PR TITLE
docs: add shortcode for including file regions

### DIFF
--- a/.hugo/layouts/shortcodes/regionInclude.html
+++ b/.hugo/layouts/shortcodes/regionInclude.html
@@ -1,8 +1,8 @@
 {{/*
   snippet.html
   Usage:
-    {{< snippet "filename.md" "region_name" >}}
-    {{< snippet "filename.python" "region_name" "python" >}}
+    {{< regionInclude "filename.md" "region_name" >}}
+    {{< regionInclude "filename.python" "region_name" "python" >}}
 */}}
 
 {{ $file := .Get 0 }}

--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -18,13 +18,13 @@ This guide assumes you have already done the following:
 1. Installed [PostgreSQL 16+ and the `psql` client][install-postgres].
 
 ### Cloud Setup (Optional)
-{{< snippet "quickstart/shared/cloud_setup.md" "cloud_setup" >}}
+{{< regionInclude "quickstart/shared/cloud_setup.md" "cloud_setup" >}}
 
 ## Step 1: Set up your database
-{{< snippet "quickstart/shared/database_setup.md" "database_setup" >}}
+{{< regionInclude "quickstart/shared/database_setup.md" "database_setup" >}}
 
 ## Step 2: Install and configure Toolbox
-{{< snippet "quickstart/shared/configure_toolbox.md" "configure_toolbox" >}}
+{{< regionInclude "quickstart/shared/configure_toolbox.md" "configure_toolbox" >}}
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/docs/en/getting-started/local_quickstart_go.md
+++ b/docs/en/getting-started/local_quickstart_go.md
@@ -17,13 +17,13 @@ This guide assumes you have already done the following:
 [install-postgres]: https://www.postgresql.org/download/
 
 ### Cloud Setup (Optional)
-{{< snippet "quickstart/shared/cloud_setup.md" "cloud_setup" >}}
+{{< regionInclude "quickstart/shared/cloud_setup.md" "cloud_setup" >}}
 
 ## Step 1: Set up your database
-{{< snippet "quickstart/shared/database_setup.md" "database_setup" >}}
+{{< regionInclude "quickstart/shared/database_setup.md" "database_setup" >}}
 
 ## Step 2: Install and configure Toolbox
-{{< snippet "quickstart/shared/configure_toolbox.md" "configure_toolbox" >}}
+{{< regionInclude "quickstart/shared/configure_toolbox.md" "configure_toolbox" >}}
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/docs/en/getting-started/local_quickstart_js.md
+++ b/docs/en/getting-started/local_quickstart_js.md
@@ -17,13 +17,13 @@ This guide assumes you have already done the following:
 [install-postgres]: https://www.postgresql.org/download/
 
 ### Cloud Setup (Optional)
-{{< snippet "quickstart/shared/cloud_setup.md" "cloud_setup" >}}
+{{< regionInclude "quickstart/shared/cloud_setup.md" "cloud_setup" >}}
 
 ## Step 1: Set up your database
-{{< snippet "quickstart/shared/database_setup.md" "database_setup" >}}
+{{< regionInclude "quickstart/shared/database_setup.md" "database_setup" >}}
 
 ## Step 2: Install and configure Toolbox
-{{< snippet "quickstart/shared/configure_toolbox.md" "configure_toolbox" >}}
+{{< regionInclude "quickstart/shared/configure_toolbox.md" "configure_toolbox" >}}
 
 ## Step 3: Connect your agent to Toolbox
 

--- a/docs/en/getting-started/quickstart/shared/cloud_setup.md
+++ b/docs/en/getting-started/quickstart/shared/cloud_setup.md
@@ -1,3 +1,4 @@
+<!-- This file has been used in local_quickstart.md, local_quickstart_go.md & local_quickstart_js.md -->
 <!-- [START cloud_setup] -->
 If you plan to use **Google Cloud’s Vertex AI** with your agent (e.g., using
 `vertexai=True` or a Google GenAI model), follow these one-time setup steps for

--- a/docs/en/getting-started/quickstart/shared/configure_toolbox.md
+++ b/docs/en/getting-started/quickstart/shared/configure_toolbox.md
@@ -1,3 +1,4 @@
+<!-- This file has been used in local_quickstart.md, local_quickstart_go.md & local_quickstart_js.md -->
 <!-- [START configure_toolbox] -->
 In this section, we will download Toolbox, configure our tools in a
 `tools.yaml`, and then run the Toolbox server.

--- a/docs/en/getting-started/quickstart/shared/database_setup.md
+++ b/docs/en/getting-started/quickstart/shared/database_setup.md
@@ -1,3 +1,4 @@
+<!-- This file has been used in local_quickstart.md, local_quickstart_go.md & local_quickstart_js.md -->
 <!-- [START database_setup] -->
 In this section, we will create a database, insert some data that needs to be
 accessed by our agent, and create a database user for Toolbox to connect with.


### PR DESCRIPTION
Introduces a new Hugo shortcode, `includeRegion`, to allow embedding specific, tagged regions from source files directly into Markdown content.

This helps maintain a single source of truth for code snippets and other repeated content, such as setup instructions, preventing duplication and simplifying updates across multiple quickstart guides.

Demo PR: https://github.com/googleapis/genai-toolbox/pull/1179