### PR TITLE
feat(prebuilt/cloud-sql-mysql): support ipType and IAM users(#1232)

### DIFF
--- a/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
@@ -7,6 +7,7 @@ sources:
     database: ${CLOUD_SQL_MYSQL_DATABASE}
     user: ${CLOUD_SQL_MYSQL_USER}
     password: ${CLOUD_SQL_MYSQL_PASSWORD}
+    ipType: ${CLOUD_SQL_MYSQL_IP_TYPE:PUBLIC}
 tools:
   execute_sql:
     kind: mysql-execute-sql

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -53,8 +53,8 @@ type Config struct {
 	Region   string         `yaml:"region" validate:"required"`
 	Instance string         `yaml:"instance" validate:"required"`
 	IPType   sources.IPType `yaml:"ipType" validate:"required"`
-	User     string         `yaml:"user" validate:"required"`
-	Password string         `yaml:"password" validate:"required"`
+	User     string         `yaml:"user" `
+	Password string         `yaml:"password" `
 	Database string         `yaml:"database" validate:"required"`
 }
 


### PR DESCRIPTION
This commit addresses issue #1232 by:
- Allowing CLOUD_SQL_MYSQL_IP_TYPE env var to control IP type, defaulting to PUBLIC.
- Allowing CLOUD_SQL_MYSQL_USER and CLOUD_SQL_MYSQL_PASSWORD env vars to be empty strings to support IAM-based authentication.
- Removed validate:"required" tags from IPType, User, and Password fields in the cloudsqlmysql.Config struct to allow empty values.

Fixes #1232

## Description

---
> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

## PR Checklist

---
> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code!  That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
