### PR TITLE
feat(prebuilt/postgres): add `list_replication_slots` tool

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1352,7 +1352,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"alloydb_postgres_database_tools": tools.ToolsetConfig{
 					Name:      "alloydb_postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_replication_slots"},
 				},
 			},
 		},
@@ -1382,7 +1382,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"cloud_sql_postgres_database_tools": tools.ToolsetConfig{
 					Name:      "cloud_sql_postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_replication_slots"},
 				},
 			},
 		},
@@ -1462,7 +1462,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"postgres_database_tools": tools.ToolsetConfig{
 					Name:      "postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_replication_slots"},
 				},
 			},
 		},

--- a/docs/en/reference/prebuilt-tools.md
+++ b/docs/en/reference/prebuilt-tools.md
@@ -28,6 +28,7 @@ See guides, [Connect from your IDE](../how-to/connect-ide/_index.md), for detail
 *   **Tools:**
     *   `execute_sql`: Executes a SQL query.
     *   `list_tables`: Lists tables in the database.
+    *   `list_replication_slots`: Lists replication slots in the database.
 
 ## AlloyDB Postgres Admin
 
@@ -101,6 +102,7 @@ See guides, [Connect from your IDE](../how-to/connect-ide/_index.md), for detail
 *   **Tools:**
     *   `execute_sql`: Executes a SQL query.
     *   `list_tables`: Lists tables in the database.
+    *   `list_replication_slots`: Lists replication slots in the database.
 
 ## Cloud SQL for SQL Server
 
@@ -238,6 +240,7 @@ See guides, [Connect from your IDE](../how-to/connect-ide/_index.md), for detail
 *   **Tools:**
     *   `execute_sql`: Executes a SQL query.
     *   `list_tables`: Lists tables in the database.
+    *   `list_replication_slots`: Lists replication slots in the database.
 
 ## Spanner (GoogleSQL dialect)
 

--- a/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
@@ -35,7 +35,27 @@ tools:
         source: alloydb-pg-source
         description: "Lists detailed schema information (object type, columns, constraints, indexes, triggers, owner, comment) as JSON for user-created tables (ordinary or partitioned). Filters by a comma-separated list of names. If names are omitted, lists all tables in user schemas."
 
+    list_replication_slots:
+        kind: postgres-sql
+        source: alloydb-pg-source
+        description: "List key details for all PostgreSQL replication slots (e.g., type, database, active status) and calculates the size of the outstanding WAL that is being prevented from removal by the slot."
+        statement: |
+            SELECT
+            slot_name,
+            slot_type,
+            plugin,
+            database,
+            temporary,
+            active,
+            restart_lsn,
+            confirmed_flush_lsn,
+            xmin,
+            catalog_xmin,
+            pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+            FROM pg_replication_slots;
+
 toolsets:
     alloydb_postgres_database_tools:
         - execute_sql
         - list_tables
+        - list_replication_slots

--- a/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
@@ -34,7 +34,27 @@ tools:
         source: cloudsql-pg-source
         description: "Lists detailed schema information (object type, columns, constraints, indexes, triggers, owner, comment) as JSON for user-created tables (ordinary or partitioned). Filters by a comma-separated list of names. If names are omitted, lists all tables in user schemas."
 
+    list_replication_slots:
+        kind: postgres-sql
+        source: cloudsql-pg-source
+        description: "List key details for all PostgreSQL replication slots (e.g., type, database, active status) and calculates the size of the outstanding WAL that is being prevented from removal by the slot."
+        statement: |
+            SELECT
+            slot_name,
+            slot_type,
+            plugin,
+            database,
+            temporary,
+            active,
+            restart_lsn,
+            confirmed_flush_lsn,
+            xmin,
+            catalog_xmin,
+            pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+            FROM pg_replication_slots;
+
 toolsets:
     cloud_sql_postgres_database_tools:
         - execute_sql
         - list_tables
+        - list_replication_slots

--- a/internal/prebuiltconfigs/tools/postgres.yaml
+++ b/internal/prebuiltconfigs/tools/postgres.yaml
@@ -33,7 +33,27 @@ tools:
         source: postgresql-source
         description: "Lists detailed schema information (object type, columns, constraints, indexes, triggers, owner, comment) as JSON for user-created tables (ordinary or partitioned). Filters by a comma-separated list of names. If names are omitted, lists all tables in user schemas."
 
+    list_replication_slots:
+        kind: postgres-sql
+        source: postgresql-source
+        description: "List key details for all PostgreSQL replication slots (e.g., type, database, active status) and calculates the size of the outstanding WAL that is being prevented from removal by the slot."
+        statement: |
+            SELECT
+            slot_name,
+            slot_type,
+            plugin,
+            database,
+            temporary,
+            active,
+            restart_lsn,
+            confirmed_flush_lsn,
+            xmin,
+            catalog_xmin,
+            pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+            FROM pg_replication_slots;
+
 toolsets:
     postgres_database_tools:
         - execute_sql
         - list_tables
+        - list_replication_slots


### PR DESCRIPTION
## Description

Adds a read-only PostgreSQL prebuilt tool `list_replication_slots`, that returns the details of replication slots and WAL retained on it Each row includes: `slot_name`, `slot_type`, `plugin`, `database`, `temporary`, `active`, `restart_lsn`, `confirmed_flush_lsn`, `catalog_min`, `retained_wal`.

**Test Output**
<img width="1411" height="727" alt="image" src="https://github.com/user-attachments/assets/b0161bdd-ca84-4d4e-81bb-31181856c823" />



---
> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

## PR Checklist

---
> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code!  That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change
