### PR TITLE
Revert "chore: Access params by maps for execute-sql tools"

### DIFF
--- a/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
+++ b/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
@@ -118,10 +118,10 @@ type Tool struct {
 }
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
-	paramsMap := params.AsMap()
-	sql, ok := paramsMap["sql"].(string)
+	sliceParams := params.AsSlice()
+	sql, ok := sliceParams[0].(string)
 	if !ok {
-		return nil, fmt.Errorf("unable to get cast %s", paramsMap["sql"])
+		return nil, fmt.Errorf("unable to get cast %s", sliceParams[0])
 	}
 
 	// Log the query executed for debugging.

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
@@ -118,10 +118,10 @@ type Tool struct {
 }
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
-	paramsMap := params.AsMap()
-	sql, ok := paramsMap["sql"].(string)
+	sliceParams := params.AsSlice()
+	sql, ok := sliceParams[0].(string)
 	if !ok {
-		return nil, fmt.Errorf("unable to get cast %s", paramsMap["sql"])
+		return nil, fmt.Errorf("unable to get cast %s", sliceParams[0])
 	}
 
 	// Log the query executed for debugging.

--- a/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
+++ b/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
@@ -124,10 +124,10 @@ type Tool struct {
 }
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
-	paramsMap := params.AsMap()
-	cypherStr, ok := paramsMap["sql"].(string)
+	sliceParams := params.AsSlice()
+	cypherStr, ok := sliceParams[0].(string)
 	if !ok {
-		return nil, fmt.Errorf("unable to get cast %s", paramsMap["sql"])
+		return nil, fmt.Errorf("unable to get cast %s", sliceParams[0])
 	}
 
 	if cypherStr == "" {

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
@@ -120,10 +120,10 @@ type Tool struct {
 }
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
-	paramsMap := params.AsMap()
-	sql, ok := paramsMap["sql"].(string)
+	sliceParams := params.AsSlice()
+	sql, ok := sliceParams[0].(string)
 	if !ok {
-		return nil, fmt.Errorf("unable to get cast %s", paramsMap["sql"])
+		return nil, fmt.Errorf("unable to get cast %s", sliceParams[0])
 	}
 	// Log the query executed for debugging.
 	logger, err := util.LoggerFromContext(ctx)

--- a/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
+++ b/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
@@ -146,10 +146,10 @@ func processRows(iter *spanner.RowIterator) ([]any, error) {
 }
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
-	paramsMap := params.AsMap()
-	sql, ok := paramsMap["sql"].(string)
+	sliceParams := params.AsSlice()
+	sql, ok := sliceParams[0].(string)
 	if !ok {
-		return nil, fmt.Errorf("unable to get cast %s", paramsMap["sql"])
+		return nil, fmt.Errorf("unable to get cast %s", sliceParams[0])
 	}
 
 	// Log the query executed for debugging.

--- a/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
+++ b/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
@@ -116,10 +116,10 @@ type Tool struct {
 }
 
 func (t Tool) Invoke(ctx context.Context, params tools.ParamValues) (any, error) {
-	paramsMap := params.AsMap()
-	sql, ok := paramsMap["sql"].(string)
+	sliceParams := params.AsSlice()
+	sql, ok := sliceParams[0].(string)
 	if !ok {
-		return nil, fmt.Errorf("unable to get cast %s", paramsMap["sql"])
+		return nil, fmt.Errorf("unable to get cast %s", sliceParams[0])
 	}
 
 	// Log the query executed for debugging.


### PR DESCRIPTION
This reverts commit 6455ba964b9bb2f8ae52e40c6c5c625379ec4219.