### PR TITLE
feat(prebuilt/postgres): add `list_invalid_indexes` tool

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1352,7 +1352,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"alloydb_postgres_database_tools": tools.ToolsetConfig{
 					Name:      "alloydb_postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_invalid_indexes"},
 				},
 			},
 		},
@@ -1382,7 +1382,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"cloud_sql_postgres_database_tools": tools.ToolsetConfig{
 					Name:      "cloud_sql_postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_invalid_indexes"},
 				},
 			},
 		},
@@ -1462,7 +1462,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"postgres_database_tools": tools.ToolsetConfig{
 					Name:      "postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_invalid_indexes"},
 				},
 			},
 		},

--- a/docs/en/reference/prebuilt-tools.md
+++ b/docs/en/reference/prebuilt-tools.md
@@ -28,6 +28,7 @@ See guides, [Connect from your IDE](../how-to/connect-ide/_index.md), for detail
 *   **Tools:**
     *   `execute_sql`: Executes a SQL query.
     *   `list_tables`: Lists tables in the database.
+    *   `list_invalid_indexes`: Lists invalid indexes in the database.
 
 ## AlloyDB Postgres Admin
 
@@ -101,6 +102,7 @@ See guides, [Connect from your IDE](../how-to/connect-ide/_index.md), for detail
 *   **Tools:**
     *   `execute_sql`: Executes a SQL query.
     *   `list_tables`: Lists tables in the database.
+    *   `list_invalid_indexes`: Lists invalid indexes in the database.
 
 ## Cloud SQL for SQL Server
 
@@ -238,6 +240,7 @@ See guides, [Connect from your IDE](../how-to/connect-ide/_index.md), for detail
 *   **Tools:**
     *   `execute_sql`: Executes a SQL query.
     *   `list_tables`: Lists tables in the database.
+    *   `list_invalid_indexes`: Lists invalid indexes in the database.
 
 ## Spanner (GoogleSQL dialect)
 

--- a/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
@@ -35,7 +35,26 @@ tools:
         source: alloydb-pg-source
         description: "Lists detailed schema information (object type, columns, constraints, indexes, triggers, owner, comment) as JSON for user-created tables (ordinary or partitioned). Filters by a comma-separated list of names. If names are omitted, lists all tables in user schemas."
 
+    list_invalid_indexes:
+        kind: postgres-sql
+        source: alloydb-pg-source
+        description: "Lists all invalid PostgreSQL indexes which are taking up disk space but are unusable by the query planner. Typically created by failed CREATE INDEX CONCURRENTLY operations."
+        statement: |
+            SELECT
+                nspname AS schema_name,
+                indexrelid::regclass AS index_name,
+                indrelid::regclass AS table_name,
+                pg_size_pretty(pg_total_relation_size(indexrelid)) AS index_size,
+                indisready,
+                indisvalid,
+                pg_get_indexdef(pg_class.oid) AS index_def
+            FROM pg_index
+            JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+            JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+            WHERE indisvalid = FALSE;
+
 toolsets:
     alloydb_postgres_database_tools:
         - execute_sql
         - list_tables
+        - list_invalid_indexes

--- a/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
@@ -34,7 +34,26 @@ tools:
         source: cloudsql-pg-source
         description: "Lists detailed schema information (object type, columns, constraints, indexes, triggers, owner, comment) as JSON for user-created tables (ordinary or partitioned). Filters by a comma-separated list of names. If names are omitted, lists all tables in user schemas."
 
+    list_invalid_indexes:
+        kind: postgres-sql
+        source: cloudsql-pg-source
+        description: "Lists all invalid PostgreSQL indexes which are taking up disk space but are unusable by the query planner. Typically created by failed CREATE INDEX CONCURRENTLY operations."
+        statement: |
+            SELECT
+                nspname AS schema_name,
+                indexrelid::regclass AS index_name,
+                indrelid::regclass AS table_name,
+                pg_size_pretty(pg_total_relation_size(indexrelid)) AS index_size,
+                indisready,
+                indisvalid,
+                pg_get_indexdef(pg_class.oid) AS index_def
+            FROM pg_index
+            JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+            JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+            WHERE indisvalid = FALSE;
+
 toolsets:
     cloud_sql_postgres_database_tools:
         - execute_sql
         - list_tables
+        - list_invalid_indexes

--- a/internal/prebuiltconfigs/tools/postgres.yaml
+++ b/internal/prebuiltconfigs/tools/postgres.yaml
@@ -33,7 +33,26 @@ tools:
         source: postgresql-source
         description: "Lists detailed schema information (object type, columns, constraints, indexes, triggers, owner, comment) as JSON for user-created tables (ordinary or partitioned). Filters by a comma-separated list of names. If names are omitted, lists all tables in user schemas."
 
+    list_invalid_indexes:
+        kind: postgres-sql
+        source: postgresql-source
+        description: "Lists all invalid PostgreSQL indexes which are taking up disk space but are unusable by the query planner. Typically created by failed CREATE INDEX CONCURRENTLY operations."
+        statement: |
+            SELECT
+                nspname AS schema_name,
+                indexrelid::regclass AS index_name,
+                indrelid::regclass AS table_name,
+                pg_size_pretty(pg_total_relation_size(indexrelid)) AS index_size,
+                indisready,
+                indisvalid,
+                pg_get_indexdef(pg_class.oid) AS index_def
+            FROM pg_index
+            JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+            JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+            WHERE indisvalid = FALSE;
+
 toolsets:
     postgres_database_tools:
         - execute_sql
         - list_tables
+        - list_invalid_indexes


### PR DESCRIPTION
## Description

Adds a read-only PostgreSQL prebuilt tool `list_invalid_indexes`, that returns the details of invalid indexes present in database. Each row includes: `schema_name`, `index_name`, `table_name`, `index_size`, `indisready`, `indisvalid`, `index_def`.

**Test Output**
<img width="1413" height="731" alt="image" src="https://github.com/user-attachments/assets/26145cb7-2dfb-40dd-a519-138489e3f1a6" />

---
> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

## PR Checklist

---
> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code!  That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
