### PR TITLE
feat(source/cloudsqladmin): Add cloud sql admin source

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,6 +125,7 @@ import (
 	_ "github.com/googleapis/genai-toolbox/internal/sources/bigquery"
 	_ "github.com/googleapis/genai-toolbox/internal/sources/bigtable"
 	_ "github.com/googleapis/genai-toolbox/internal/sources/clickhouse"
+	_ "github.com/googleapis/genai-toolbox/internal/sources/cloudsqladmin"
 	_ "github.com/googleapis/genai-toolbox/internal/sources/cloudsqlmssql"
 	_ "github.com/googleapis/genai-toolbox/internal/sources/cloudsqlmysql"
 	_ "github.com/googleapis/genai-toolbox/internal/sources/cloudsqlpg"

--- a/docs/en/resources/sources/cloud-sql-admin.md
+++ b/docs/en/resources/sources/cloud-sql-admin.md
@@ -1,0 +1,36 @@
+---
+title: "Cloud SQL Admin"
+type: docs
+weight: 1
+description: >
+  A "cloud-sql-admin" source provides a client for the Cloud SQL Admin API.
+aliases:
+- /resources/sources/cloud-sql-admin
+---
+
+## About
+
+The `cloud-sql-admin` source provides a client to interact with the [Google Cloud SQL Admin API](https://cloud.google.com/sql/docs/mysql/admin-api/v1). This allows tools to perform administrative tasks on Cloud SQL instances, such as creating users and databases.
+
+Authentication can be handled in two ways:
+1.  **Application Default Credentials (ADC):** By default, the source uses ADC to authenticate with the API.
+2.  **Client-side OAuth:** If `useClientOAuth` is set to `true`, the source will expect an OAuth 2.0 access token to be provided by the client (e.g., a web browser) for each request.
+
+## Example
+
+```yaml
+sources:
+    my-cloud-sql-admin:
+        kind: cloud-sql-admin
+
+    my-oauth-cloud-sql-admin:
+        kind: cloud-sql-admin
+        useClientOAuth: true
+```
+
+## Reference
+
+| **field**      | **type** | **required** | **description**                                                                                                                                                           |
+|----------------|:--------:|:------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| kind           |  string  |     true     | Must be "cloud-sql-admin".                                                                                                                                                |
+| useClientOAuth | boolean  |    false     | If true, the source will use client-side OAuth for authorization. Otherwise, it will use Application Default Credentials. Defaults to `false`. |

--- a/internal/sources/cloudsqladmin/cloud_sql_admin.go
+++ b/internal/sources/cloudsqladmin/cloud_sql_admin.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cloudsqladmin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/goccy/go-yaml"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+)
+
+const SourceKind string = "cloud-sql-admin"
+
+// validate interface
+var _ sources.SourceConfig = Config{}
+
+func init() {
+	if !sources.Register(SourceKind, newConfig) {
+		panic(fmt.Sprintf("source kind %q already registered", SourceKind))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources.SourceConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+type Config struct {
+	Name           string `yaml:"name" validate:"required"`
+	Kind           string `yaml:"kind" validate:"required"`
+	UseClientOAuth bool   `yaml:"useClientOAuth"`
+}
+
+func (r Config) SourceConfigKind() string {
+	return SourceKind
+}
+
+// Initialize initializes a CloudSQL Admin Source instance.
+func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
+	ua, err := util.UserAgentFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error in User Agent retrieval: %s", err)
+	}
+
+	var client *http.Client
+	if r.UseClientOAuth {
+		client = nil
+	} else {
+		// Use Application Default Credentials
+		creds, err := google.FindDefaultCredentials(ctx, sqladmin.SqlserviceAdminScope)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		}
+		client = oauth2.NewClient(ctx, creds.TokenSource)
+	}
+
+	s := &Source{
+		Name:           r.Name,
+		Kind:           SourceKind,
+		BaseURL:        "https://sqladmin.googleapis.com",
+		Client:         client,
+		UserAgent:      ua,
+		UseClientOAuth: r.UseClientOAuth,
+	}
+	return s, nil
+}
+
+var _ sources.Source = &Source{}
+
+type Source struct {
+	Name           string `yaml:"name"`
+	Kind           string `yaml:"kind"`
+	BaseURL        string
+	Client         *http.Client
+	UserAgent      string
+	UseClientOAuth bool
+}
+
+func (s *Source) SourceKind() string {
+	return SourceKind
+}
+
+func (s *Source) GetClient(ctx context.Context, accessToken string) (*http.Client, error) {
+	if s.UseClientOAuth {
+		if accessToken == "" {
+			return nil, fmt.Errorf("client-side OAuth is enabled but no access token was provided")
+		}
+		token := &oauth2.Token{AccessToken: accessToken}
+		return oauth2.NewClient(ctx, oauth2.StaticTokenSource(token)), nil
+	}
+	return s.Client, nil
+}
+
+func (s *Source) UseClientAuthorization() bool {
+	return s.UseClientOAuth
+}

--- a/internal/sources/cloudsqladmin/cloud_sql_admin_test.go
+++ b/internal/sources/cloudsqladmin/cloud_sql_admin_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqladmin_test
+
+import (
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/sources/cloudsqladmin"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+)
+
+func TestParseFromYamlCloudSQLAdmin(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		desc string
+		in   string
+		want server.SourceConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			sources:
+				my-cloud-sql-admin-instance:
+					kind: cloud-sql-admin
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-cloud-sql-admin-instance": cloudsqladmin.Config{
+					Name:           "my-cloud-sql-admin-instance",
+					Kind:           cloudsqladmin.SourceKind,
+					UseClientOAuth: false,
+				},
+			},
+		},
+		{
+			desc: "use client auth example",
+			in: `
+			sources:
+				my-cloud-sql-admin-instance:
+					kind: cloud-sql-admin
+					useClientOAuth: true
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-cloud-sql-admin-instance": cloudsqladmin.Config{
+					Name:           "my-cloud-sql-admin-instance",
+					Kind:           cloudsqladmin.SourceKind,
+					UseClientOAuth: true,
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			got := struct {
+				Sources server.SourceConfigs `yaml:"sources"`
+			}{}
+			// Parse contents
+			err := yaml.Unmarshal(testutils.FormatYaml(tc.in), &got)
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if !cmp.Equal(tc.want, got.Sources) {
+				t.Fatalf("incorrect parse: want %v, got %v", tc.want, got.Sources)
+			}
+		})
+	}
+}
+
+func TestFailParseFromYaml(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		desc string
+		in   string
+		err  string
+	}{
+		{
+			desc: "extra field",
+			in: `
+			sources:
+				my-cloud-sql-admin-instance:
+					kind: cloud-sql-admin
+					project: test-project
+			`,
+			err: `unable to parse source "my-cloud-sql-admin-instance" as "cloud-sql-admin": [2:1] unknown field "project"
+   1 | kind: cloud-sql-admin
+>  2 | project: test-project
+       ^
+`,
+		},
+		{
+			desc: "missing required field",
+			in: `
+			sources:
+				my-cloud-sql-admin-instance:
+					useClientOAuth: true
+			`,
+			err: "missing 'kind' field for source \"my-cloud-sql-admin-instance\"",
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			got := struct {
+				Sources server.SourceConfigs `yaml:"sources"`
+			}{}
+			// Parse contents
+			err := yaml.Unmarshal(testutils.FormatYaml(tc.in), &got)
+			if err == nil {
+				t.Fatalf("expect parsing to fail")
+			}
+			errStr := err.Error()
+			if errStr != tc.err {
+				t.Fatalf("unexpected error: got %q, want %q", errStr, tc.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

---
This PR introduces the `cloud-sql-admin` source, which provides a client for the Google Cloud SQL Admin API.

```

sources:
  my-cloud-sql-admin:
    kind: cloud-sql-admin
```



## PR Checklist

---
> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code!  That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
