### PR TITLE
feat(ui): inspect sources and auth services from Toolbox UI

### DIFF
--- a/internal/server/static/authServices.html
+++ b/internal/server/static/authServices.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AuthServices View</title>
+    <link rel="stylesheet" href="/ui/css/style.css">
+</head>
+<body>
+    <div id="navbar-container" data-active-nav="/ui/authServices"></div>
+
+    <aside class="second-nav">
+        <h4>My Sources</h4>
+        <div id="secondary-panel-content">
+            <p>Fetching Auth Services...</p>
+        </div>
+    </aside>
+
+    <div id="main-content-container"></div>
+
+    <script type="module" src="/ui/js/authServices.js"></script>
+    <script src="/ui/js/navbar.js"></script>
+    <script src="/ui/js/mainContent.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const navbarContainer = document.getElementById('navbar-container');
+            const activeNav = navbarContainer.getAttribute('data-active-nav');
+            renderNavbar('navbar-container', activeNav);
+            renderMainContent('main-content-container', 'auth-service-info-area')
+        });
+    </script>
+</body>
+</html>

--- a/internal/server/static/authServices.html
+++ b/internal/server/static/authServices.html
@@ -10,7 +10,7 @@
     <div id="navbar-container" data-active-nav="/ui/authServices"></div>
 
     <aside class="second-nav">
-        <h4>My Sources</h4>
+        <h4>My Auth Services</h4>
         <div id="secondary-panel-content">
             <p>Fetching Auth Services...</p>
         </div>

--- a/internal/server/static/css/style.css
+++ b/internal/server/static/css/style.css
@@ -174,19 +174,7 @@ body {
     display: inline-flex;
 }
 
-.btn--setup-gis {
-    background-color: white;
-    color: var(--text-primary-gray);
-    border: 2px solid var(--text-primary-gray);
-}
-
-.btn--externalDocs {
-    background-color: var(--button-secondary);
-    text-decoration: none;
-    display: inline-flex;
-}
-
-.tool-button {
+.second-nav-choice {
     display: flex;
     align-items: center;
     padding: 12px;
@@ -747,4 +735,57 @@ body {
         font-size: 90%;
         vertical-align: baseline;
     }
+}
+
+.item-details-box {
+    margin-top: 20px;
+    overflow-x: auto;
+
+    h5 {
+        color: var(--toolbox-blue);
+        margin-top: 0;
+        margin-bottom: 10px;
+        font-weight: bold;
+    }
+}
+
+.item-details-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.item-detail-entry {
+    display: grid;
+    grid-template-columns: minmax(120px, auto) 1fr; 
+    gap: 6px; 
+    padding: 4px 4px; 
+    border-bottom: 1px solid #f0f0f0; 
+    align-items: start;
+
+    &:last-child {
+        border-bottom: none;
+    }
+}
+
+.item-detail-key {
+    font-weight: bolder; 
+    color: var(--toolbox-blue);
+    padding: 4px 6px;
+    padding-right: 8px;
+}
+
+.item-detail-value {
+    color: var(--text-primary-gray);
+    padding: 4px 6px;
+}
+
+.item-details-box.error p {
+    color: #d93025; 
+    font-style: italic;
+}
+
+dl {
+    margin-block-start: 0;
+    margin-block-end: 0;
 }

--- a/internal/server/static/css/style.css
+++ b/internal/server/static/css/style.css
@@ -174,6 +174,18 @@ body {
     display: inline-flex;
 }
 
+.btn--setup-gis {
+    background-color: white;
+    color: var(--text-primary-gray);
+    border: 2px solid var(--text-primary-gray);
+}
+
+.btn--externalDocs {
+    background-color: var(--button-secondary);
+    text-decoration: none;
+    display: inline-flex;
+}
+
 .tool-button {
     display: flex;
     align-items: center;

--- a/internal/server/static/js/authServices.js
+++ b/internal/server/static/js/authServices.js
@@ -15,13 +15,13 @@
 import { loadItems } from './resourceDisplay.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-    const sourceListArea = document.getElementById('secondary-panel-content');
-    const sourceInfoArea = document.getElementById('source-info-area');
+    const authServiceListArea = document.getElementById('secondary-panel-content');
+    const authServiceInfoArea = document.getElementById('auth-service-info-area');
 
-    if (!sourceListArea || !sourceInfoArea) {
+    if (!authServiceListArea || !authServiceInfoArea) {
         console.error('Required DOM elements not found.');
         return;
     }
 
-    loadItems('sources', sourceListArea, sourceInfoArea);
+    loadItems('authservices', authServiceListArea, authServiceInfoArea);
 });

--- a/internal/server/static/js/loadTools.js
+++ b/internal/server/static/js/loadTools.js
@@ -67,7 +67,7 @@ function renderToolList(apiResponse, secondNavContent, toolDisplayArea) {
         const button = document.createElement('button');
         button.textContent = toolName;
         button.dataset.toolname = toolName;
-        button.classList.add('tool-button');
+        button.classList.add('second-nav-choice');
         button.addEventListener('click', (event) => handleToolClick(event, secondNavContent, toolDisplayArea));
         li.appendChild(button);
         ul.appendChild(li);
@@ -84,7 +84,7 @@ function renderToolList(apiResponse, secondNavContent, toolDisplayArea) {
 function handleToolClick(event, secondNavContent, toolDisplayArea) {
     const toolName = event.target.dataset.toolname;
     if (toolName) {
-        const currentActive = secondNavContent.querySelector('.tool-button.active');
+        const currentActive = secondNavContent.querySelector('.second-nav-choice.active');
         if (currentActive) {
             currentActive.classList.remove('active');
         }

--- a/internal/server/static/js/navbar.js
+++ b/internal/server/static/js/navbar.js
@@ -30,7 +30,7 @@ function renderNavbar(containerId, activePath) {
                 <img src="/ui/assets/mcptoolboxlogo.png" alt="App Logo">
             </div>
             <ul>
-                <!--<li><a href="/ui/sources">Sources</a></li>-->
+                <li><a href="/ui/sources">Sources</a></li>
                 <!--<li><a href="/ui/authservices">Auth Services</a></li>-->
                 <li><a href="/ui/tools">Tools</a></li>
                 <li><a href="/ui/toolsets">Toolsets</a></li>

--- a/internal/server/static/js/navbar.js
+++ b/internal/server/static/js/navbar.js
@@ -31,7 +31,7 @@ function renderNavbar(containerId, activePath) {
             </div>
             <ul>
                 <li><a href="/ui/sources">Sources</a></li>
-                <!--<li><a href="/ui/authservices">Auth Services</a></li>-->
+                <li><a href="/ui/authservices">Auth Services</a></li>
                 <li><a href="/ui/tools">Tools</a></li>
                 <li><a href="/ui/toolsets">Toolsets</a></li>
             </ul>

--- a/internal/server/static/js/resourceDisplay.js
+++ b/internal/server/static/js/resourceDisplay.js
@@ -1,0 +1,254 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const MOCK_SOURCE_MANIFEST = {
+    "sources": {
+        "my-alloydb-pg-source": {
+            kind: "alloydb-postgres",
+            project: "my-project-id",
+            region: "us-central1",
+            cluster: "my-cluster",
+            instance: "my-instance",
+            database: "my_db",
+            ipType: "public"
+        },
+        "my-bigtable-source": {
+            kind: "bigtable",
+            project: "my-project-id",
+            instance: "test-instance"
+        },
+    }
+};
+
+async function getMockSourceListData() {
+    console.warn(`[MOCK] Returning mock data for all sources`);
+    return MOCK_SOURCE_MANIFEST;
+}
+
+async function getMockSourceDetailsData(sourceName) {
+    console.warn(`[MOCK] Returning mock data for source details: ${sourceName}`);
+    const SOURCE_DATA = MOCK_SOURCE_MANIFEST.sources[sourceName];
+    if (SOURCE_DATA) {
+        return { "sources": { [sourceName]: SOURCE_DATA } };
+    } else {
+        throw new Error(`Mock Source "${sourceName}" not found`);
+    }
+}
+
+const MOCK_AUTH_SERVICE_MANIFEST = {
+    "authservices": {
+        "my-auth-service-1": {
+            kind: "google oauth2",
+        },
+        "another-auth": {
+            kind: "other",
+        }
+    }
+};
+
+async function getMockAuthServiceListData() {
+    console.warn(`[MOCK] Returning mock data for all authservices`);
+    return MOCK_AUTH_SERVICE_MANIFEST;
+}
+
+async function getMockAuthServiceDetailsData(authServiceName) {
+    console.warn(`[MOCK] Returning mock data for auth service details: ${authServiceName}`);
+    const SERVICE_DATA = MOCK_AUTH_SERVICE_MANIFEST.authservices[authServiceName];
+    if (SERVICE_DATA) {
+        return { "authservices": { [authServiceName]: SERVICE_DATA } };
+    } else {
+        throw new Error(`Mock Auth Service "${authServiceName}" not found`);
+    }
+}
+
+const itemConfigs = {
+    sources: {
+        getListData: getMockSourceListData, // replace with real API call to GET all sources
+        getDetailsData: getMockSourceDetailsData, // replace with real API call to GET specific source
+        listKey: 'sources',
+        nameAttribute: 'data-itemname',
+        displayName: 'Source',
+        singularName: 'source',
+    },
+    authservices: {
+        getListData: getMockAuthServiceListData, // replace with real API call to GET all auth services
+        getDetailsData: getMockAuthServiceDetailsData, //replace with real API call to get specific auth service
+        listKey: 'authservices',
+        nameAttribute: 'data-itemname',
+        displayName: 'Auth Service',
+        singularName: 'authservice',
+    }
+};
+
+/**
+ * Renders the details of an item.
+ * @param {string} itemName - The name of the item.
+ * @param {!Object<string, *>} itemDetails - The object containing the item's attributes.
+ * @param {!HTMLElement} displayArea - The HTML element to render the details into.
+ * @param {string} displayName - The display name of the item type.
+ */
+function displayItemDetails(itemName, itemDetails, displayArea, displayName) {
+    displayArea.innerHTML = '';
+
+    const title = document.createElement('h3');
+    title.textContent = `${displayName}: ${itemName}`;
+    displayArea.appendChild(title);
+
+    const entries = Object.entries(itemDetails);
+    if (entries.length === 0) {
+        const para = document.createElement('p');
+        para.textContent = 'No details available.';
+        displayArea.appendChild(para);
+        return;
+    }
+
+    const ul = document.createElement('ul');
+    ul.classList.add('resource-details-list');
+
+    for (const [key, value] of entries) {
+        const li = document.createElement('li');
+        li.classList.add('resource-detail-item');
+
+        const keyDiv = document.createElement('div');
+        keyDiv.classList.add('key');
+        keyDiv.textContent = key;
+        li.appendChild(keyDiv);
+
+        const valueDiv = document.createElement('div');
+        valueDiv.classList.add('value');
+        valueDiv.textContent = String(value);
+        li.appendChild(valueDiv);
+
+        ul.appendChild(li);
+    }
+    displayArea.appendChild(ul);
+}
+
+/**
+ * Fetches and displays details for a specific item.
+ * @param {string} itemType - 'sources' or 'authservices'.
+ * @param {string} itemName - The name of the item.
+ * @param {!HTMLElement} displayArea - The element to render details into.
+ * @param {!Object} config - The configuration object for the item type.
+ */
+async function fetchItemDetails(itemType, itemName, displayArea, config) {
+    displayArea.innerHTML = `<p>Loading details for ${itemName}...</p>`;
+    try {
+        const apiResponse = await config.getDetailsData(itemName);
+        const itemDetails = apiResponse && apiResponse[config.listKey] ? apiResponse[config.listKey][itemName] : null;
+
+        if (!itemDetails) {
+            throw new Error(`${config.displayName} "${itemName}" data not found in API response.`);
+        }
+
+        displayItemDetails(itemName, itemDetails, displayArea, config.displayName);
+        console.log(`${config.displayName} details:`, itemDetails);
+
+    } catch (error) {
+        console.error(`Failed to load details for ${config.singularName} "${itemName}":`, error);
+        displayArea.innerHTML = `<p class="error">Failed to load details for ${itemName}: ${error.message}</p>`;
+    }
+}
+
+/**
+ * Handles the click event on an item button.
+ * @param {!Event} event - The click event object.
+ * @param {string} itemType - 'sources' or 'authservices'.
+ * @param {!HTMLElement} listContainer - The parent element containing the item buttons.
+ * @param {!HTMLElement} displayArea - The HTML element where item details will be shown.
+ * @param {!Object} config - The configuration object for the item type.
+ */
+function handleItemClick(event, itemType, listContainer, displayArea, config) {
+    const itemName = event.target.getAttribute(config.nameAttribute);
+    if (itemName) {
+        const currentActive = listContainer.querySelector('.second-nav-choice.active');
+        if (currentActive) currentActive.classList.remove('active');
+        event.target.classList.add('active');
+        fetchItemDetails(itemType, itemName, displayArea, config);
+    }
+}
+
+/**
+ * Renders the list of items as buttons.
+ * @param {string} itemType - 'sources' or 'authservices'.
+ * @param {?Object} apiResponse - The API response object.
+ * @param {!HTMLElement} listContainer - The element to render the list into.
+ * @param {!HTMLElement} displayArea - The element for displaying item details.
+ * @param {!Object} config - The configuration object for the item type.
+ */
+function renderList(itemType, apiResponse, listContainer, displayArea, config) {
+    listContainer.innerHTML = '';
+
+    const itemsObject = apiResponse ? apiResponse[config.listKey] : null;
+
+    if (!itemsObject || typeof itemsObject !== 'object' || itemsObject === null) {
+        console.error(`Error: Expected an object with a "${config.listKey}" property, but received:`, apiResponse);
+        listContainer.textContent = `Error: Invalid response format from ${config.displayName} API.`;
+        return;
+    }
+
+    const itemNames = Object.keys(itemsObject);
+
+    if (itemNames.length === 0) {
+        listContainer.textContent = `No ${config.displayName}s found.`;
+        return;
+    }
+
+    const ul = document.createElement('ul');
+    itemNames.forEach(itemName => {
+        const li = document.createElement('li');
+        const button = document.createElement('button');
+        button.textContent = itemName;
+        button.setAttribute(config.nameAttribute, itemName);
+        button.classList.add('second-nav-choice');
+        button.addEventListener('click', (event) => handleItemClick(event, itemType, listContainer, displayArea, config));
+        li.appendChild(button);
+        ul.appendChild(li);
+    });
+    listContainer.appendChild(ul);
+}
+
+/**
+ * Fetches and renders a list of items (sources or authservices).
+ * @param {string} itemType - 'sources' or 'authservices'.
+ * @param {!HTMLElement} listContainer - Element to render the list into.
+ * @param {!HTMLElement} displayArea - Element to display item details.
+ * @returns {!Promise<void>}
+ */
+async function loadItems(itemType, listContainer, displayArea) {
+    const config = itemConfigs[itemType];
+    if (!config) {
+        console.error(`Unknown item type: ${itemType}`);
+        if (listContainer) {
+            listContainer.innerHTML = `<p class="error">Configuration error.</p>`;
+        }
+        return;
+    }
+
+    if (!listContainer || !displayArea) {
+        console.error("List container or display area not provided to loadItems");
+        return;
+    }
+
+    listContainer.innerHTML = `<p>Fetching ${config.displayName}s...</p>`;
+    try {
+        const apiResponse = await config.getListData();
+        renderList(itemType, apiResponse, listContainer, displayArea, config);
+    } catch (error) {
+        console.error(`Failed to load ${config.displayName}s:`, error);
+        listContainer.innerHTML = `<p class="error">Failed to load ${config.displayName}s: <pre><code>${error}</code></pre></p>`;
+    }
+}
+
+export { loadItems };

--- a/internal/server/static/js/resourceDisplay.js
+++ b/internal/server/static/js/resourceDisplay.js
@@ -98,41 +98,58 @@ const itemConfigs = {
  * @param {!HTMLElement} displayArea - The HTML element to render the details into.
  * @param {string} displayName - The display name of the item type.
  */
-function displayItemDetails(itemName, itemDetails, displayArea, displayName) {
+function displayItemDetails(itemName, itemDetails, displayArea) {
     displayArea.innerHTML = '';
 
-    const title = document.createElement('h3');
-    title.textContent = `${displayName}: ${itemName}`;
-    displayArea.appendChild(title);
+    const container = document.createElement('div');
+    container.className = 'tool-box item-details-box';
+
+    const dl = document.createElement('dl');
+    dl.classList.add('item-details-list');
+
+    // add the name (key in the original json response) as the first key-value pair
+    const nameEntryDiv = document.createElement('div');
+    nameEntryDiv.classList.add('item-detail-entry');
+
+    const nameDt = document.createElement('dt');
+    nameDt.classList.add('item-detail-key');
+    nameDt.textContent = 'name';
+    nameEntryDiv.appendChild(nameDt);
+
+    const nameDd = document.createElement('dd');
+    nameDd.classList.add('item-detail-value');
+    nameDd.textContent = itemName;
+    nameEntryDiv.appendChild(nameDd);
+
+    dl.appendChild(nameEntryDiv);
 
     const entries = Object.entries(itemDetails);
-    if (entries.length === 0) {
+    if (entries.length === 0 && !itemName) { 
         const para = document.createElement('p');
         para.textContent = 'No details available.';
-        displayArea.appendChild(para);
+        container.appendChild(para);
+        displayArea.appendChild(container);
         return;
     }
 
-    const ul = document.createElement('ul');
-    ul.classList.add('resource-details-list');
-
     for (const [key, value] of entries) {
-        const li = document.createElement('li');
-        li.classList.add('resource-detail-item');
+        const entryDiv = document.createElement('div');
+        entryDiv.classList.add('item-detail-entry');
 
-        const keyDiv = document.createElement('div');
-        keyDiv.classList.add('key');
-        keyDiv.textContent = key;
-        li.appendChild(keyDiv);
+        const dt = document.createElement('dt');
+        dt.classList.add('item-detail-key');
+        dt.textContent = key;
+        entryDiv.appendChild(dt);
 
-        const valueDiv = document.createElement('div');
-        valueDiv.classList.add('value');
-        valueDiv.textContent = String(value);
-        li.appendChild(valueDiv);
+        const dd = document.createElement('dd');
+        dd.classList.add('item-detail-value');
+        dd.textContent = String(value);
+        entryDiv.appendChild(dd);
 
-        ul.appendChild(li);
+        dl.appendChild(entryDiv);
     }
-    displayArea.appendChild(ul);
+    container.appendChild(dl);
+    displayArea.appendChild(container);
 }
 
 /**
@@ -152,7 +169,7 @@ async function fetchItemDetails(itemType, itemName, displayArea, config) {
             throw new Error(`${config.displayName} "${itemName}" data not found in API response.`);
         }
 
-        displayItemDetails(itemName, itemDetails, displayArea, config.displayName);
+        displayItemDetails(itemName, itemDetails, displayArea);
         console.log(`${config.displayName} details:`, itemDetails);
 
     } catch (error) {

--- a/internal/server/static/js/sources.js
+++ b/internal/server/static/js/sources.js
@@ -1,0 +1,261 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+document.addEventListener('DOMContentLoaded', () => {
+    const sourceInfoArea = document.getElementById('source-info-area');
+    const secondaryPanelContent = document.getElementById('secondary-panel-content');
+
+    if (!secondaryPanelContent || !sourceInfoArea) {
+        console.error('Required DOM elements not found.');
+        return;
+    }
+
+    loadSources(secondaryPanelContent, sourceInfoArea)
+});
+
+const MOCK_SOURCE_MANIFEST = {
+    "sources": {
+        "my-alloydb-pg-source": {
+            kind: "alloydb-postgres",
+            project: "my-project-id",
+            region: "us-central1",
+            cluster: "my-cluster",
+            instance: "my-instance",
+            database: "my_db",
+            ipType: "public"
+        },
+        "my-bigtable-source": {
+            kind: "bigtable",
+            project: "my-project-id",
+            instance: "test-instance"
+        },
+        "my-couchbase-instance": {
+            kind: "couchbase",
+            connectionString: "couchebase://localhost:8091",
+            bucket: "travel-sample",
+            scope: "inventory"
+        }
+    }
+};
+
+/**
+ * Returns mock data for the source list.
+ * @returns {!Promise<Object>} Mocked API response data.
+ */
+async function getMockSourceListData() {
+    console.warn(`[MOCK] Returning mock data for all sources`);
+    return MOCK_SOURCE_MANIFEST;
+}
+
+/**
+ * Returns mock data for source details in the specified JSON format.
+ * @param {string} sourceName The name of the source.
+ * @returns {!Promise<Object>} Mocked API response data.
+ */
+async function getMockSourceDetailsData(sourceName) {
+    console.warn(`[MOCK] Returning mock data for source details: ${sourceName}`);
+    const SOURCE_DATA = MOCK_SOURCE_MANIFEST.sources[sourceName]; 
+    if (SOURCE_DATA) {
+        return {
+            "sources": {
+                [sourceName]: SOURCE_DATA
+            }
+        };
+    } else {
+        throw new Error(`Mock Source "${sourceName}" not found`);
+    }
+}
+
+/**
+ * Fetches a source list from the /api/sources endpoint and initiates creating the source list.
+ * @param {!HTMLElement} secondNavContent The HTML element where the source list will be rendered.
+ * @param {!HTMLElement} displayArea The HTML element where the details of a selected source will be displayed.
+ * @returns {!Promise<void>} A promise that resolves when the sources are loaded and rendered, or rejects on error.
+ */
+export async function loadSources(secondNavContent, displayArea) {
+    secondNavContent.innerHTML = '<p>Fetching sources...</p>';
+    try {
+        // MOCK VERSION OF API CALL - GET ALL SOURCES
+        const apiResponse = await getMockSourceListData();
+
+        // REAL API CALL - GET ALL SOURCES
+        // const response = await fetch(`/api/sources/`);
+        // if (!response.ok) {
+        //     throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`);
+        // }
+        // const apiResponse = await response.json();
+
+        renderSourceList(apiResponse, secondNavContent, displayArea);
+    } catch (error) {
+        console.error('Failed to load sources:', error);
+        secondNavContent.innerHTML = `<p class="error">Failed to load sources: <pre><code>${error}</code></pre></p>`;
+    }
+}
+
+/**
+ * Renders the list of sources as buttons within the provided HTML element.
+ * @param {?{sources: ?Object<string,*>} } apiResponse The API response object containing the sources.
+ * @param {!HTMLElement} secondNavContent The HTML element to render the source list into.
+ * @param {!HTMLElement} displayArea The HTML element for displaying source details.
+ */
+function renderSourceList(apiResponse, secondNavContent, displayArea) {
+    secondNavContent.innerHTML = '';
+    console.log(apiResponse)
+    if (!apiResponse || typeof apiResponse.sources !== 'object' || apiResponse.sources === null) {
+        console.error('Error: Expected an object with a "sources" property, but received:', apiResponse);
+        secondNavContent.textContent = 'Error: Invalid response format from sources API.';
+        return;
+    }
+
+    const sourcesObject = apiResponse.sources;
+    const sourceNames = Object.keys(sourcesObject);
+
+    if (sourceNames.length === 0) {
+        secondNavContent.textContent = 'No sources found.';
+        return;
+    }
+
+    const ul = document.createElement('ul');
+    sourceNames.forEach(sourceName => {
+        const li = document.createElement('li');
+        const button = document.createElement('button');
+        button.textContent = sourceName;
+        button.dataset.sourcename = sourceName;
+        button.classList.add('second-nav-choice');
+        button.addEventListener('click', (event) => handleSourceClick(event, secondNavContent, displayArea));
+        li.appendChild(button);
+        ul.appendChild(li);
+    });
+    secondNavContent.appendChild(ul);
+}
+
+/**
+ * Handles the click event on a source button.
+ * @param {!Event} event The click event object.
+ * @param {!HTMLElement} secondNavContent The parent element containing the source buttons.
+ * @param {!HTMLElement} displayArea The HTML element where source details will be shown.
+ */
+function handleSourceClick(event, secondNavContent, displayArea) {
+    const sourceName = event.target.dataset.sourcename;
+    if (sourceName) {
+        const currentActive = secondNavContent.querySelector('.second-nav-choice.active'); 
+        if (currentActive) currentActive.classList.remove('active');
+        event.target.classList.add('active');
+        fetchSourceDetails(sourceName, displayArea);
+    }
+}
+
+/**
+ * Fetches and displays details for a specific source.
+ * @param {string} sourceName The name of the source.
+ * @param {!HTMLElement} displayArea The element to render details into.
+ */
+async function fetchSourceDetails(sourceName, displayArea) {
+
+    displayArea.innerHTML = `<p>Loading details for ${sourceName}...</p>`;
+    try {
+        // MOCK VERSION OF API CALL - GET SPECIFIC SOURCES BY NAME
+        const apiResponse = await getMockSourceDetailsData(sourceName);
+
+        // REAL API CALL - GET SPECIFIC SOURCES BY NAME
+        // const response = await fetch(`/api/source/${encodeURIComponent(sourceName)}`, { signal });
+        // if (!response.ok) {
+        //     throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`);
+        // }
+        // const apiResponse = await response.json();
+
+        // Adjusted check for the new structure
+        if (!apiResponse.sources || !apiResponse.sources[sourceName]) {
+            throw new Error(`Source "${sourceName}" data not found in API response.`);
+        }
+
+        const sourceDetails = apiResponse.sources[sourceName]; 
+        displaySourceDetails(sourceName, sourceDetails, displayArea);
+        console.log("Source details:", sourceDetails);
+
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.debug("Source detail fetch aborted.");
+        } else {
+            console.error(`Failed to load details for source "${sourceName}":`, error);
+            displayArea.innerHTML = `<p class="error">Failed to load details for ${sourceName}: ${error.message}</p>`;
+        }
+    }
+}
+
+/**
+ * Renders the details of a source manifest in a user-friendly format.
+ * @param {string} sourceName The name of the source.
+ * @param {!Object<string, *>} sourceDetails The object containing the source's attributes.
+ * @param {!HTMLElement} displayArea The HTML element to render the details into.
+ */
+function displaySourceDetails(sourceName, sourceDetails, displayArea) {
+    displayArea.innerHTML = ''; 
+
+    const title = document.createElement('h3');
+    const entries = Object.entries(sourceDetails);
+
+    title.textContent = `${sourceName}:`;
+    displayArea.appendChild(title);
+
+    if (entries.length === 0) {
+        const para = document.createElement('p');
+        para.textContent = 'No details available.';
+        displayArea.appendChild(para);
+        return;
+    }
+
+    // SINGLE LIST
+
+    // const ul = document.createElement('ul');
+    // ul.classList.add('source-details-list');
+
+    // for (const [key, value] of entries) {
+    //     const li = document.createElement('li');
+    //     const keyElement = document.createElement('strong');
+    //     const valueElement = document.createElement('span');
+
+    //     li.classList.add('source-detail-item');
+    //     keyElement.textContent = `${key}: `;
+    //     keyElement.classList.add('key')
+    //     li.appendChild(keyElement);
+    //     valueElement.textContent = String(value);
+    //     valueElement.classList.add('value')
+    //     li.appendChild(valueElement);
+    //     ul.appendChild(li);
+    // }
+    // displayArea.appendChild(ul);
+
+    // DOUBLE LIST
+    const ul = document.createElement('ul');
+    ul.classList.add('source-details-list');
+
+    for (const [key, value] of entries) {
+        const li = document.createElement('li');
+        li.classList.add('source-detail-item');
+
+        const keyDiv = document.createElement('div');
+        keyDiv.classList.add('key');
+        keyDiv.textContent = key;
+        li.appendChild(keyDiv);
+
+        const valueDiv = document.createElement('div');
+        valueDiv.classList.add('value');
+        valueDiv.textContent = String(value);
+        li.appendChild(valueDiv);
+
+        ul.appendChild(li);
+    }
+    displayArea.appendChild(ul);
+}

--- a/internal/server/static/sources.html
+++ b/internal/server/static/sources.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sources View</title>
+    <link rel="stylesheet" href="/ui/css/style.css">
+</head>
+<body>
+    <div id="navbar-container" data-active-nav="/ui/sources"></div>
+
+    <aside class="second-nav">
+        <h4>My Sources</h4>
+        <div id="secondary-panel-content">
+            <p>Fetching sources...</p>
+        </div>
+    </aside>
+
+    <div id="main-content-container"></div>
+
+    <script type="module" src="/ui/js/sources.js"></script>
+    <script src="/ui/js/navbar.js"></script>
+    <script src="/ui/js/mainContent.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const navbarContainer = document.getElementById('navbar-container');
+            const activeNav = navbarContainer.getAttribute('data-active-nav');
+            renderNavbar('navbar-container', activeNav);
+            renderMainContent('main-content-container', 'source-info-area')
+        });
+    </script>
+</body>
+</html>

--- a/internal/server/web.go
+++ b/internal/server/web.go
@@ -22,6 +22,7 @@ func webRouter() (chi.Router, error) {
 
 	// direct routes for html pages to provide clean URLs
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/index.html") })
+	r.Get("/sources", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/sources.html") })
 	r.Get("/tools", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/tools.html") })
 	r.Get("/toolsets", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/toolsets.html") })
 

--- a/internal/server/web.go
+++ b/internal/server/web.go
@@ -23,6 +23,7 @@ func webRouter() (chi.Router, error) {
 	// direct routes for html pages to provide clean URLs
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/index.html") })
 	r.Get("/sources", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/sources.html") })
+	r.Get("/authservices", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/authServices.html") })
 	r.Get("/tools", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/tools.html") })
 	r.Get("/toolsets", func(w http.ResponseWriter, r *http.Request) { serveHTML(w, r, "static/toolsets.html") })
 

--- a/internal/server/web_test.go
+++ b/internal/server/web_test.go
@@ -87,6 +87,20 @@ func TestWebEndpoint(t *testing.T) {
 			wantContentType: "text/html",
 			wantPageTitle:   "Sources View",
 		},
+		{
+			name:            "web auth services page",
+			path:            "/ui/authservices",
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/html",
+			wantPageTitle:   "AuthServices View",
+		},
+		{
+			name:            "web auth services page with trailing slash",
+			path:            "/ui/authservices/",
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/html",
+			wantPageTitle:   "AuthServices View",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/server/web_test.go
+++ b/internal/server/web_test.go
@@ -73,6 +73,20 @@ func TestWebEndpoint(t *testing.T) {
 			wantContentType: "text/html",
 			wantPageTitle:   "Toolsets View",
 		},
+		{
+			name:            "web sources page",
+			path:            "/ui/sources",
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/html",
+			wantPageTitle:   "Sources View",
+		},
+		{
+			name:            "web sources page with trailing slash",
+			path:            "/ui/sources/",
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/html",
+			wantPageTitle:   "Sources View",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Add a `sources` and `authServices` tab, allowing users to view these resources from Toolbox UI.

NOTE: Currently this uses mock data stored within MOCK_SOURCE_MANIFEST  and MOCK_AUTH_SERVICE_MANIFEST to simulate API calls to fetch, as these endpoints are still awaiting the design and implementation of Toolbox's advanced control plane.