### PR TITLE
docs: Remove obsolete Homebrew entry in README TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ documentation](https://googleapis.github.io/genai-toolbox/).
 - [Getting Started](#getting-started)
   - [Installing the server](#installing-the-server)
   - [Running the server](#running-the-server)
-    - [Homebrew Users](#homebrew-users)
   - [Integrating your application](#integrating-your-application)
 - [Configuration](#configuration)
   - [Sources](#sources)


### PR DESCRIPTION
Fixes https://github.com/googleapis/genai-toolbox/issues/1590

Removes the unused link for Homebrew users from the TOC in README.md.