### PR TITLE
feat(prebuilt/cloudsql): Add cloud-sql-get-instances tool

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -284,6 +284,24 @@ steps:
           cloudsqlmysql \
           mysql
 
+  - id: "cloud-sql"
+    name: golang:1
+    waitFor: ["compile-test-binary"]
+    entrypoint: /bin/bash
+    env:
+      - "GOPATH=/gopath"
+    secretEnv: ["CLIENT_ID"]
+    volumes:
+      - name: "go"
+        path: "/gopath"
+    args:
+      - -c
+      - |
+        .ci/test_with_coverage.sh \
+          "Cloud SQL" \
+          cloudsql \
+          cloudsql
+
   - id: "mysql"
     name: golang:1
     waitFor: ["compile-test-binary"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/googleapis/genai-toolbox/internal/tools/bigtable"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/clickhouse/clickhouseexecutesql"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/clickhouse/clickhousesql"
+	_ "github.com/googleapis/genai-toolbox/internal/tools/cloudsql/cloudsqlgetinstances"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/couchbase"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/dataplex/dataplexlookupentry"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/dataplex/dataplexsearchaspecttypes"

--- a/docs/en/resources/tools/cloudsql/_index.md
+++ b/docs/en/resources/tools/cloudsql/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Cloud SQL"
+type: docs
+weight: 1
+description: > 
+  Tools that work with Cloud SQL Control Plane. 
+---

--- a/docs/en/resources/tools/cloudsql/cloudsqlgetinstances.md
+++ b/docs/en/resources/tools/cloudsql/cloudsqlgetinstances.md
@@ -1,0 +1,35 @@
+---
+title: "cloud-sql-get-instances"
+type: docs
+weight: 10
+description: >
+  Get a Cloud SQL instance resource.
+---
+
+The `cloud-sql-get-instances` tool retrieves a Cloud SQL instance resource using the Cloud SQL Admin API.
+
+{{< notice info >}}
+This tool uses a `source` of kind `http`, and the `baseUrl` for that source must be `https://sqladmin.googleapis.com/`.
+{{< /notice >}}
+
+{{< notice info >}}
+The toolbox automatically generates a bearer token on behalf of the user with the `https://www.googleapis.com/auth/sqlservice.admin` scope to authenticate requests.
+{{< /notice >}}
+
+## Example
+
+```yaml
+tools:
+  get-sql-instance:
+    kind: cloud-sql-get-instances
+    description: "Get a Cloud SQL instance resource."
+    source: http-source
+```
+
+## Reference
+
+| **field**   | **type** | **required** | **description**                                                                                                  |
+| ----------- | :------: | :----------: | ---------------------------------------------------------------------------------------------------------------- |
+| kind        |  string  |     true     | Must be "cloud-sql-get-instances".                                                                            |
+| description |  string  |     true     | A description of the tool.                                                                                       |
+| source      |  string  |     true     | The name of the `http` source to use. The source's `baseUrl` must be `https://sqladmin.googleapis.com/`.         |

--- a/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
+++ b/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
@@ -1,0 +1,193 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlgetinstances
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	httpsource "github.com/googleapis/genai-toolbox/internal/sources/http"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"golang.org/x/oauth2/google"
+)
+
+const kind string = "cloud-sql-get-instances"
+
+func init() {
+	if !tools.Register(kind, newConfig) {
+		panic(fmt.Sprintf("tool kind %q already registered", kind))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+// Config defines the configuration for the get-instances tool.
+type Config struct {
+	Name         string   `yaml:"name" validate:"required"`
+	Kind         string   `yaml:"kind" validate:"required"`
+	Description  string   `yaml:"description" validate:"required"`
+	Source       string   `yaml:"source" validate:"required"`
+	AuthRequired []string `yaml:"authRequired"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+// ToolConfigKind returns the kind of the tool.
+func (cfg Config) ToolConfigKind() string {
+	return kind
+}
+
+// Initialize initializes the tool from the configuration.
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	rawS, ok := srcs[cfg.Source]
+	if !ok {
+		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
+	}
+
+	s, ok := rawS.(*httpsource.Source)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `http`", kind)
+	}
+
+	if s.BaseURL != "https://sqladmin.googleapis.com" && !strings.HasPrefix(s.BaseURL, "http://127.0.0.1") {
+		return nil, fmt.Errorf("invalid source for %q tool: baseUrl must be `https://sqladmin.googleapis.com/`", kind)
+	}
+
+	allParameters := tools.Parameters{
+		tools.NewStringParameter("project", "The project ID"),
+		tools.NewStringParameter("instance", "The instance ID"),
+	}
+	paramManifest := allParameters.Manifest()
+
+	inputSchema := allParameters.McpManifest()
+	inputSchema.Required = []string{"project", "instance"}
+
+	mcpManifest := tools.McpManifest{
+		Name:        cfg.Name,
+		Description: cfg.Description,
+		InputSchema: inputSchema,
+	}
+
+	return Tool{
+		Name:        cfg.Name,
+		Kind:        kind,
+		BaseURL:     s.BaseURL,
+		Client:      s.Client,
+		AllParams:   allParameters,
+		manifest:    tools.Manifest{Description: cfg.Description, Parameters: paramManifest},
+		mcpManifest: mcpManifest,
+	}, nil
+}
+
+// Tool represents the get-instances tool.
+type Tool struct {
+	Name        string `yaml:"name"`
+	Kind        string `yaml:"kind"`
+	Description string `yaml:"description"`
+
+	BaseURL   string           `yaml:"baseURL"`
+	AllParams tools.Parameters `yaml:"allParams"`
+
+	Client      *http.Client
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+// Invoke executes the tool's logic.
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken tools.AccessToken) (any, error) {
+	paramsMap := params.AsMap()
+
+	project, ok := paramsMap["project"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing 'project' parameter")
+	}
+	instance, ok := paramsMap["instance"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing 'instance' parameter")
+	}
+
+	urlString := fmt.Sprintf("%s/v1/projects/%s/instances/%s", t.BaseURL, project, instance)
+
+	req, _ := http.NewRequest(http.MethodGet, urlString, nil)
+
+	tokenSource, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/sqlservice.admin")
+	if err != nil {
+		return nil, fmt.Errorf("error creating token source: %w", err)
+	}
+	token, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving token: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, response body: %s", resp.StatusCode, string(body))
+	}
+
+	var data any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("error unmarshalling response body: %w", err)
+	}
+
+	return data, nil
+}
+
+// ParseParams parses the parameters for the tool.
+func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {
+	return tools.ParseParams(t.AllParams, data, claims)
+}
+
+// Manifest returns the tool's manifest.
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+// McpManifest returns the tool's MCP manifest.
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+// Authorized checks if the tool is authorized.
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return true
+}
+
+func (t Tool) RequiresClientAuthorization() bool {
+	return false
+}

--- a/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances_test.go
+++ b/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlgetinstances_test
+
+import (
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	cloudsqlgetinstances "github.com/googleapis/genai-toolbox/internal/tools/cloudsql/cloudsqlgetinstances"
+)
+
+func TestParseFromYaml(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			tools:
+				get-instances:
+					kind: cloud-sql-get-instances
+					description: "A tool to get cloud sql instances"
+					source: "my-gcp-source"
+			`,
+			want: server.ToolConfigs{
+				"get-instances": cloudsqlgetinstances.Config{
+					Name:         "get-instances",
+					Kind:         "cloud-sql-get-instances",
+					Description:  "A tool to get cloud sql instances",
+					Source:       "my-gcp-source",
+					AuthRequired: []string{},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := struct {
+				Tools server.ToolConfigs `yaml:"tools"`
+			}{}
+			// Parse contents
+			err := yaml.UnmarshalContext(ctx, testutils.FormatYaml(tc.in), &got)
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got.Tools); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+}

--- a/tests/cloudsql/cloud_sql_get_instances_test.go
+++ b/tests/cloudsql/cloud_sql_get_instances_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsql
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/tests"
+)
+
+var (
+	getInstancesToolKind = "cloud-sql-get-instances"
+)
+
+type instance struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+type handler struct {
+	mu        sync.Mutex
+	instances map[string]*instance
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// The format is /v1/projects/{project}/instances/{instance_name}
+	// We only care about the instance_name for the test
+	parts := regexp.MustCompile("/").Split(r.URL.Path, -1)
+	instanceName := parts[len(parts)-1]
+
+	inst, ok := h.instances[instanceName]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(inst); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func TestGetInstancesToolEndpoints(t *testing.T) {
+	h := &handler{
+		instances: map[string]*instance{
+			"instance-1": {Name: "instance-1", Kind: "sql#instance"},
+		},
+	}
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var args []string
+
+	toolsFile := getToolsConfig(server.URL)
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	tcs := []struct {
+		name          string
+		toolName      string
+		body          string
+		want          string
+		expectError   bool
+		wantSubstring bool
+	}{
+		{
+			name:     "successful get instance",
+			toolName: "get-instance-1",
+			body:     `{"project": "p1", "instance": "instance-1"}`,
+			want:     `{"name":"instance-1","kind":"sql#instance"}`,
+		},
+		{
+			name:        "failed get instance",
+			toolName:    "get-instance-2",
+			body:        `{"project": "p1", "instance": "instance-2"}`,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			api := fmt.Sprintf("http://127.0.0.1:5000/api/tool/%s/invoke", tc.toolName)
+			req, err := http.NewRequest(http.MethodPost, api, bytes.NewBufferString(tc.body))
+			if err != nil {
+				t.Fatalf("unable to create request: %s", err)
+			}
+			req.Header.Add("Content-type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("unable to send request: %s", err)
+			}
+			defer resp.Body.Close()
+
+			if tc.expectError {
+				if resp.StatusCode == http.StatusOK {
+					t.Fatal("expected error but got status 200")
+				}
+				return
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				bodyBytes, _ := io.ReadAll(resp.Body)
+				t.Fatalf("response status code is not 200, got %d: %s", resp.StatusCode, string(bodyBytes))
+			}
+
+			var result struct {
+				Result any `json:"result"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			var gotBytes []byte
+			if s, ok := result.Result.(string); ok {
+				gotBytes = []byte(s)
+			} else {
+				var err error
+				gotBytes, err = json.Marshal(result.Result)
+				if err != nil {
+					t.Fatalf("failed to marshal result: %v", err)
+				}
+			}
+
+			if tc.wantSubstring {
+				if !bytes.Contains(gotBytes, []byte(tc.want)) {
+					t.Fatalf("unexpected result: got %q, want substring %q", string(gotBytes), tc.want)
+				}
+				return
+			}
+
+			var got, want map[string]any
+			if err := json.Unmarshal(gotBytes, &got); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tc.want), &want); err != nil {
+				t.Fatalf("failed to unmarshal want: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("unexpected result: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func getToolsConfig(baseURL string) map[string]any {
+	return map[string]any{
+		"tools": map[string]any{
+			"get-instance-1": map[string]any{
+				"kind":         getInstancesToolKind,
+				"description":  "get instance 1",
+				"source":       "sqladmin",
+				"authRequired": []string{},
+			},
+			"get-instance-2": map[string]any{
+				"kind":         getInstancesToolKind,
+				"description":  "get instance 2",
+				"source":       "sqladmin",
+				"authRequired": []string{},
+			},
+		},
+		"sources": map[string]any{
+			"sqladmin": map[string]any{
+				"kind":    "http",
+				"baseUrl": baseURL,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description

---
This pull request introduces the `cloud-sql-get-instances` tool, which enables users to retrieve detailed information about a specified Cloud SQL instance. This tool enhances the toolbox by providing a direct and authenticated way to interact with the Google Cloud SQL Admin API. Authentication is handled automatically by generating a bearer token from the environment's Application Default Credentials with the `https://www.googleapis.com/auth/sqlservice.admin` scope.


<img width="282" height="1064" alt="image" src="https://github.com/user-attachments/assets/253d3939-7de2-4324-bc2b-8a2eb20eb133" />



####


## PR Checklist

---
> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code!  That way we can discuss the change, evaluate
  designs, and agree on the general idea - Tracked internally
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
