### PR TITLE
docs: Fix PR template link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,19 @@
 ## Description
+
 ---
 > Should include a concise description of the changes (bug or feature), it's
 > impact, along with a summary of the solution
 
 ## PR Checklist
+
 ---
 > Thank you for opening a Pull Request! Before submitting your PR, there are a
 > few things you can do to make sure it goes smoothly:
+
 - [ ] Make sure you reviewed
   [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
 - [ ] Make sure to open an issue as a
-  [bug/issue](https://github.com/googleapis/langchain-google-alloydb-pg-python/issues/new/choose)
+  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
   before writing your code!  That way we can discuss the change, evaluate
   designs, and agree on the general idea
 - [ ] Ensure the tests and linter pass


### PR DESCRIPTION
Should link to the Toolbox repo