### PR TITLE
docs: add tools naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,9 @@ implementation](https://github.com/googleapis/genai-toolbox/blob/main/internal/s
 
 ### Adding a New Tool
 
+> [!NOTE]
+> Please follow the tool naming convention detailed [here](./DEVELOPER.md#tool-naming-conventions).
+
 We recommend looking at an [example tool
 implementation](https://github.com/googleapis/genai-toolbox/tree/main/internal/tools/postgres/postgressql).
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -44,6 +44,47 @@ Before you begin, ensure you have the following:
     curl http://127.0.0.1:5000
     ```
 
+### Tool Naming Conventions
+
+This section details the purpose and conventions for MCP Toolbox's tools naming
+properties, **tool name** and **tool kind**.
+
+```
+cancel_hotel: <- tool name
+    kind: postgres-sql  <- tool kind
+    source: my_pg_source
+```
+
+#### Tool Name
+
+Tool name is the identifier used by a Large Language Model (LLM) to invoke a
+specific tool.
+* Custom tools: The user can define any name they want. The below guidelines
+  do not apply.
+* Pre-built tools: The tool name is predefined and cannot be changed. It
+should follow the guidelines.
+
+The following guidelines apply to tool names:
+* Should use underscores over hyphens (e.g., `list_collections` instead of
+  `list-collections`).
+* Should not have the product name in the name (e.g., `list_collections` instead
+  of `firestore_list_collections`).
+* Superficial changes are NOT considered as breaking (e.g., changing tool name).
+* Non-superficial changes MAY be considered breaking (e.g. adding new parameters
+  to a function) until they can be validated through extensive testing to ensure
+  they do not negatively impact agent's performances.
+
+#### Tool Kind
+
+Tool kind serves as a category or type that a user can assign to a tool.
+
+The following guidelines apply to tool kinds:
+* Should user hyphens over underscores (e.g. `firestore-list-collections` or
+  `firestore_list_colelctions`).
+* Should use product name in name (e.g. `firestore-list-collections` over
+  `list-collections`).
+* Changes to tool kind are breaking changes and should be avoided.
+
 ## Testing
 
 ### Infrastructure


### PR DESCRIPTION
Add guidelines for MCP Toolbox tools naming properties: **tool name** and **tool kind**.