### PR TITLE
docs(hugo): ignore quickstart folder from site indexing

### DIFF
--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -8,6 +8,8 @@ defaultContentLanguageInSubdir = false
 enableGitInfo = true
 enableRobotsTXT = true
 
+ignoreFiles = ["quickstart/"]
+
 [languages]
   [languages.en]
     languageName ="English"


### PR DESCRIPTION
Prevents Hugo from automatically indexing the quickstart folder in site navigation and search results.
This keeps documentation structure clean by excluding development/testing quickstart resources from public docs.