### PR TITLE
feat: Add new custom tool kind for alloydb create-instance

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -62,6 +62,23 @@ steps:
           postgressql \
           postgresexecutesql
 
+  - id: "alloydb"
+    name: golang:1
+    waitFor: ["compile-test-binary"]
+    entrypoint: /bin/bash
+    env:
+      - "GOPATH=/gopath"
+    volumes:
+      - name: "go"
+        path: "/gopath"
+    args:
+      - -c
+      - |
+        .ci/test_with_coverage.sh \
+          "AlloyDB" \
+          alloydb \
+          alloydb
+
   - id: "alloydb-pg"
     name: golang:1
     waitFor: ["compile-test-binary"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/util"
 
 	// Import tool packages for side effect of registration
+	_ "github.com/googleapis/genai-toolbox/internal/tools/alloydb/alloydbcreateinstance"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/alloydbainl"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/bigquery/bigqueryconversationalanalytics"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/bigquery/bigqueryexecutesql"

--- a/docs/en/resources/tools/alloydb/_index.md
+++ b/docs/en/resources/tools/alloydb/_index.md
@@ -1,0 +1,7 @@
+---
+title: "AlloyDB for PostgreSQL"
+type: docs
+weight: 1
+description: > 
+  Tools for AlloyDB PostgreSQL.
+---

--- a/docs/en/resources/tools/alloydb/alloydbcreateinstance.md
+++ b/docs/en/resources/tools/alloydb/alloydbcreateinstance.md
@@ -1,0 +1,48 @@
+---
+title: "alloydb-create-instance"
+type: docs
+weight: 1
+description: >
+  The "alloydb-create-instance" tool creates a new AlloyDB instance within a specified cluster.
+aliases:
+- /resources/tools/alloydb-create-instance
+---
+
+## About
+
+The `alloydb-create-instance` tool creates a new AlloyDB instance (PRIMARY or READ_POOL) within a specified cluster.
+This tool provisions a new instance with a **public IP address**.
+
+  **Permissions & APIs Required:**
+  Before using, ensure the following on your GCP project:
+  1. The [AlloyDB API](https://console.cloud.google.com/apis/library/alloydb.googleapis.com) is enabled.
+  2. The user or service account executing the tool has the following IAM roles:
+     - `roles/alloydb.admin`: To create and manage AlloyDB instances.
+
+The tool takes the following input parameters:
+
+| Parameter | Type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| `projectId` | string | The GCP project ID where the cluster exists. | Yes |
+| `locationId` | string | The GCP location where the cluster exists (e.g., `us-central1`). | Yes |
+| `clusterId` | string | The ID of the existing cluster to add this instance to. | Yes |
+| `instanceId` | string | A unique identifier for the new AlloyDB instance. | Yes |
+| `instanceType`| string | The type of instance. Valid values are: `PRIMARY`, `READ_POOL`. | Yes |
+| `displayName` | string | A user-friendly name for the instance. | Yes |
+| `nodeCount` | int | The number of nodes for a read pool. Required only if `instanceType` is `READ_POOL`. Default: `1`| No |
+> **Note**
+> This tool does not have a `source` and authenticates using the environment's
+[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials).
+## Example
+
+```yaml
+tools:
+  alloydb_create_instance:
+    kind: alloydb-create-instance
+    description: Use this tool to create a new AlloyDB instance within a specified cluster.
+```
+## Reference
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| kind        |                   string                   |     true     | Must be alloydb-create-instance.                                                                  |                                               |
+| description |                   string                   |     true     | Description of the tool that is passed to the agent.                                             |

--- a/internal/prebuiltconfigs/tools/alloydb-postgres-admin.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres-admin.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 sources:
   alloydb-api-source:
     kind: http
@@ -56,64 +70,9 @@ tools:
     multiplier: 2
     maxRetries: 10
   alloydb-create-instance:
-    kind: http
+    kind: alloydb-create-instance
     source: alloydb-api-source
-    method: POST
-    path: /v1/projects/{{.projectId}}/locations/{{.locationId}}/clusters/{{.clusterId}}/instances
     description: "Creates a new AlloyDB instance (PRIMARY, READ_POOL, or SECONDARY) within a cluster. This is a long-running operation. Take all parameters from user in one go. This will return operation id to be used by get operations tool."
-    pathParams:
-      - name: projectId
-        type: string
-        description: "The GCP project ID."
-      - name: locationId
-        type: string
-        description: "The location of the cluster (e.g., 'us-central1')."
-        default: us-central1
-      - name: clusterId
-        type: string
-        description: "The ID of the cluster to create the instance in."
-    queryParams:
-      - name: instanceId
-        type: string
-        description: "A unique ID for the new AlloyDB instance."
-    requestBody: |
-      {
-        "instanceType": "{{.instanceType}}",
-        {{- if .displayName }}
-        "displayName": "{{.displayName}}",
-        {{- end }}
-        {{- if eq .instanceType "READ_POOL" }}
-        "readPoolConfig": {
-          "nodeCount": {{.nodeCount}}
-        },
-        {{- end }}
-        {{- if eq .instanceType "SECONDARY" }}
-        "secondaryConfig": {
-          "primaryClusterName": "{{.primaryClusterName}}"
-        },
-        {{- end }}
-        "networkConfig": {
-          "enablePublicIp": true
-        },
-        "databaseFlags": {
-          "password.enforce_complexity": "on"
-        }
-      }
-    bodyParams:
-      - name: instanceType
-        type: string
-        description: "The type of instance to create. Required. Valid values are: PRIMARY, READ_POOL, SECONDARY."
-      - name: displayName
-        type: string
-        description: "An optional, user-friendly name for the instance."
-      - name: nodeCount
-        type: integer
-        description: "The number of nodes in the read pool. Required only if instanceType is READ_POOL. Default is 1."
-        default: 1
-      - name: primaryClusterName
-        type: string
-        description: "The full resource name of the primary cluster for a SECONDARY instance. Required only if instanceType is SECONDARY. Otherwise don't ask"
-        default: ""
   alloydb-list-clusters:
       kind: http
       source: alloydb-api-source

--- a/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
+++ b/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
@@ -1,0 +1,249 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alloydbcreateinstance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	httpsrc "github.com/googleapis/genai-toolbox/internal/sources/http"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"golang.org/x/oauth2/google"
+)
+
+const kind string = "alloydb-create-instance"
+
+func init() {
+	if !tools.Register(kind, newConfig) {
+		panic(fmt.Sprintf("tool kind %q already registered", kind))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+// Configuration for the create-instance tool.
+type Config struct {
+	Name         string            `yaml:"name" validate:"required"`
+	Kind         string            `yaml:"kind" validate:"required"`
+	Source       string            `yaml:"source" validate:"required"`
+	Description  string            `yaml:"description" validate:"required"`
+	AuthRequired []string          `yaml:"authRequired"`
+	BaseURL string `yaml:"baseURL"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+// ToolConfigKind returns the kind of the tool.
+func (cfg Config) ToolConfigKind() string {
+	return kind
+}
+
+// Initialize initializes the tool from the configuration.
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	rawS, ok := srcs[cfg.Source]
+	if !ok {
+		return nil, fmt.Errorf("source %q not found", cfg.Source)
+	}
+
+	s, ok := rawS.(*httpsrc.Source)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `http`", kind)
+	}
+
+	allParameters := tools.Parameters{
+		tools.NewStringParameter("projectId", "The GCP project ID."),
+		tools.NewStringParameter("locationId", "The location of the cluster (e.g., 'us-central1')."),
+		tools.NewStringParameter("clusterId", "The ID of the cluster to create the instance in."),
+		tools.NewStringParameter("instanceId", "A unique ID for the new AlloyDB instance."),
+		tools.NewStringParameter("instanceType", "The type of instance to create. Required. Valid values are: PRIMARY, READ_POOL."),
+		tools.NewStringParameter("displayName", "A user-friendly name for the instance."),
+		tools.NewIntParameterWithDefault("nodeCount", 1, "The number of nodes in the read pool. Required only if instanceType is READ_POOL. Default is 1."),
+	}
+	paramManifest := allParameters.Manifest()
+
+	inputSchema := allParameters.McpManifest()
+	inputSchema.Required = []string{"projectId", "locationId", "clusterId", "instanceType", "instanceId"}
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: inputSchema,
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://alloydb.googleapis.com"
+	}
+
+	return Tool{
+		Name:         cfg.Name,
+		Kind:         kind,
+		BaseURL:      baseURL,
+		AuthRequired: cfg.AuthRequired,
+		Client:       s.Client,
+		AllParams:    allParameters,
+		manifest:     tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
+		mcpManifest:  mcpManifest,
+	}, nil
+}
+
+// Tool represents the create-instance tool.
+type Tool struct {
+	Name         string   `yaml:"name"`
+	Kind         string   `yaml:"kind"`
+	Description  string   `yaml:"description"`
+	AuthRequired []string `yaml:"authRequired"`
+
+	BaseURL   string           `yaml:"baseURL"`
+	AllParams tools.Parameters `yaml:"allParams"`
+
+	Client      *http.Client
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+// Invoke executes the tool's logic.
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken tools.AccessToken) (any, error) {
+	paramsMap := params.AsMap()
+	projectId, ok := paramsMap["projectId"].(string)
+    if !ok || projectId == "" {
+        return nil, fmt.Errorf("invalid or missing 'projectId' parameter; expected a non-empty string")
+    }
+
+	locationId, ok := paramsMap["locationId"].(string)
+    if !ok {
+        return nil, fmt.Errorf("iinvalid or missing 'locationId' parameter; expected a non-empty string")
+    }
+
+    clusterId, ok := paramsMap["clusterId"].(string)
+    if !ok || clusterId == "" {
+        return nil, fmt.Errorf("invalid or missing 'clusterId' parameter; expected a non-empty string")
+    }
+
+    instanceId, ok := paramsMap["instanceId"].(string)
+    if !ok || instanceId == "" {
+        return nil, fmt.Errorf("invalid or missing 'instanceId' parameter; expected a non-empty string")
+    }
+
+	instanceType, ok := paramsMap["instanceType"].(string)
+	if !ok || instanceType == "" {
+		return nil, fmt.Errorf("invalid or missing 'instanceType' parameter; expected a non-empty string")
+	}
+
+	urlString := fmt.Sprintf("%s/v1/projects/%s/locations/%s/clusters/%s/instances?instanceId=%s", t.BaseURL, projectId, locationId, clusterId, instanceId)
+
+	requestBodyMap := map[string]any{
+		"instanceType": instanceType,
+		"networkConfig": map[string]any{
+			"enablePublicIp": true,
+		},
+		"databaseFlags": map[string]string{
+			"password.enforce_complexity": "on",
+		},
+	}
+
+	if displayName, ok := paramsMap["displayName"].(string); ok && displayName != "" {
+		requestBodyMap["displayName"] = displayName
+	}
+
+	if instanceType == "READ_POOL" {
+        nodeCount, ok := paramsMap["nodeCount"].(int) 
+        if !ok {
+            return nil, fmt.Errorf("invalid 'nodeCount' parameter; expected an integer for READ_POOL")
+        }
+        requestBodyMap["readPoolConfig"] = map[string]any{
+            "nodeCount": nodeCount,
+        }
+    }
+
+	bodyBytes, err := json.Marshal(requestBodyMap)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlString, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("error creating HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	tokenSource, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("error creating token source: %w", err)
+	}
+	token, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving token: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, response body: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result any
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("error unmarshaling JSON response: %w", err)
+	}
+
+	return result, nil
+}
+
+// ParseParams parses the parameters for the tool.
+func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {
+	return tools.ParseParams(t.AllParams, data, claims)
+}
+
+// Manifest returns the tool's manifest.
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+// McpManifest returns the tool's MCP manifest.
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+// Authorized checks if the tool is authorized.
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return true
+}
+
+func (t Tool) RequiresClientAuthorization() bool {
+	return false
+}

--- a/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance_test.go
+++ b/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alloydbcreateinstance_test
+
+import (
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	alloydbcreateinstance "github.com/googleapis/genai-toolbox/internal/tools/alloydb/alloydbcreateinstance"
+)
+
+func TestParseFromYaml(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			tools:
+				create-my-instance:
+					kind: alloydb-create-instance
+					source: my-alloydb-admin-source
+					description: some description
+			`,
+			want: server.ToolConfigs{
+				"create-my-instance": alloydbcreateinstance.Config{
+					Name:         "create-my-instance",
+					Kind:         "alloydb-create-instance",
+					Source:       "my-alloydb-admin-source",
+					Description:  "some description",
+					AuthRequired: []string{},
+				},
+			},
+		},
+		{
+			desc: "with auth required",
+			in: `
+			tools:
+				create-my-instance-auth:
+					kind: alloydb-create-instance
+					source: my-alloydb-admin-source
+					description: some description
+					authRequired: 
+						- my-google-auth-service
+						- other-auth-service
+			`,
+			want: server.ToolConfigs{
+				"create-my-instance-auth": alloydbcreateinstance.Config{
+					Name:         "create-my-instance-auth",
+					Kind:         "alloydb-create-instance",
+					Source:       "my-alloydb-admin-source",
+					Description:  "some description",
+					AuthRequired: []string{"my-google-auth-service", "other-auth-service"},
+				},
+			},
+		},
+		{
+			desc: "with base url",
+			in: `
+			tools:
+				create-my-instance-baseurl:
+					kind: alloydb-create-instance
+					source: my-alloydb-admin-source
+					description: some description
+					baseURL: "https://example.com"
+			`,
+			want: server.ToolConfigs{
+				"create-my-instance-baseurl": alloydbcreateinstance.Config{
+					Name:         "create-my-instance-baseurl",
+					Kind:         "alloydb-create-instance",
+					Source:       "my-alloydb-admin-source",
+					Description:  "some description",
+					BaseURL:      "https://example.com",
+					AuthRequired: []string{},
+				},
+			},
+		},
+		{
+			desc: "with auth and base url",
+			in: `
+			tools:
+				create-my-instance-all:
+					kind: alloydb-create-instance
+					source: my-alloydb-admin-source
+					description: some description
+					authRequired: 
+						- my-google-auth-service
+						- other-auth-service
+					baseURL: "https://example.com"
+			`,
+			want: server.ToolConfigs{
+				"create-my-instance-all": alloydbcreateinstance.Config{
+					Name:         "create-my-instance-all",
+					Kind:         "alloydb-create-instance",
+					Source:       "my-alloydb-admin-source",
+					Description:  "some description",
+					AuthRequired: []string{"my-google-auth-service", "other-auth-service"},
+					BaseURL:      "https://example.com",
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := struct {
+				Tools server.ToolConfigs `yaml:"tools"`
+			}{}
+			// Parse contents
+			err := yaml.UnmarshalContext(ctx, testutils.FormatYaml(tc.in), &got)
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got.Tools); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+}

--- a/tests/alloydb/alloydb_integration_test.go
+++ b/tests/alloydb/alloydb_integration_test.go
@@ -1,0 +1,203 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alloydb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/tests"
+)
+
+var (
+	AlloyDBCreateInstanceToolKind = "alloydb-create-instance"
+)
+
+// HTTP handler for mock server
+type handler struct {
+	mu       sync.Mutex
+	response mockResponse
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.response.body == "" {
+		return
+	}
+
+	w.WriteHeader(h.response.statusCode)
+	if _, err := w.Write([]byte(h.response.body)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (h *handler) setResponse(res mockResponse) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.response = res
+}
+
+type mockResponse struct {
+	statusCode int
+	body       string
+}
+
+func TestAlloyDBCreateInstance(t *testing.T) {
+	h := &handler{}
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	toolsFile := getAlloyDBCreateToolsConfig(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	if err != nil {
+		t.Fatalf("command initialization failed: %v", err)
+	}
+	defer cleanup()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer waitCancel()
+	_, err = testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Fatalf("toolbox server didn't start successfully: %s", err)
+	}
+
+	tcs := []struct {
+		name           string
+		requestBody    string
+		wantStatusCode int
+		mockResponse   mockResponse
+		want           map[string]any
+	}{
+		{
+			name:           "create primary instance success",
+			requestBody:    `{"projectId": "test-p", "locationId": "test-l", "clusterId": "test-c", "instanceId": "inst-1", "instanceType": "PRIMARY", "displayName": "My Primary"}`,
+			wantStatusCode: http.StatusOK,
+			mockResponse:   mockResponse{statusCode: http.StatusOK, body: `{"done":false,"metadata":{"@type":"type.googleapis.com/google.cloud.alloydb.v1.OperationMetadata","apiVersion":"v1","target":"projects/test-p/locations/test-l/clusters/test-c/instances/inst-1","verb":"create"},"name":"projects/test-p/locations/test-l/operations/op-123"}`},
+			want:           map[string]any{"done": false, "metadata": map[string]any{"@type": "type.googleapis.com/google.cloud.alloydb.v1.OperationMetadata", "apiVersion": "v1", "target": "projects/test-p/locations/test-l/clusters/test-c/instances/inst-1", "verb": "create"}, "name": "projects/test-p/locations/test-l/operations/op-123"},
+		},
+		{
+			name:           "create read pool instance success",
+			requestBody:    `{"projectId": "test-p", "locationId": "test-l", "clusterId": "test-c", "instanceId": "read-1", "instanceType": "READ_POOL", "displayName": "read-instance", "nodeCount": 3}`,
+			wantStatusCode: http.StatusOK,
+			mockResponse:   mockResponse{statusCode: http.StatusOK, body: `{"done":false,"metadata":{"@type":"type.googleapis.com/google.cloud.alloydb.v1.OperationMetadata","apiVersion":"v1","target":"projects/test-p/locations/test-l/clusters/test-c/instances/read-1","verb":"create"},"name":"projects/test-p/locations/test-l/operations/op-456"}`},
+			want:           map[string]any{"done": false, "metadata": map[string]any{"@type": "type.googleapis.com/google.cloud.alloydb.v1.OperationMetadata", "apiVersion": "v1", "target": "projects/test-p/locations/test-l/clusters/test-c/instances/read-1", "verb": "create"}, "name": "projects/test-p/locations/test-l/operations/op-456"},
+		},
+		{
+			name:           "create instance api failure",
+			requestBody:    `{"projectId": "test-p", "locationId": "test-l", "clusterId": "test-c", "instanceId": "inst-fail", "instanceType": "PRIMARY"}`,
+			wantStatusCode: http.StatusBadRequest,
+			mockResponse:   mockResponse{statusCode: http.StatusInternalServerError, body: `{"error": "some api error"}`},
+		},
+		{
+			name:           "create instance missing projectId",
+			requestBody:    `{"locationId": "l1", "clusterId": "c1", "instanceId": "i1", "instanceType": "PRIMARY"}`,
+			wantStatusCode: http.StatusBadRequest,
+			mockResponse:   mockResponse{body: ""},
+		},
+		{
+			name:           "create instance missing instanceType",
+			requestBody:    `{"projectId": "p1", "locationId": "l1", "clusterId": "c1", "instanceId": "i1"}`,
+			wantStatusCode: http.StatusBadRequest,
+			mockResponse:   mockResponse{body: ""},
+		},
+		{
+			name:           "create instance missing clusterId",
+			requestBody:    `{"projectId": "p1", "locationId": "l1", "instanceId": "i1", "instanceType": "PRIMARY"}`,
+			wantStatusCode: http.StatusBadRequest,
+			mockResponse:   mockResponse{body: ""},
+		},
+		{
+			name:           "create instance missing instanceId",
+			requestBody:    `{"projectId": "p1", "locationId": "l1", "clusterId": "c1", "instanceType": "PRIMARY"}`,
+			wantStatusCode: http.StatusBadRequest,
+			mockResponse:   mockResponse{body: ""},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			h.setResponse(tc.mockResponse)
+
+			api := "http://127.0.0.1:5000/api/tool/alloydb-create-instance/invoke"
+			req, err := http.NewRequest(http.MethodPost, api, bytes.NewBufferString(tc.requestBody))
+			if err != nil {
+				t.Fatalf("unable to create request: %s", err)
+			}
+			req.Header.Add("Content-type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("unable to send request: %s", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatusCode {
+				bodyBytes, _ := io.ReadAll(resp.Body)
+				t.Fatalf("expected status %d, got %d: %s", tc.wantStatusCode, resp.StatusCode, string(bodyBytes))
+			}
+
+			if tc.want != nil {
+				var result struct {
+					Result string `json:"result"`
+				}
+				if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+
+				var got map[string]any
+				if err := json.Unmarshal([]byte(result.Result), &got); err != nil {
+					t.Fatalf("failed to unmarshal nested result: %v", err)
+				}
+
+				if diff := cmp.Diff(got, tc.want); diff != "" {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func getAlloyDBCreateToolsConfig(baseURL string) map[string]any {
+	return map[string]any{
+		"sources": map[string]any{
+			"alloydb-admin-source": map[string]any{
+				"kind":    "http",
+				"baseUrl": baseURL,
+			},
+		},
+		"tools": map[string]any{
+			"alloydb-create-instance": map[string]any{
+				"kind":        AlloyDBCreateInstanceToolKind,
+				"source":      "alloydb-admin-source",
+				"description": "Create a new AlloyDB instance (PRIMARY or READ_POOL) within a cluster. This is a long-running operation.",
+				"baseURL":     baseURL,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description

---
This pull request introduces a new custom tool kind `alloydb-create-instance` that allows users to create a new AlloyDB instance within a specified cluster.
### Example Configuration

```yaml
tools:
  alloydb_create_instance:
    kind: alloydb-create-instance
    description: Use this tool to create a new AlloyDB instance within a specified cluster.
```

### Example Request
``` 
curl -X POST http://127.0.0.1:5000/api/tool/alloydb_create_instance/invoke \
-H "Content-Type: application/json" \
-d '{
    "projectId": "example-project",
    "locationId": "us-central1",
    "clusterId": "example-cluster",
    "instanceId": "example-instance-id",
    "instanceType": "PRIMARY",
    "displayName": "example-instance"
}'
```

## PR Checklist

---
> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code!  That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
