### PR TITLE
docs: fix genkit js quickstart

### DIFF
--- a/docs/en/getting-started/local_quickstart_js.md
+++ b/docs/en/getting-started/local_quickstart_js.md
@@ -423,7 +423,7 @@ async function run() {
         apiKey: process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY
       })
     ],
-    model: googleAI.model('gemini-2.0-flash'),
+    model: googleAI.model('gemini-1.5-pro'),
   });
 
   const toolboxTools = await toolboxClient.loadToolset("my-toolset");


### PR DESCRIPTION
Using the quickstart with genkit js and other gemini models is giving flaking responses at this time. 