### PR TITLE
docs: Improve binary installation instructions for multiple platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,53 @@ following instructions for your OS and CPU architecture.
 To install Toolbox as a binary:
 
 <!-- {x-release-please-start-version} -->
-```sh
-# see releases page for other versions
-export VERSION=0.16.0
-curl -O https://storage.googleapis.com/genai-toolbox/v$VERSION/linux/amd64/toolbox
-chmod +x toolbox
-```
-
+> <details>
+> <summary>Linux (AMD64)</summary>
+>
+> To install Toolbox as a binary on Linux (AMD64):
+> ```sh
+> # see releases page for other versions
+> export VERSION=0.16.0
+> curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/v$VERSION/linux/amd64/toolbox
+> chmod +x toolbox
+> ```
+>
+> </details>
+> <details>
+> <summary>macOS (Apple Silicon)</summary>
+>
+> To install Toolbox as a binary on macOS (Apple Silicon):
+> ```sh
+> # see releases page for other versions
+> export VERSION=0.16.0
+> curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/v$VERSION/darwin/arm64/toolbox
+> chmod +x toolbox
+> ```
+>
+> </details>
+> <details>
+> <summary>macOS (Intel)</summary>
+>
+> To install Toolbox as a binary on macOS (Intel):
+> ```sh
+> # see releases page for other versions
+> export VERSION=0.16.0
+> curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/v$VERSION/darwin/amd64/toolbox
+> chmod +x toolbox
+> ```
+>
+> </details>
+> <details>
+> <summary>Windows (AMD64)</summary>
+>
+> To install Toolbox as a binary on Windows (AMD64):
+> ```powershell
+> # see releases page for other versions
+> $VERSION = "0.16.0"
+> Invoke-WebRequest -Uri "https://storage.googleapis.com/genai-toolbox/v$VERSION/windows/amd64/toolbox.exe" -OutFile "toolbox.exe"
+> ```
+>
+> </details>
 </details>
 
 <details>

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -81,16 +81,43 @@ following instructions for your OS and CPU architecture.
 <!-- {x-release-please-start-version} -->
 {{< tabpane text=true >}}
 {{% tab header="Binary" lang="en" %}}
-
-To install Toolbox as a binary:
-
+{{< tabpane text=true >}}
+{{% tab header="Linux (AMD64)" lang="en" %}}
+To install Toolbox as a binary on Linux (AMD64):
 ```sh
 # see releases page for other versions
 export VERSION=0.16.0
-curl -O https://storage.googleapis.com/genai-toolbox/v$VERSION/linux/amd64/toolbox
+curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/v$VERSION/linux/amd64/toolbox
 chmod +x toolbox
 ```
-
+{{% /tab %}}
+{{% tab header="macOS (Apple Silicon)" lang="en" %}}
+To install Toolbox as a binary on macOS (Apple Silicon):
+```sh
+# see releases page for other versions
+export VERSION=0.16.0
+curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/v$VERSION/darwin/arm64/toolbox
+chmod +x toolbox
+```
+{{% /tab %}}
+{{% tab header="macOS (Intel)" lang="en" %}}
+To install Toolbox as a binary on macOS (Intel):
+```sh
+# see releases page for other versions
+export VERSION=0.16.0
+curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/v$VERSION/darwin/amd64/toolbox
+chmod +x toolbox
+```
+{{% /tab %}}
+{{% tab header="Windows (AMD64)" lang="en" %}}
+To install Toolbox as a binary on Windows (AMD64):
+```powershell
+# see releases page for other versions
+$VERSION = "0.16.0"
+Invoke-WebRequest -Uri "https://storage.googleapis.com/genai-toolbox/v$VERSION/windows/amd64/toolbox.exe" -OutFile "toolbox.exe"
+```
+{{% /tab %}}
+{{< /tabpane >}}
 {{% /tab %}}
 {{% tab header="Container image" lang="en" %}}
 You can also install Toolbox as a container:


### PR DESCRIPTION
# Overview
The previous installation instructions for the Toolbox binary only provided a curl command for Linux AMD64 systems. This was confusing for users on other platforms like macOS and Windows, who had to manually figure out the correct download URL from the releases page.

This PR overhauls the installation process in both the `README.md` and the official documentation site. It provides dedicated, copy-pasteable commands for all major platforms and makes the download commands more reliable.

# Changes
* Replaced the single, Linux-only installation command with a multi-level tabbed/collapsible interface in both the `README.md` and the official documentation.
* Added dedicated installation commands for multiple platforms, including Windows (AMD64) that now using the native `Invoke-WebRequest` in PowerShell.
* Updated all `curl` commands to include the `-L` flag.
  * This makes the download more robust by automatically following any HTTP redirects.

# Before
## `README.md`
<img width="1870" height="868" alt="image" src="https://github.com/user-attachments/assets/28b714b5-1938-42cb-904b-3a4d61f1c56a" />

## Docsite
<img width="1728" height="788" alt="image" src="https://github.com/user-attachments/assets/b63d579d-ce8f-4974-9860-1fee5a8d0dc7" />

# After
## `README.md`
<img width="1814" height="1082" alt="image" src="https://github.com/user-attachments/assets/54985eaf-c721-4f11-86d2-cc027aeea0ad" />

## Docsite
<img width="2066" height="1112" alt="image" src="https://github.com/user-attachments/assets/a07380b7-3b38-4b99-a95e-f942356f2200" />