### PR TITLE
chore: update yaml tag in source and auth services

### DIFF
--- a/internal/auth/google/google.go
+++ b/internal/auth/google/google.go
@@ -31,7 +31,7 @@ var _ auth.AuthServiceConfig = Config{}
 // Auth service configuration
 type Config struct {
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	ClientID string `yaml:"clientId" validate:"required"`
 }
 

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -49,7 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string         `yaml:"name" validate:"required"`
-	Type     string         `yaml:"kind" validate:"required"`
+	Type     string         `yaml:"type" validate:"required"`
 	Project  string         `yaml:"project" validate:"required"`
 	Region   string         `yaml:"region" validate:"required"`
 	Cluster  string         `yaml:"cluster" validate:"required"`

--- a/internal/sources/alloydbpg/alloydb_pg_test.go
+++ b/internal/sources/alloydbpg/alloydb_pg_test.go
@@ -15,14 +15,13 @@
 package alloydbpg_test
 
 import (
+	"context"
 	"testing"
 
-	yaml "github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
-	"github.com/googleapis/genai-toolbox/internal/testutils"
 )
 
 func TestParseFromYamlAlloyDBPg(t *testing.T) {
@@ -34,17 +33,17 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 		{
 			desc: "basic example",
 			in: `
-			sources:
-				my-pg-instance:
-					kind: alloydb-postgres
-					project: my-project
-					region: my-region
-					cluster: my-cluster
-					instance: my-instance
-					database: my_db
-					user: my_user
-					password: my_pass
-			`,
+            type: sources
+            name: my-pg-instance
+            type: alloydb-postgres
+            project: my-project
+            region: my-region
+            cluster: my-cluster
+            instance: my-instance
+            database: my_db
+            user: my_user
+            password: my_pass
+            `,
 			want: map[string]sources.SourceConfig{
 				"my-pg-instance": alloydbpg.Config{
 					Name:     "my-pg-instance",
@@ -63,18 +62,18 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 		{
 			desc: "public ipType",
 			in: `
-			sources:
-				my-pg-instance:
-					kind: alloydb-postgres
-					project: my-project
-					region: my-region
-					cluster: my-cluster
-					instance: my-instance
-					ipType: Public
-					database: my_db
-					user: my_user
-					password: my_pass
-			`,
+            type: sources
+            name: my-pg-instance
+            type: alloydb-postgres
+            project: my-project
+            region: my-region
+            cluster: my-cluster
+            instance: my-instance
+            ipType: Public
+            database: my_db
+            user: my_user
+            password: my_pass
+            `,
 			want: map[string]sources.SourceConfig{
 				"my-pg-instance": alloydbpg.Config{
 					Name:     "my-pg-instance",
@@ -93,18 +92,18 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 		{
 			desc: "private ipType",
 			in: `
-			sources:
-				my-pg-instance:
-					kind: alloydb-postgres
-					project: my-project
-					region: my-region
-					cluster: my-cluster
-					instance: my-instance
-					ipType: private
-					database: my_db
-					user: my_user
-					password: my_pass
-			`,
+            type: sources
+            name: my-pg-instance
+            type: alloydb-postgres
+            project: my-project
+            region: my-region
+            cluster: my-cluster
+            instance: my-instance
+            ipType: private
+            database: my_db
+            user: my_user
+            password: my_pass
+            `,
 			want: map[string]sources.SourceConfig{
 				"my-pg-instance": alloydbpg.Config{
 					Name:     "my-pg-instance",
@@ -123,16 +122,12 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := struct {
-				Sources server.SourceConfigs `yaml:"sources"`
-			}{}
-			// Parse contents
-			err := yaml.Unmarshal(testutils.FormatYaml(tc.in), &got)
+			sources, _, _, _, err := server.UnmarshalResourceConfig(context.Background(), []byte(tc.in))
 			if err != nil {
 				t.Fatalf("unable to unmarshal: %s", err)
 			}
-			if !cmp.Equal(tc.want, got.Sources) {
-				t.Fatalf("incorrect parse: want %v, got %v", tc.want, got.Sources)
+			if !cmp.Equal(tc.want, sources) {
+				t.Fatalf("incorrect parse: want %v, got %v", tc.want, sources)
 			}
 		})
 	}
@@ -147,60 +142,71 @@ func TestFailParseFromYaml(t *testing.T) {
 		{
 			desc: "invalid ipType",
 			in: `
-			sources:
-				my-pg-instance:
-					kind: alloydb-postgres
-					project: my-project
-					region: my-region
-					cluster: my-cluster
-					instance: my-instance
-					ipType: fail 
-					database: my_db
-					user: my_user
-					password: my_pass
-			`,
-			err: "unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": ipType invalid: must be one of \"public\", or \"private\"",
+            type: sources
+            name: my-pg-instance
+            type: alloydb-postgres
+            project: my-project
+            region: my-region
+            cluster: my-cluster
+            instance: my-instance
+            ipType: fail 
+            database: my_db
+            user: my_user
+            password: my_pass
+            `,
+			err: "error unmarshaling sources: unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": ipType invalid: must be one of \"public\", or \"private\"",
 		},
 		{
 			desc: "extra field",
 			in: `
-			sources:
-				my-pg-instance:
-					kind: alloydb-postgres
-					project: my-project
-					region: my-region
-					cluster: my-cluster
-					instance: my-instance
-					database: my_db
-					user: my_user
-					password: my_pass
-					foo: bar
-			`,
-			err: "unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": [3:1] unknown field \"foo\"\n   1 | cluster: my-cluster\n   2 | database: my_db\n>  3 | foo: bar\n       ^\n   4 | instance: my-instance\n   5 | kind: alloydb-postgres\n   6 | password: my_pass\n   7 | ",
+            type: sources
+            name: my-pg-instance
+            type: alloydb-postgres
+            project: my-project
+            region: my-region
+            cluster: my-cluster
+            instance: my-instance
+            database: my_db
+            user: my_user
+            password: my_pass
+            foo: bar
+            `,
+			err: "error unmarshaling sources: unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": [3:1] unknown field \"foo\"\n   1 | cluster: my-cluster\n   2 | database: my_db\n>  3 | foo: bar\n       ^\n   4 | instance: my-instance\n   5 | name: my-pg-instance\n   6 | password: my_pass\n   7 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
-			sources:
-				my-pg-instance:
-					kind: alloydb-postgres
-					region: my-region
-					cluster: my-cluster
-					instance: my-instance
-					database: my_db
-					user: my_user
-					password: my_pass
-			`,
-			err: "unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",
+            type: sources
+            name: my-pg-instance
+            type: alloydb-postgres
+            region: my-region
+            cluster: my-cluster
+            instance: my-instance
+            database: my_db
+            user: my_user
+            password: my_pass
+            `,
+			err: "error unmarshaling sources: unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",
+		},
+		{
+			desc: "old tools file format",
+			in: `
+            sources:
+                my-pg-instance:
+                    type: alloydb-postgres
+                    region: my-region
+                    cluster: my-cluster
+                    instance: my-instance
+                    database: my_db
+                    user: my_user
+                    password: my_pass
+            `,
+			err: "missing 'type' field or it is not a string",
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := struct {
-				Sources server.SourceConfigs `yaml:"sources"`
-			}{}
-			// Parse contents
-			err := yaml.Unmarshal(testutils.FormatYaml(tc.in), &got)
+			_, _, _, _, err := server.UnmarshalResourceConfig(context.Background(), []byte(tc.in))
 			if err == nil {
 				t.Fatalf("expect parsing to fail")
 			}

--- a/internal/sources/bigquery/bigquery.go
+++ b/internal/sources/bigquery/bigquery.go
@@ -54,7 +54,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 type Config struct {
 	// BigQuery configs
 	Name           string `yaml:"name" validate:"required"`
-	Type           string `yaml:"kind" validate:"required"`
+	Type           string `yaml:"type" validate:"required"`
 	Project        string `yaml:"project" validate:"required"`
 	Location       string `yaml:"location"`
 	UseClientOAuth bool   `yaml:"useClientOAuth"`

--- a/internal/sources/bigquery/bigquery_test.go
+++ b/internal/sources/bigquery/bigquery_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlBigQuery(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: bigquery
+					type: bigquery
 					project: my-project
 					location: us
 			`,
@@ -54,7 +54,7 @@ func TestParseFromYamlBigQuery(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: bigquery
+					type: bigquery
 					project: my-project
 					location: us
 					useClientOAuth: true
@@ -99,19 +99,19 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: bigquery
+					type: bigquery
 					project: my-project
 					location: us
 					foo: bar
 			`,
-			err: "unable to parse source \"my-instance\" as \"bigquery\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | kind: bigquery\n   3 | location: us\n   4 | project: my-project",
+			err: "unable to parse source \"my-instance\" as \"bigquery\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | type: bigquery\n   3 | location: us\n   4 | project: my-project",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-instance:
-					kind: bigquery
+					type: bigquery
 					location: us
 			`,
 			err: "unable to parse source \"my-instance\" as \"bigquery\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",

--- a/internal/sources/bigtable/bigtable.go
+++ b/internal/sources/bigtable/bigtable.go
@@ -47,7 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Project  string `yaml:"project" validate:"required"`
 	Instance string `yaml:"instance" validate:"required"`
 }

--- a/internal/sources/bigtable/bigtable_test.go
+++ b/internal/sources/bigtable/bigtable_test.go
@@ -36,7 +36,7 @@ func TestParseFromYamlBigtableDb(t *testing.T) {
 			in: `
 			sources:
 				my-bigtable-instance:
-					kind: bigtable
+					type: bigtable
 					project: my-project
 					instance: my-instance
 			`,
@@ -79,19 +79,19 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-bigtable-instance:
-					kind: bigtable
+					type: bigtable
 					project: my-project
 					instance: my-instance
 					foo: bar
 			`,
-			err: "unable to parse source \"my-bigtable-instance\" as \"bigtable\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | instance: my-instance\n   3 | kind: bigtable\n   4 | project: my-project",
+			err: "unable to parse source \"my-bigtable-instance\" as \"bigtable\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | instance: my-instance\n   3 | type: bigtable\n   4 | project: my-project",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-bigtable-instance:
-					kind: bigtable
+					type: bigtable
 					project: my-project
 			`,
 			err: "unable to parse source \"my-bigtable-instance\" as \"bigtable\": Key: 'Config.Instance' Error:Field validation for 'Instance' failed on the 'required' tag",

--- a/internal/sources/clickhouse/clickhouse.go
+++ b/internal/sources/clickhouse/clickhouse.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Host     string `yaml:"host" validate:"required"`
 	Port     string `yaml:"port" validate:"required"`
 	Database string `yaml:"database" validate:"required"`

--- a/internal/sources/clickhouse/clickhouse_test.go
+++ b/internal/sources/clickhouse/clickhouse_test.go
@@ -42,7 +42,7 @@ func TestNewConfig(t *testing.T) {
 			name: "all fields specified",
 			yaml: `
 				name: test-clickhouse
-				kind: clickhouse
+				type: clickhouse
 				host: localhost
 				port: "8443"
 				user: default
@@ -67,7 +67,7 @@ func TestNewConfig(t *testing.T) {
 			name: "minimal configuration with defaults",
 			yaml: `
 				name: minimal-clickhouse
-				kind: clickhouse
+				type: clickhouse
 				host: 127.0.0.1
 				port: "8123"
 				user: testuser
@@ -89,7 +89,7 @@ func TestNewConfig(t *testing.T) {
 			name: "http protocol",
 			yaml: `
 				name: http-clickhouse
-				kind: clickhouse
+				type: clickhouse
 				host: clickhouse.example.com
 				port: "8123"
 				user: analytics
@@ -114,7 +114,7 @@ func TestNewConfig(t *testing.T) {
 			name: "https with secure connection",
 			yaml: `
 				name: secure-clickhouse
-				kind: clickhouse
+				type: clickhouse
 				host: secure.clickhouse.io
 				port: "8443"
 				user: secureuser
@@ -167,7 +167,7 @@ func TestNewConfigInvalidYAML(t *testing.T) {
 			name: "invalid yaml syntax",
 			yaml: `
 				name: test-clickhouse
-				kind: clickhouse
+				type: clickhouse
 				host: [invalid
 			`,
 			expectError: true,
@@ -176,7 +176,7 @@ func TestNewConfigInvalidYAML(t *testing.T) {
 			name: "missing required fields",
 			yaml: `
 				name: test-clickhouse
-				kind: clickhouse
+				type: clickhouse
 			`,
 			expectError: false,
 		},

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
@@ -50,7 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 type Config struct {
 	// Cloud SQL MSSQL configs
 	Name      string         `yaml:"name" validate:"required"`
-	Type      string         `yaml:"kind" validate:"required"`
+	Type      string         `yaml:"type" validate:"required"`
 	Project   string         `yaml:"project" validate:"required"`
 	Region    string         `yaml:"region" validate:"required"`
 	Instance  string         `yaml:"instance" validate:"required"`

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql_test.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlCloudSQLMssql(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: cloud-sql-mssql
+					type: cloud-sql-mssql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -89,7 +89,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: cloud-sql-mssql
+					type: cloud-sql-mssql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -106,7 +106,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: cloud-sql-mssql
+					type: cloud-sql-mssql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -116,14 +116,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					password: my_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-instance\" as \"cloud-sql-mssql\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | ipAddress: localhost\n   5 | kind: cloud-sql-mssql\n   6 | ",
+			err: "unable to parse source \"my-instance\" as \"cloud-sql-mssql\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | ipAddress: localhost\n   5 | type: cloud-sql-mssql\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-instance:
-					kind: cloud-sql-mssql
+					type: cloud-sql-mssql
 					region: my-region
 					instance: my-instance
 					database: my_db

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string         `yaml:"name" validate:"required"`
-	Type     string         `yaml:"kind" validate:"required"`
+	Type     string         `yaml:"type" validate:"required"`
 	Project  string         `yaml:"project" validate:"required"`
 	Region   string         `yaml:"region" validate:"required"`
 	Instance string         `yaml:"instance" validate:"required"`

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql_test.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: cloud-sql-mysql
+					type: cloud-sql-mysql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -62,7 +62,7 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: cloud-sql-mysql
+					type: cloud-sql-mysql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -90,7 +90,7 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: cloud-sql-mysql
+					type: cloud-sql-mysql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -143,7 +143,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: cloud-sql-mysql
+					type: cloud-sql-mysql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -159,7 +159,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: cloud-sql-mysql
+					type: cloud-sql-mysql
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -168,14 +168,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					password: my_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-mysql-instance\" as \"cloud-sql-mysql\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | kind: cloud-sql-mysql\n   5 | password: my_pass\n   6 | ",
+			err: "unable to parse source \"my-mysql-instance\" as \"cloud-sql-mysql\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | type: cloud-sql-mysql\n   5 | password: my_pass\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: cloud-sql-mysql
+					type: cloud-sql-mysql
 					region: my-region
 					instance: my-instance
 					database: my_db

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string         `yaml:"name" validate:"required"`
-	Type     string         `yaml:"kind" validate:"required"`
+	Type     string         `yaml:"type" validate:"required"`
 	Project  string         `yaml:"project" validate:"required"`
 	Region   string         `yaml:"region" validate:"required"`
 	Instance string         `yaml:"instance" validate:"required"`

--- a/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: cloud-sql-postgres
+					type: cloud-sql-postgres
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -62,7 +62,7 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: cloud-sql-postgres
+					type: cloud-sql-postgres
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -90,7 +90,7 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: cloud-sql-postgres
+					type: cloud-sql-postgres
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -143,7 +143,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: cloud-sql-postgres
+					type: cloud-sql-postgres
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -159,7 +159,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: cloud-sql-postgres
+					type: cloud-sql-postgres
 					project: my-project
 					region: my-region
 					instance: my-instance
@@ -168,14 +168,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					password: my_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-pg-instance\" as \"cloud-sql-postgres\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | kind: cloud-sql-postgres\n   5 | password: my_pass\n   6 | ",
+			err: "unable to parse source \"my-pg-instance\" as \"cloud-sql-postgres\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | type: cloud-sql-postgres\n   5 | password: my_pass\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-pg-instance:
-					kind: cloud-sql-postgres
+					type: cloud-sql-postgres
 					region: my-region
 					instance: my-instance
 					database: my_db

--- a/internal/sources/couchbase/couchbase.go
+++ b/internal/sources/couchbase/couchbase.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name                 string `yaml:"name" validate:"required"`
-	Type                 string `yaml:"kind" validate:"required"`
+	Type                 string `yaml:"type" validate:"required"`
 	ConnectionString     string `yaml:"connectionString" validate:"required"`
 	Bucket               string `yaml:"bucket" validate:"required"`
 	Scope                string `yaml:"scope" validate:"required"`

--- a/internal/sources/couchbase/couchbase_test.go
+++ b/internal/sources/couchbase/couchbase_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlCouchbase(t *testing.T) {
 			in: `
 			sources:
 				my-couchbase-instance:
-					kind: couchbase
+					type: couchbase
 					connectionString: localhost
 					username: Administrator
 					password: password
@@ -59,7 +59,7 @@ func TestParseFromYamlCouchbase(t *testing.T) {
 			in: `
 			sources:
 				my-couchbase-instance:
-					kind: couchbase
+					type: couchbase
 					connectionString: couchbases://localhost
 					bucket: travel-sample
 					scope: inventory
@@ -117,7 +117,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-couchbase-instance:
-					kind: couchbase
+					type: couchbase
 					connectionString: localhost
 					username: Administrator
 					password: password
@@ -125,14 +125,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					scope: inventory
 					foo: bar
 			`,
-			err: "unable to parse source \"my-couchbase-instance\" as \"couchbase\": [3:1] unknown field \"foo\"\n   1 | bucket: travel-sample\n   2 | connectionString: localhost\n>  3 | foo: bar\n       ^\n   4 | kind: couchbase\n   5 | password: password\n   6 | scope: inventory\n   7 | ",
+			err: "unable to parse source \"my-couchbase-instance\" as \"couchbase\": [3:1] unknown field \"foo\"\n   1 | bucket: travel-sample\n   2 | connectionString: localhost\n>  3 | foo: bar\n       ^\n   4 | type: couchbase\n   5 | password: password\n   6 | scope: inventory\n   7 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-couchbase-instance:
-					kind: couchbase
+					type: couchbase
 					username: Administrator
 					password: password
 					bucket: travel-sample

--- a/internal/sources/dataplex/dataplex.go
+++ b/internal/sources/dataplex/dataplex.go
@@ -49,7 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 type Config struct {
 	// Dataplex configs
 	Name    string `yaml:"name" validate:"required"`
-	Type    string `yaml:"kind" validate:"required"`
+	Type    string `yaml:"type" validate:"required"`
 	Project string `yaml:"project" validate:"required"`
 }
 

--- a/internal/sources/dataplex/dataplex_test.go
+++ b/internal/sources/dataplex/dataplex_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlDataplex(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: dataplex
+					type: dataplex
 					project: my-project
 			`,
 			want: server.SourceConfigs{
@@ -76,18 +76,18 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-instance:
-					kind: dataplex
+					type: dataplex
 					project: my-project
 					foo: bar
 			`,
-			err: "unable to parse source \"my-instance\" as \"dataplex\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | kind: dataplex\n   3 | project: my-project",
+			err: "unable to parse source \"my-instance\" as \"dataplex\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | type: dataplex\n   3 | project: my-project",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-instance:
-					kind: dataplex
+					type: dataplex
 			`,
 			err: "unable to parse source \"my-instance\" as \"dataplex\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",
 		},

--- a/internal/sources/dgraph/dgraph.go
+++ b/internal/sources/dgraph/dgraph.go
@@ -66,7 +66,7 @@ type DgraphClient struct {
 
 type Config struct {
 	Name      string `yaml:"name" validate:"required"`
-	Type      string `yaml:"kind" validate:"required"`
+	Type      string `yaml:"type" validate:"required"`
 	DgraphUrl string `yaml:"dgraphUrl" validate:"required"`
 	User      string `yaml:"user"`
 	Password  string `yaml:"password"`

--- a/internal/sources/dgraph/dgraph_test.go
+++ b/internal/sources/dgraph/dgraph_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlDgraph(t *testing.T) {
 			in: `
 			sources:
 				my-dgraph-instance:
-					kind: dgraph
+					type: dgraph
 					dgraphUrl: https://localhost:8080
 					apiKey: abc123
 					password: pass@123
@@ -59,7 +59,7 @@ func TestParseFromYamlDgraph(t *testing.T) {
 			in: `
 			sources:
 				my-dgraph-instance:
-					kind: dgraph
+					type: dgraph
 					dgraphUrl: https://localhost:8080
 			`,
 			want: server.SourceConfigs{
@@ -102,18 +102,18 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-dgraph-instance:
-					kind: dgraph
+					type: dgraph
 					dgraphUrl: https://localhost:8080
 					foo: bar
 			`,
-			err: "unable to parse source \"my-dgraph-instance\" as \"dgraph\": [2:1] unknown field \"foo\"\n   1 | dgraphUrl: https://localhost:8080\n>  2 | foo: bar\n       ^\n   3 | kind: dgraph",
+			err: "unable to parse source \"my-dgraph-instance\" as \"dgraph\": [2:1] unknown field \"foo\"\n   1 | dgraphUrl: https://localhost:8080\n>  2 | foo: bar\n       ^\n   3 | type: dgraph",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-dgraph-instance:
-					kind: dgraph
+					type: dgraph
 			`,
 			err: "unable to parse source \"my-dgraph-instance\" as \"dgraph\": Key: 'Config.DgraphUrl' Error:Field validation for 'DgraphUrl' failed on the 'required' tag",
 		},

--- a/internal/sources/firebird/firebird.go
+++ b/internal/sources/firebird/firebird.go
@@ -45,7 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Host     string `yaml:"host" validate:"required"`
 	Port     string `yaml:"port" validate:"required"`
 	User     string `yaml:"user" validate:"required"`

--- a/internal/sources/firebird/firebird_test.go
+++ b/internal/sources/firebird/firebird_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlFirebird(t *testing.T) {
 			in: `
 			sources:
 				my-fdb-instance:
-					kind: firebird
+					type: firebird
 					host: my-host
 					port: my-port
 					database: my_db
@@ -84,7 +84,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-fdb-instance:
-					kind: firebird
+					type: firebird
 					host: my-host
 					port: my-port
 					database: my_db
@@ -92,14 +92,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					password: my_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-fdb-instance\" as \"firebird\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: my-host\n   4 | kind: firebird\n   5 | password: my_pass\n   6 | ",
+			err: "unable to parse source \"my-fdb-instance\" as \"firebird\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: my-host\n   4 | type: firebird\n   5 | password: my_pass\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-fdb-instance:
-					kind: firebird
+					type: firebird
 					host: my-host
 					port: my-port
 					database: my_db

--- a/internal/sources/firestore/firestore.go
+++ b/internal/sources/firestore/firestore.go
@@ -49,7 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 type Config struct {
 	// Firestore configs
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Project  string `yaml:"project" validate:"required"`
 	Database string `yaml:"database"` // Optional, defaults to "(default)"
 }

--- a/internal/sources/firestore/firestore_test.go
+++ b/internal/sources/firestore/firestore_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlFirestore(t *testing.T) {
 			in: `
 			sources:
 				my-firestore:
-					kind: firestore
+					type: firestore
 					project: my-project
 			`,
 			want: server.SourceConfigs{
@@ -52,7 +52,7 @@ func TestParseFromYamlFirestore(t *testing.T) {
 			in: `
 			sources:
 				my-firestore:
-					kind: firestore
+					type: firestore
 					project: my-project
 					database: my-database
 			`,
@@ -94,18 +94,18 @@ func TestFailParseFromYamlFirestore(t *testing.T) {
 			in: `
 			sources:
 				my-firestore:
-					kind: firestore
+					type: firestore
 					project: my-project
 					foo: bar
 			`,
-			err: "unable to parse source \"my-firestore\" as \"firestore\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | kind: firestore\n   3 | project: my-project",
+			err: "unable to parse source \"my-firestore\" as \"firestore\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | type: firestore\n   3 | project: my-project",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-firestore:
-					kind: firestore
+					type: firestore
 					database: my-database
 			`,
 			err: "unable to parse source \"my-firestore\" as \"firestore\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",

--- a/internal/sources/http/http.go
+++ b/internal/sources/http/http.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name                   string            `yaml:"name" validate:"required"`
-	Type                   string            `yaml:"kind" validate:"required"`
+	Type                   string            `yaml:"type" validate:"required"`
 	BaseURL                string            `yaml:"baseUrl"`
 	Timeout                string            `yaml:"timeout"`
 	DefaultHeaders         map[string]string `yaml:"headers"`

--- a/internal/sources/http/http_test.go
+++ b/internal/sources/http/http_test.go
@@ -36,7 +36,7 @@ func TestParseFromYamlHttp(t *testing.T) {
 			in: `
 			sources:
 				my-http-instance:
-					kind: http
+					type: http
 					baseUrl: http://test_server/
 			`,
 			want: map[string]sources.SourceConfig{
@@ -54,7 +54,7 @@ func TestParseFromYamlHttp(t *testing.T) {
 			in: `
 			sources:
 				my-http-instance:
-					kind: http
+					type: http
 					baseUrl: http://test_server/
 					timeout: 10s
 					headers:
@@ -106,7 +106,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-http-instance:
-					kind: http
+					type: http
 					baseUrl: http://test_server/
 					timeout: 10s
 					headers:
@@ -115,7 +115,7 @@ func TestFailParseFromYaml(t *testing.T) {
 						api-key: test_api_key
 					project: test-project
 			`,
-			err: "unable to parse source \"my-http-instance\" as \"http\": [5:1] unknown field \"project\"\n   2 | headers:\n   3 |   Authorization: test_header\n   4 | kind: http\n>  5 | project: test-project\n       ^\n   6 | queryParams:\n   7 |   api-key: test_api_key\n   8 | timeout: 10s",
+			err: "unable to parse source \"my-http-instance\" as \"http\": [5:1] unknown field \"project\"\n   2 | headers:\n   3 |   Authorization: test_header\n   4 | type: http\n>  5 | project: test-project\n       ^\n   6 | queryParams:\n   7 |   api-key: test_api_key\n   8 | timeout: 10s",
 		},
 		{
 			desc: "missing required field",
@@ -124,7 +124,7 @@ func TestFailParseFromYaml(t *testing.T) {
 				my-http-instance:
 					baseUrl: http://test_server/
 			`,
-			err: "missing 'kind' field for source \"my-http-instance\"",
+			err: "missing 'type' field for source \"my-http-instance\"",
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/sources/looker/looker.go
+++ b/internal/sources/looker/looker.go
@@ -56,7 +56,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name               string `yaml:"name" validate:"required"`
-	Type               string `yaml:"kind" validate:"required"`
+	Type               string `yaml:"type" validate:"required"`
 	BaseURL            string `yaml:"base_url" validate:"required"`
 	ClientId           string `yaml:"client_id" validate:"required"`
 	ClientSecret       string `yaml:"client_secret" validate:"required"`

--- a/internal/sources/looker/looker_test.go
+++ b/internal/sources/looker/looker_test.go
@@ -36,7 +36,7 @@ func TestParseFromYamlLooker(t *testing.T) {
 			in: `
 			sources:
 				my-looker-instance:
-					kind: looker
+					type: looker
 					base_url: http://example.looker.com/
 					client_id: jasdl;k;tjl
 					client_secret: sdakl;jgflkasdfkfg
@@ -86,20 +86,20 @@ func TestFailParseFromYamlLooker(t *testing.T) {
 			in: `
 			sources:
 				my-looker-instance:
-					kind: looker
+					type: looker
 					base_url: http://example.looker.com/
 					client_id: jasdl;k;tjl
 					client_secret: sdakl;jgflkasdfkfg
 					project: test-project
 			`,
-			err: "unable to parse source \"my-looker-instance\" as \"looker\": [5:1] unknown field \"project\"\n   2 | client_id: jasdl;k;tjl\n   3 | client_secret: sdakl;jgflkasdfkfg\n   4 | kind: looker\n>  5 | project: test-project\n       ^\n",
+			err: "unable to parse source \"my-looker-instance\" as \"looker\": [5:1] unknown field \"project\"\n   2 | client_id: jasdl;k;tjl\n   3 | client_secret: sdakl;jgflkasdfkfg\n   4 | type: looker\n>  5 | project: test-project\n       ^\n",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-looker-instance:
-					kind: looker
+					type: looker
 					base_url: http://example.looker.com/
 					client_id: jasdl;k;tjl
 			`,

--- a/internal/sources/mongodb/mongodb.go
+++ b/internal/sources/mongodb/mongodb.go
@@ -47,7 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name string `yaml:"name" validate:"required"`
-	Type string `yaml:"kind" validate:"required"`
+	Type string `yaml:"type" validate:"required"`
 	Uri  string `yaml:"uri" validate:"required"` // MongoDB Atlas connection URI
 }
 

--- a/internal/sources/mongodb/mongodb_test.go
+++ b/internal/sources/mongodb/mongodb_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlMongoDB(t *testing.T) {
 			in: `
 			sources:
 				mongo-db:
-					kind: "mongodb"
+					type: "mongodb"
 					uri: "mongodb+srv://username:password@host/dbname"
 			`,
 			want: server.SourceConfigs{
@@ -76,18 +76,18 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				mongo-db:
-					kind: mongodb
+					type: mongodb
 					uri: "mongodb+srv://username:password@host/dbname"
 					foo: bar
 			`,
-			err: "unable to parse source \"mongo-db\" as \"mongodb\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | kind: mongodb\n   3 | uri: mongodb+srv://username:password@host/dbname",
+			err: "unable to parse source \"mongo-db\" as \"mongodb\": [1:1] unknown field \"foo\"\n>  1 | foo: bar\n       ^\n   2 | type: mongodb\n   3 | uri: mongodb+srv://username:password@host/dbname",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				mongo-db:
-					kind: mongodb
+					type: mongodb
 			`,
 			err: "unable to parse source \"mongo-db\" as \"mongodb\": Key: 'Config.Uri' Error:Field validation for 'Uri' failed on the 'required' tag",
 		},

--- a/internal/sources/mssql/mssql.go
+++ b/internal/sources/mssql/mssql.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 type Config struct {
 	// Cloud SQL MSSQL configs
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Host     string `yaml:"host" validate:"required"`
 	Port     string `yaml:"port" validate:"required"`
 	User     string `yaml:"user" validate:"required"`

--- a/internal/sources/mssql/mssql_test.go
+++ b/internal/sources/mssql/mssql_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlMssql(t *testing.T) {
 			in: `
 			sources:
 				my-mssql-instance:
-					kind: mssql
+					type: mssql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -59,7 +59,7 @@ func TestParseFromYamlMssql(t *testing.T) {
 			in: `
 			sources:
 				my-mssql-instance:
-					kind: mssql
+					type: mssql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -109,7 +109,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-mssql-instance:
-					kind: mssql
+					type: mssql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -117,14 +117,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					password: my_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-mssql-instance\" as \"mssql\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: 0.0.0.0\n   4 | kind: mssql\n   5 | password: my_pass\n   6 | ",
+			err: "unable to parse source \"my-mssql-instance\" as \"mssql\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: 0.0.0.0\n   4 | type: mssql\n   5 | password: my_pass\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-mssql-instance:
-					kind: mssql
+					type: mssql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db

--- a/internal/sources/mysql/mysql.go
+++ b/internal/sources/mysql/mysql.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name         string            `yaml:"name" validate:"required"`
-	Type         string            `yaml:"kind" validate:"required"`
+	Type         string            `yaml:"type" validate:"required"`
 	Host         string            `yaml:"host" validate:"required"`
 	Port         string            `yaml:"port" validate:"required"`
 	User         string            `yaml:"user" validate:"required"`

--- a/internal/sources/mysql/mysql_test.go
+++ b/internal/sources/mysql/mysql_test.go
@@ -40,7 +40,7 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: mysql
+					type: mysql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -64,7 +64,7 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: mysql
+					type: mysql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -90,7 +90,7 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: mysql
+					type: mysql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -147,7 +147,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: mysql
+					type: mysql
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -162,7 +162,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: mysql
+					type: mysql
 					port: my-port
 					database: my_db
 					user: my_user
@@ -175,7 +175,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-mysql-instance:
-					kind: mysql
+					type: mysql
 					host: 0.0.0.0
 					port: 3306
 					database: my_db

--- a/internal/sources/neo4j/neo4j.go
+++ b/internal/sources/neo4j/neo4j.go
@@ -45,7 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Uri      string `yaml:"uri" validate:"required"`
 	User     string `yaml:"user" validate:"required"`
 	Password string `yaml:"password" validate:"required"`

--- a/internal/sources/neo4j/neo4j_test.go
+++ b/internal/sources/neo4j/neo4j_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlNeo4j(t *testing.T) {
 			in: `
 			sources:
 				my-neo4j-instance:
-					kind: neo4j
+					type: neo4j
 					uri: neo4j+s://my-host:7687
 					database: my_db
 					user: my_user
@@ -82,21 +82,21 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-neo4j-instance:
-					kind: neo4j
+					type: neo4j
 					uri: neo4j+s://my-host:7687
 					database: my_db
 					user: my_user
 					password: my_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-neo4j-instance\" as \"neo4j\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | kind: neo4j\n   4 | password: my_pass\n   5 | uri: neo4j+s://my-host:7687\n   6 | ",
+			err: "unable to parse source \"my-neo4j-instance\" as \"neo4j\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | type: neo4j\n   4 | password: my_pass\n   5 | uri: neo4j+s://my-host:7687\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-neo4j-instance:
-					kind: neo4j
+					type: neo4j
 					uri: neo4j+s://my-host:7687
 					database: my_db
 					user: my_user

--- a/internal/sources/oceanbase/oceanbase.go
+++ b/internal/sources/oceanbase/oceanbase.go
@@ -47,7 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name         string `yaml:"name" validate:"required"`
-	Type         string `yaml:"kind" validate:"required"`
+	Type         string `yaml:"type" validate:"required"`
 	Host         string `yaml:"host" validate:"required"`
 	Port         string `yaml:"port" validate:"required"`
 	User         string `yaml:"user" validate:"required"`

--- a/internal/sources/oceanbase/oceanbase_test.go
+++ b/internal/sources/oceanbase/oceanbase_test.go
@@ -36,7 +36,7 @@ func TestParseFromYamlOceanBase(t *testing.T) {
 			in: `
 			sources:
 				my-oceanbase-instance:
-					kind: oceanbase
+					type: oceanbase
 					host: 0.0.0.0
 					port: 2881
 					database: ob_db
@@ -60,7 +60,7 @@ func TestParseFromYamlOceanBase(t *testing.T) {
 			in: `
 			sources:
 				my-oceanbase-instance:
-					kind: oceanbase
+					type: oceanbase
 					host: 0.0.0.0
 					port: 2881
 					database: ob_db
@@ -111,7 +111,7 @@ func TestFailParseFromYamlOceanBase(t *testing.T) {
 			in: `
 			sources:
 				my-oceanbase-instance:
-					kind: oceanbase
+					type: oceanbase
 					host: 0.0.0.0
 					port: 2881
 					database: ob_db
@@ -119,14 +119,14 @@ func TestFailParseFromYamlOceanBase(t *testing.T) {
 					password: ob_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-oceanbase-instance\" as \"oceanbase\": [2:1] unknown field \"foo\"\n   1 | database: ob_db\n>  2 | foo: bar\n       ^\n   3 | host: 0.0.0.0\n   4 | kind: oceanbase\n   5 | password: ob_pass\n   6 | ",
+			err: "unable to parse source \"my-oceanbase-instance\" as \"oceanbase\": [2:1] unknown field \"foo\"\n   1 | database: ob_db\n>  2 | foo: bar\n       ^\n   3 | host: 0.0.0.0\n   4 | type: oceanbase\n   5 | password: ob_pass\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-oceanbase-instance:
-					kind: oceanbase
+					type: oceanbase
 					port: 2881
 					database: ob_db
 					user: ob_user

--- a/internal/sources/postgres/postgres.go
+++ b/internal/sources/postgres/postgres.go
@@ -47,7 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name        string            `yaml:"name" validate:"required"`
-	Type        string            `yaml:"kind" validate:"required"`
+	Type        string            `yaml:"type" validate:"required"`
 	Host        string            `yaml:"host" validate:"required"`
 	Port        string            `yaml:"port" validate:"required"`
 	User        string            `yaml:"user" validate:"required"`

--- a/internal/sources/postgres/postgres_test.go
+++ b/internal/sources/postgres/postgres_test.go
@@ -37,7 +37,7 @@ func TestParseFromYamlPostgres(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: postgres
+					type: postgres
 					host: my-host
 					port: my-port
 					database: my_db
@@ -61,7 +61,7 @@ func TestParseFromYamlPostgres(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: postgres
+					type: postgres
 					host: my-host
 					port: my-port
 					database: my_db
@@ -117,7 +117,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-pg-instance:
-					kind: postgres
+					type: postgres
 					host: my-host
 					port: my-port
 					database: my_db
@@ -125,14 +125,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					password: my_pass
 					foo: bar
 			`,
-			err: "unable to parse source \"my-pg-instance\" as \"postgres\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: my-host\n   4 | kind: postgres\n   5 | password: my_pass\n   6 | ",
+			err: "unable to parse source \"my-pg-instance\" as \"postgres\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: my-host\n   4 | type: postgres\n   5 | password: my_pass\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-pg-instance:
-					kind: postgres
+					type: postgres
 					host: my-host
 					port: my-port
 					database: my_db

--- a/internal/sources/redis/redis.go
+++ b/internal/sources/redis/redis.go
@@ -45,7 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name           string   `yaml:"name" validate:"required"`
-	Type           string   `yaml:"kind" validate:"required"`
+	Type           string   `yaml:"type" validate:"required"`
 	Address        []string `yaml:"address" validate:"required"`
 	Username       string   `yaml:"username"`
 	Password       string   `yaml:"password"`

--- a/internal/sources/redis/redis_test.go
+++ b/internal/sources/redis/redis_test.go
@@ -36,7 +36,7 @@ func TestParseFromYamlRedis(t *testing.T) {
 			in: `
 			sources:
 				my-redis-instance:
-					kind: redis
+					type: redis
 					address:
 					  - 127.0.0.1
 			`,
@@ -55,7 +55,7 @@ func TestParseFromYamlRedis(t *testing.T) {
 			in: `
 			sources:
 				my-redis-instance:
-					kind: redis
+					type: redis
 					address:
 					  - 127.0.0.1
 					password: my-pass
@@ -105,7 +105,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-redis-instance:
-					kind: redis
+					type: redis
 					project: my-project
 					address:
 					  - 127.0.0.1
@@ -119,7 +119,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-redis-instance:
-					kind: redis
+					type: redis
 					project: my-project
 					address:
 					  - 127.0.0.1
@@ -133,7 +133,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-redis-instance:
-					kind: redis
+					type: redis
 			`,
 			err: "unable to parse source \"my-redis-instance\" as \"redis\": Key: 'Config.Address' Error:Field validation for 'Address' failed on the 'required' tag",
 		},

--- a/internal/sources/spanner/spanner.go
+++ b/internal/sources/spanner/spanner.go
@@ -46,7 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string          `yaml:"name" validate:"required"`
-	Type     string          `yaml:"kind" validate:"required"`
+	Type     string          `yaml:"type" validate:"required"`
 	Project  string          `yaml:"project" validate:"required"`
 	Instance string          `yaml:"instance" validate:"required"`
 	Dialect  sources.Dialect `yaml:"dialect" validate:"required"`

--- a/internal/sources/spanner/spanner_test.go
+++ b/internal/sources/spanner/spanner_test.go
@@ -36,7 +36,7 @@ func TestParseFromYamlSpannerDb(t *testing.T) {
 			in: `
 			sources:
 				my-spanner-instance:
-					kind: spanner
+					type: spanner
 					project: my-project
 					instance: my-instance
 					database: my_db
@@ -57,7 +57,7 @@ func TestParseFromYamlSpannerDb(t *testing.T) {
 			in: `
 			sources:
 				my-spanner-instance:
-					kind: spanner
+					type: spanner
 					project: my-project
 					instance: my-instance
 					dialect: Googlesql 
@@ -79,7 +79,7 @@ func TestParseFromYamlSpannerDb(t *testing.T) {
 			in: `
 			sources:
 				my-spanner-instance:
-					kind: spanner
+					type: spanner
 					project: my-project
 					instance: my-instance
 					dialect: postgresql
@@ -126,7 +126,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-spanner-instance:
-					kind: spanner
+					type: spanner
 					project: my-project
 					instance: my-instance
 					dialect: fail
@@ -139,20 +139,20 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-spanner-instance:
-					kind: spanner
+					type: spanner
 					project: my-project
 					instance: my-instance
 					database: my_db
 					foo: bar
 			`,
-			err: "unable to parse source \"my-spanner-instance\" as \"spanner\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | kind: spanner\n   5 | project: my-project",
+			err: "unable to parse source \"my-spanner-instance\" as \"spanner\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | instance: my-instance\n   4 | type: spanner\n   5 | project: my-project",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-spanner-instance:
-					kind: spanner
+					type: spanner
 					project: my-project
 					instance: my-instance
 			`,

--- a/internal/sources/sqlite/sqlite.go
+++ b/internal/sources/sqlite/sqlite.go
@@ -46,7 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Database string `yaml:"database" validate:"required"` // Path to SQLite database file
 }
 

--- a/internal/sources/sqlite/sqlite_test.go
+++ b/internal/sources/sqlite/sqlite_test.go
@@ -36,7 +36,7 @@ func TestParseFromYamlSQLite(t *testing.T) {
 			in: `
             sources:
                 my-sqlite-db:
-                    kind: sqlite
+                    type: sqlite
                     database: /path/to/database.db
             `,
 			want: map[string]sources.SourceConfig{

--- a/internal/sources/tidb/tidb.go
+++ b/internal/sources/tidb/tidb.go
@@ -54,7 +54,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"kind" validate:"required"`
+	Type     string `yaml:"type" validate:"required"`
 	Host     string `yaml:"host" validate:"required"`
 	Port     string `yaml:"port" validate:"required"`
 	User     string `yaml:"user" validate:"required"`

--- a/internal/sources/tidb/tidb_test.go
+++ b/internal/sources/tidb/tidb_test.go
@@ -35,7 +35,7 @@ func TestParseFromYamlTiDB(t *testing.T) {
 			in: `
 			sources:
 				my-tidb-instance:
-					kind: tidb
+					type: tidb
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -60,7 +60,7 @@ func TestParseFromYamlTiDB(t *testing.T) {
 			in: `
 			sources:
 				my-tidb-cloud:
-					kind: tidb
+					type: tidb
 					host: gateway01.us-west-2.prod.aws.tidbcloud.com
 					port: 4000
 					database: test_db
@@ -86,7 +86,7 @@ func TestParseFromYamlTiDB(t *testing.T) {
 			in: `
 			sources:
 				my-tidb-cloud:
-					kind: tidb
+					type: tidb
 					host: gateway01.us-west-2.prod.aws.tidbcloud.com
 					port: 4000
 					database: test_db
@@ -136,7 +136,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-tidb-instance:
-					kind: tidb
+					type: tidb
 					host: 0.0.0.0
 					port: my-port
 					database: my_db
@@ -145,14 +145,14 @@ func TestFailParseFromYaml(t *testing.T) {
 					ssl: false
 					foo: bar
 			`,
-			err: "unable to parse source \"my-tidb-instance\" as \"tidb\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: 0.0.0.0\n   4 | kind: tidb\n   5 | password: my_pass\n   6 | ",
+			err: "unable to parse source \"my-tidb-instance\" as \"tidb\": [2:1] unknown field \"foo\"\n   1 | database: my_db\n>  2 | foo: bar\n       ^\n   3 | host: 0.0.0.0\n   4 | type: tidb\n   5 | password: my_pass\n   6 | ",
 		},
 		{
 			desc: "missing required field",
 			in: `
 			sources:
 				my-tidb-instance:
-					kind: tidb
+					type: tidb
 					port: my-port
 					database: my_db
 					user: my_user

--- a/internal/sources/trino/trino.go
+++ b/internal/sources/trino/trino.go
@@ -48,7 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name            string `yaml:"name" validate:"required"`
-	Type            string `yaml:"kind" validate:"required"`
+	Type            string `yaml:"type" validate:"required"`
 	Host            string `yaml:"host" validate:"required"`
 	Port            string `yaml:"port" validate:"required"`
 	User            string `yaml:"user"`

--- a/internal/sources/trino/trino_test.go
+++ b/internal/sources/trino/trino_test.go
@@ -140,7 +140,7 @@ func TestParseFromYamlTrino(t *testing.T) {
 			in: `
 			sources:
 				my-trino-instance:
-					kind: trino
+					type: trino
 					host: localhost
 					port: "8080"
 					user: testuser
@@ -164,7 +164,7 @@ func TestParseFromYamlTrino(t *testing.T) {
 			in: `
 			sources:
 				my-trino-instance:
-					kind: trino
+					type: trino
 					host: localhost
 					port: "8443"
 					user: testuser
@@ -198,7 +198,7 @@ func TestParseFromYamlTrino(t *testing.T) {
 			in: `
 			sources:
 				my-trino-anonymous:
-					kind: trino
+					type: trino
 					host: localhost
 					port: "8080"
 					catalog: hive

--- a/internal/sources/valkey/valkey.go
+++ b/internal/sources/valkey/valkey.go
@@ -45,7 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
-	Type         string   `yaml:"kind" validate:"required"`
+	Type         string   `yaml:"type" validate:"required"`
 	Address      []string `yaml:"address" validate:"required"`
 	Username     string   `yaml:"username"`
 	Password     string   `yaml:"password"`

--- a/internal/sources/valkey/valkey_test.go
+++ b/internal/sources/valkey/valkey_test.go
@@ -37,7 +37,7 @@ func TestParseFromYamlValkey(t *testing.T) {
 			in: `
 			sources:
 				my-valkey-instance:
-					kind: valkey
+					type: valkey
 					address:
 					  - 127.0.0.1
 			`,
@@ -59,7 +59,7 @@ func TestParseFromYamlValkey(t *testing.T) {
 			in: `
 			sources:
 				my-valkey-instance:
-					kind: valkey
+					type: valkey
 					address:
 					  - 127.0.0.1
 					database: 1
@@ -111,7 +111,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-valkey-instance:
-					kind: valkey
+					type: valkey
 					project: my-project
 					address:
 					  - 127.0.0.1
@@ -125,7 +125,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-valkey-instance:
-					kind: valkey
+					type: valkey
 					address:
 					  - 127.0.0.1
 					project: proj
@@ -138,7 +138,7 @@ func TestFailParseFromYaml(t *testing.T) {
 			in: `
 			sources:
 				my-valkey-instance:
-					kind: valkey
+					type: valkey
 			`,
 			err: "unable to parse source \"my-valkey-instance\" as \"valkey\": Key: 'Config.Address' Error:Field validation for 'Address' failed on the 'required' tag",
 		},


### PR DESCRIPTION
Update yaml tag in source and auth services from `kind` to `type`.

We'll need all yaml tag updates in order for the tests to pass.