### PR TITLE
docs: fix js quickstart

### DIFF
--- a/docs/en/getting-started/local_quickstart_js.md
+++ b/docs/en/getting-started/local_quickstart_js.md
@@ -294,7 +294,7 @@ from Toolbox.
 
    {{< tabpane persist=header >}}
 {{< tab header="LangChain" lang="bash" >}}
-npm install langchain @langchain/google-vertexai
+npm install langchain @langchain/google-genai
 {{< /tab >}}
 {{< tab header="GenkitJS" lang="bash" >}}
 npm install genkit @genkit-ai/vertexai
@@ -309,7 +309,7 @@ npm install llamaindex @llamaindex/google @llamaindex/workflow
     {{< tabpane persist=header >}}
 {{< tab header="LangChain" lang="js" >}}
 
-import { ChatVertexAI } from "@langchain/google-vertexai";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { ToolboxClient } from "@toolbox-sdk/core";
 import { tool } from "@langchain/core/tools";
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
@@ -336,7 +336,7 @@ const queries = [
 ];
 
 async function runApplication() {
-  const model = new ChatVertexAI({
+  const model = new ChatGoogleGenerativeAI({
     model: "gemini-2.0-flash",
   });
 


### PR DESCRIPTION
Use the newly recommended `@langchain/google-genai` library to use gemini API keys.