### PR TITLE
feat(source/alloydb-admin): Add user agent and attach alloydb api in alloydb-admin source

### DIFF
--- a/docs/en/resources/tools/alloydb/alloydb-list-instances.md
+++ b/docs/en/resources/tools/alloydb/alloydb-list-instances.md
@@ -35,5 +35,5 @@ tools:
 | **field**   |                  **type**                  | **required** | **description**                                                                                  |
 |-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
 | kind        |                   string                   |     true     | Must be alloydb-list-instances.                                                                  |                                               |
-| source      |                   string                   |     true     | The name of an alloydb-admin source.                                                             |
+| source      |                   string                   |     true     | The name of an `alloydb-admin` source.                                                             |
 | description |                   string                   |     true     | Description of the tool that is passed to the agent.                                             |

--- a/docs/en/resources/tools/alloydb/alloydb-list-users.md
+++ b/docs/en/resources/tools/alloydb/alloydb-list-users.md
@@ -34,5 +34,5 @@ tools:
 | **field**   |                  **type**                  | **required** | **description**                                                                                  |
 |-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
 | kind        |                   string                   |     true     | Must be alloydb-list-users.                                                                  |                                               |
-| source      |                   string                   |     true     | The name of an alloydb-admin source.                                                                       |
+| source      |                   string                   |     true     | The name of an `alloydb-admin` source.                                                                       |
 | description |                   string                   |     true     | Description of the tool that is passed to the agent.                                             |

--- a/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
+++ b/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
@@ -22,8 +22,6 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	alloydbadmin "github.com/googleapis/genai-toolbox/internal/sources/alloydbadmin"
 	"github.com/googleapis/genai-toolbox/internal/tools"
-	"google.golang.org/api/alloydb/v1"
-	"google.golang.org/api/option"
 )
 
 const kind string = "alloydb-get-cluster"
@@ -127,21 +125,14 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken 
 		return nil, fmt.Errorf("invalid 'clusterId' parameter; expected a string")
 	}
 
-	// Get an authenticated HTTP client from the source
-	client, err := t.Source.GetClient(ctx, string(accessToken))
+	service, err := t.Source.GetService(ctx, string(accessToken))
 	if err != nil {
-		return nil, fmt.Errorf("error getting authorized client: %w", err)
-	}
-
-	// Create a new AlloyDB service client using the authorized client
-	alloydbService, err := alloydb.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, fmt.Errorf("error creating AlloyDB service: %w", err)
+		return nil, err
 	}
 
 	urlString := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", projectId, locationId, clusterId)
 
-	resp, err := alloydbService.Projects.Locations.Clusters.Get(urlString).Do()
+	resp, err := service.Projects.Locations.Clusters.Get(urlString).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error getting AlloyDB cluster: %w", err)
 	}

--- a/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
+++ b/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
@@ -22,8 +22,6 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	alloydbadmin "github.com/googleapis/genai-toolbox/internal/sources/alloydbadmin"
 	"github.com/googleapis/genai-toolbox/internal/tools"
-	"google.golang.org/api/alloydb/v1"
-	"google.golang.org/api/option"
 )
 
 const kind string = "alloydb-list-clusters"
@@ -123,21 +121,14 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken 
 		return nil, fmt.Errorf("invalid 'locationId' parameter; expected a string")
 	}
 
-	// Get an authenticated HTTP client from the source
-	client, err := t.Source.GetClient(ctx, string(accessToken))
+	service, err := t.Source.GetService(ctx, string(accessToken))
 	if err != nil {
-		return nil, fmt.Errorf("error getting authorized client: %w", err)
-	}
-
-	// Create a new AlloyDB service client using the authorized client
-	alloydbService, err := alloydb.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, fmt.Errorf("error creating AlloyDB service: %w", err)
+		return nil, err
 	}
 
 	urlString := fmt.Sprintf("projects/%s/locations/%s", projectId, locationId)
 
-	resp, err := alloydbService.Projects.Locations.Clusters.List(urlString).Do()
+	resp, err := service.Projects.Locations.Clusters.List(urlString).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error listing AlloyDB clusters: %w", err)
 	}

--- a/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
+++ b/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
@@ -22,8 +22,6 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	alloydbadmin "github.com/googleapis/genai-toolbox/internal/sources/alloydbadmin"
 	"github.com/googleapis/genai-toolbox/internal/tools"
-	"google.golang.org/api/alloydb/v1"
-	"google.golang.org/api/option"
 )
 
 const kind string = "alloydb-list-instances"
@@ -128,21 +126,14 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken 
 		return nil, fmt.Errorf("invalid 'clusterId' parameter; expected a string")
 	}
 
-	// Get an authenticated HTTP client from the source
-	client, err := t.Source.GetClient(ctx, string(accessToken))
+	service, err := t.Source.GetService(ctx, string(accessToken))
 	if err != nil {
-		return nil, fmt.Errorf("error getting authorized client: %w", err)
-	}
-
-	// Create a new AlloyDB service client using the authorized client
-	alloydbService, err := alloydb.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, fmt.Errorf("error creating AlloyDB service: %w", err)
+		return nil, err
 	}
 
 	urlString := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", projectId, locationId, clusterId)
 
-	resp, err := alloydbService.Projects.Locations.Clusters.Instances.List(urlString).Do()
+	resp, err := service.Projects.Locations.Clusters.Instances.List(urlString).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error listing AlloyDB instances: %w", err)
 	}

--- a/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
+++ b/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
@@ -22,8 +22,6 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	alloydbadmin "github.com/googleapis/genai-toolbox/internal/sources/alloydbadmin"
 	"github.com/googleapis/genai-toolbox/internal/tools"
-	"google.golang.org/api/alloydb/v1"
-	"google.golang.org/api/option"
 )
 
 const kind string = "alloydb-list-users"
@@ -128,21 +126,14 @@ func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken 
 		return nil, fmt.Errorf("invalid 'clusterId' parameter; expected a string")
 	}
 
-	// Get an authenticated HTTP client from the source
-	client, err := t.Source.GetClient(ctx, string(accessToken))
+	service, err := t.Source.GetService(ctx, string(accessToken))
 	if err != nil {
-		return nil, fmt.Errorf("error getting authorized client: %w", err)
-	}
-
-	// Create a new AlloyDB service client using the authorized client
-	alloydbService, err := alloydb.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, fmt.Errorf("error creating AlloyDB service: %w", err)
+		return nil, err
 	}
 
 	urlString := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", projectId, locationId, clusterId)
 
-	resp, err := alloydbService.Projects.Locations.Clusters.Users.List(urlString).Do()
+	resp, err := service.Projects.Locations.Clusters.Users.List(urlString).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error listing AlloyDB users: %w", err)
 	}


### PR DESCRIPTION
## Description

---

- This PR introduces a userAgentRoundTripper that prepends our custom user agent to the existing User-Agent header
- Moves alloydb api client to `alloydb-admin` source
- Updates alloydb control plane tools (`alloydb-get-cluster`, `alloydb-list-clusters`, `alloydb-list-instances`, `alloydb-list-users`)  accordingly.

## PR Checklist

---
> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code!  That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
