### PR TITLE
feat: Add `UseClientOAuth` to Tool manifest

### DIFF
--- a/internal/tools/alloydbainl/alloydbainl.go
+++ b/internal/tools/alloydbainl/alloydbainl.go
@@ -133,7 +133,7 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		NLConfig:     cfg.NLConfig,
 		AuthRequired: cfg.AuthRequired,
 		Pool:         s.PostgresPool(),
-		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.NLConfigParameters.Manifest(), AuthRequired: cfg.AuthRequired},
+		manifest:     tools.Manifest{Description: cfg.Description, Parameters: cfg.NLConfigParameters.Manifest(), AuthRequired: cfg.AuthRequired, UseClientOAuth: false},
 		mcpManifest:  mcpManifest,
 	}
 

--- a/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
+++ b/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
@@ -146,16 +146,20 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	t := Tool{
-		Name:               cfg.Name,
-		Kind:               kind,
-		Project:            s.BigQueryProject(),
-		Location:           s.BigQueryLocation(),
-		Parameters:         parameters,
-		AuthRequired:       cfg.AuthRequired,
-		Client:             s.BigQueryClient(),
-		UseClientOAuth:     s.UseClientAuthorization(),
-		TokenSource:        s.BigQueryTokenSource(),
-		manifest:           tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
+		Name:           cfg.Name,
+		Kind:           kind,
+		Project:        s.BigQueryProject(),
+		Location:       s.BigQueryLocation(),
+		Parameters:     parameters,
+		AuthRequired:   cfg.AuthRequired,
+		Client:         s.BigQueryClient(),
+		UseClientOAuth: s.UseClientAuthorization(),
+		TokenSource:    s.BigQueryTokenSource(),
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: s.UseClientAuthorization()},
 		mcpManifest:        mcpManifest,
 		MaxQueryResultRows: s.GetMaxQueryResultRows(),
 	}

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -110,8 +110,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		ClientCreator:  s.BigQueryClientCreator(),
 		Client:         s.BigQueryClient(),
 		RestService:    s.BigQueryRestService(),
-		manifest:       tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:    mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: s.UseClientAuthorization()},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
+++ b/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
@@ -114,8 +114,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		ClientCreator:  s.BigQueryClientCreator(),
 		Client:         s.BigQueryClient(),
 		RestService:    s.BigQueryRestService(),
-		manifest:       tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:    mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: s.UseClientAuthorization()},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
+++ b/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
@@ -102,8 +102,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		UseClientOAuth: s.UseClientAuthorization(),
 		ClientCreator:  s.BigQueryClientCreator(),
 		Client:         s.BigQueryClient(),
-		manifest:       tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:    mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: s.UseClientAuthorization()},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
+++ b/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
@@ -104,8 +104,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		UseClientOAuth: s.UseClientAuthorization(),
 		ClientCreator:  s.BigQueryClientCreator(),
 		Client:         s.BigQueryClient(),
-		manifest:       tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:    mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: s.UseClientAuthorization()},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
+++ b/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
@@ -102,8 +102,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		UseClientOAuth: s.UseClientAuthorization(),
 		ClientCreator:  s.BigQueryClientCreator(),
 		Client:         s.BigQueryClient(),
-		manifest:       tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:    mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: s.UseClientAuthorization()},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
+++ b/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
@@ -103,8 +103,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		UseClientOAuth: s.UseClientAuthorization(),
 		ClientCreator:  s.BigQueryClientCreator(),
 		Client:         s.BigQueryClient(),
-		manifest:       tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:    mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: s.UseClientAuthorization()},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/bigquery/bigquerysql/bigquerysql.go
+++ b/internal/tools/bigquery/bigquerysql/bigquerysql.go
@@ -114,8 +114,11 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		Client:         s.BigQueryClient(),
 		RestService:    s.BigQueryRestService(),
 		ClientCreator:  s.BigQueryClientCreator(),
-		manifest:       tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
-		mcpManifest:    mcpManifest,
+		manifest: tools.Manifest{
+			Description:  cfg.Description,
+			Parameters:   paramManifest,
+			AuthRequired: cfg.AuthRequired},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/bigtable/bigtable.go
+++ b/internal/tools/bigtable/bigtable.go
@@ -102,8 +102,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		Statement:          cfg.Statement,
 		AuthRequired:       cfg.AuthRequired,
 		Client:             s.BigtableClient(),
-		manifest:           tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
-		mcpManifest:        mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     paramManifest,
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: false},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
+++ b/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
@@ -86,8 +86,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		Parameters:   parameters,
 		AuthRequired: cfg.AuthRequired,
 		Pool:         s.ClickHousePool(),
-		manifest:     tools.Manifest{Description: cfg.Description, Parameters: parameters.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:  mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: false},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/clickhouse/clickhousesql/clickhousesql.go
+++ b/internal/tools/clickhouse/clickhousesql/clickhousesql.go
@@ -91,8 +91,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		Statement:          cfg.Statement,
 		AuthRequired:       cfg.AuthRequired,
 		Pool:               s.ClickHousePool(),
-		manifest:           tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
-		mcpManifest:        mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     paramManifest,
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: false},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/couchbase/couchbase.go
+++ b/internal/tools/couchbase/couchbase.go
@@ -104,8 +104,12 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		Scope:                s.CouchbaseScope(),
 		QueryScanConsistency: s.CouchbaseQueryScanConsistency(),
 		AuthRequired:         cfg.AuthRequired,
-		manifest:             tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
-		mcpManifest:          mcpManifest,
+		manifest: tools.Manifest{
+			Description:    cfg.Description,
+			Parameters:     paramManifest,
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: false},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }

--- a/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
+++ b/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
@@ -113,9 +113,10 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		AuthRequired:  cfg.AuthRequired,
 		CatalogClient: s.CatalogClient(),
 		manifest: tools.Manifest{
-			Description:  cfg.Description,
-			Parameters:   parameters.Manifest(),
-			AuthRequired: cfg.AuthRequired,
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: false,
 		},
 		mcpManifest: mcpManifest,
 	}

--- a/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
+++ b/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
@@ -99,9 +99,10 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		CatalogClient: s.CatalogClient(),
 		ProjectID:     s.ProjectID(),
 		manifest: tools.Manifest{
-			Description:  cfg.Description,
-			Parameters:   parameters.Manifest(),
-			AuthRequired: cfg.AuthRequired,
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: false,
 		},
 		mcpManifest: mcpManifest,
 	}

--- a/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
+++ b/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
@@ -98,9 +98,10 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 		CatalogClient: s.CatalogClient(),
 		ProjectID:     s.ProjectID(),
 		manifest: tools.Manifest{
-			Description:  cfg.Description,
-			Parameters:   parameters.Manifest(),
-			AuthRequired: cfg.AuthRequired,
+			Description:    cfg.Description,
+			Parameters:     parameters.Manifest(),
+			AuthRequired:   cfg.AuthRequired,
+			UseClientOAuth: false,
 		},
 		mcpManifest: mcpManifest,
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -77,9 +77,10 @@ type Tool interface {
 
 // Manifest is the representation of tools sent to Client SDKs.
 type Manifest struct {
-	Description  string              `json:"description"`
-	Parameters   []ParameterManifest `json:"parameters"`
-	AuthRequired []string            `json:"authRequired"`
+	Description    string              `json:"description"`
+	Parameters     []ParameterManifest `json:"parameters"`
+	AuthRequired   []string            `json:"authRequired"`
+	UseClientOAuth bool                `json:"useClientOAuth"`
 }
 
 // Definition for a tool the MCP client can call.

--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -150,9 +150,10 @@ func TestLooker(t *testing.T) {
 	tests.RunToolGetTestByName(t, "get_models",
 		map[string]any{
 			"get_models": map[string]any{
-				"description":  "Simple tool to test end to end functionality.",
-				"authRequired": []any{},
-				"parameters":   []any{},
+				"description":    "Simple tool to test end to end functionality.",
+				"authRequired":   []any{},
+				"parameters":     []any{},
+				"useClientOAuth": false,
 			},
 		},
 	)
@@ -170,14 +171,16 @@ func TestLooker(t *testing.T) {
 						"type":        "string",
 					},
 				},
+				"useClientOAuth": false,
 			},
 		},
 	)
 	tests.RunToolGetTestByName(t, "get_dimensions",
 		map[string]any{
 			"get_dimensions": map[string]any{
-				"description":  "Simple tool to test end to end functionality.",
-				"authRequired": []any{},
+				"description":    "Simple tool to test end to end functionality.",
+				"authRequired":   []any{},
+				"useClientOAuth": false,
 				"parameters": []any{
 					map[string]any{
 						"authSources": []any{},
@@ -200,8 +203,9 @@ func TestLooker(t *testing.T) {
 	tests.RunToolGetTestByName(t, "get_measures",
 		map[string]any{
 			"get_measures": map[string]any{
-				"description":  "Simple tool to test end to end functionality.",
-				"authRequired": []any{},
+				"description":    "Simple tool to test end to end functionality.",
+				"authRequired":   []any{},
+				"useClientOAuth": false,
 				"parameters": []any{
 					map[string]any{
 						"authSources": []any{},

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -41,9 +41,10 @@ func RunToolGetTest(t *testing.T) {
 			api:  "http://127.0.0.1:5000/api/tool/my-simple-tool/",
 			want: map[string]any{
 				"my-simple-tool": map[string]any{
-					"description":  "Simple tool to test end to end functionality.",
-					"parameters":   []any{},
-					"authRequired": []any{},
+					"description":    "Simple tool to test end to end functionality.",
+					"parameters":     []any{},
+					"authRequired":   []any{},
+					"useClientOAuth": false,
 				},
 			},
 		},


### PR DESCRIPTION
Support client credentials passthrough on SDKs