### PR TITLE
ci: disabling dataplex integration tests due to failure

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -152,25 +152,25 @@ steps:
           bigquery \
           bigquery
 
-  - id: "dataplex"
-    name: golang:1
-    waitFor: ["compile-test-binary"]
-    entrypoint: /bin/bash
-    env:
-      - "GOPATH=/gopath"
-      - "DATAPLEX_PROJECT=$PROJECT_ID"
-      - "SERVICE_ACCOUNT_EMAIL=$SERVICE_ACCOUNT_EMAIL"
-    secretEnv: ["CLIENT_ID"]
-    volumes:
-      - name: "go"
-        path: "/gopath"
-    args:
-      - -c
-      - |
-        .ci/test_with_coverage.sh \
-          "Dataplex" \
-          dataplex \
-          dataplex
+  # - id: "dataplex"
+  #   name: golang:1
+  #   waitFor: ["compile-test-binary"]
+  #   entrypoint: /bin/bash
+  #   env:
+  #     - "GOPATH=/gopath"
+  #     - "DATAPLEX_PROJECT=$PROJECT_ID"
+  #     - "SERVICE_ACCOUNT_EMAIL=$SERVICE_ACCOUNT_EMAIL"
+  #   secretEnv: ["CLIENT_ID"]
+  #   volumes:
+  #     - name: "go"
+  #       path: "/gopath"
+  #   args:
+  #     - -c
+  #     - |
+  #       .ci/test_with_coverage.sh \
+  #         "Dataplex" \
+  #         dataplex \
+  #         dataplex
 
   - id: "postgres"
     name: golang:1


### PR DESCRIPTION
## Description
---
Disabling Dataplex integration tests due to test failure. This is blocking PRs from merging.


🛠️ Ref #1250