### PR TITLE
fix:fixed the broken links

### DIFF
--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -65,7 +65,7 @@ avoiding full table scans or complex filters.
 - [`bigquery-sql`](../tools/bigquery/bigquery-sql.md)  
   Run SQL queries directly against BigQuery datasets.
 
-- [`bigquery-search-catalog`](../tools/bigquery/bigquery-search_catalog.md)
+- [`bigquery-search-catalog`](../tools/bigquery/bigquery-search-catalog.md)
   List all entries in Dataplex Catalog (e.g. tables, views, models) that matches
   given user query.
 

--- a/docs/en/resources/tools/alloydbainl/alloydb-ai-nl.md
+++ b/docs/en/resources/tools/alloydbainl/alloydb-ai-nl.md
@@ -34,7 +34,7 @@ database layer.
 
 {{< notice tip >}} AlloyDB AI natural language is currently in gated public
 preview. For more information on availability and limitations, please see
-[AlloyDB AI natural language overview](https://cloud.google.com/alloydb/docs/ai/natural-language-overview)
+[AlloyDB AI natural language overview](https://cloud.google.com/alloydb/docs/ai/natural-language-landing)
 {{< /notice >}}
 
 To enable AlloyDB AI natural language for your AlloyDB cluster, please follow
@@ -42,7 +42,7 @@ the steps listed in the [Generate SQL queries that answer natural language
 questions][alloydb-ai-gen-nl], including enabling the extension and configuring
 context for your application.
 
-[alloydb-ai-nl-overview]: https://cloud.google.com/alloydb/docs/ai/natural-language-overview
+[alloydb-ai-nl-overview]: https://cloud.google.com/alloydb/docs/ai/natural-language-landing
 [alloydb-ai-gen-nl]: https://cloud.google.com/alloydb/docs/ai/generate-sql-queries-natural-language
 
 ## Configuration

--- a/docs/en/resources/tools/cassandra/cassandra-cql.md
+++ b/docs/en/resources/tools/cassandra/cassandra-cql.md
@@ -14,12 +14,12 @@ aliases:
 A `cassandra-cql` tool executes a pre-defined CQL statement against a Cassandra
 database. It's compatible with any of the following sources:
 
-- [cassandra](../sources/cassandra.md)
+- [cassandra](../../sources/cassandra.md)
 
 The specified CQL statement is executed as a [prepared statement][cassandra-prepare],
 and expects parameters in the CQL query to be in the form of placeholders `?`.
 
-[cassandra-prepare]: https://docs.datastax.com/en/developer/go-driver/4.8/cql-prepared-statements/
+[cassandra-prepare]: https://docs.datastax.com/en/datastax-drivers/developing/prepared-statements.html
 
 ## Example
 

--- a/docs/en/resources/tools/dataplex/dataplex-lookup-entry.md
+++ b/docs/en/resources/tools/dataplex/dataplex-lookup-entry.md
@@ -13,7 +13,7 @@ aliases:
 A `dataplex-lookup-entry` tool returns details of a particular entry in Dataplex
 Catalog. It's compatible with the following sources:
 
-- [dataplex](../sources/dataplex.md)
+- [dataplex](../../sources/dataplex.md)
 
 `dataplex-lookup-entry` takes a required `name` parameter which contains the
 project and location to which the request should be attributed in the following

--- a/docs/en/resources/tools/firebird/firebird-execute-sql.md
+++ b/docs/en/resources/tools/firebird/firebird-execute-sql.md
@@ -14,7 +14,7 @@ aliases:
 A `firebird-execute-sql` tool executes a SQL statement against a Firebird
 database. It's compatible with the following source:
 
-- [firebird](../sources/firebird.md)
+- [firebird](../../sources/firebird.md)
 
 `firebird-execute-sql` takes one input parameter `sql` and runs the sql
 statement against the `source`.

--- a/docs/en/resources/tools/firebird/firebird-sql.md
+++ b/docs/en/resources/tools/firebird/firebird-sql.md
@@ -14,7 +14,7 @@ aliases:
 A `firebird-sql` tool executes a pre-defined SQL statement against a Firebird
 database. It's compatible with the following source:
 
-- [firebird](../sources/firebird.md)
+- [firebird](../../sources/firebird.md)
 
 The specified SQL statement is executed as a [prepared statement][fb-prepare],
 and supports both positional parameters (`?`) and named parameters (`:param_name`).
@@ -102,7 +102,7 @@ tools:
 > including identifiers, column names, and table names. **This makes it more
 > vulnerable to SQL injections**. Using basic parameters only (see above) is
 > recommended for performance and safety reasons. For more details, please check
-> [templateParameters](_index#template-parameters).
+> [templateParameters](..#template-parameters).
 
 ```yaml
 tools:
@@ -131,5 +131,5 @@ tools:
 | source             |                      string                      |     true     | Name of the source the SQL should execute on.                                                                                              |
 | description        |                      string                      |     true     | Description of the tool that is passed to the LLM.                                                                                         |
 | statement          |                      string                      |     true     | SQL statement to execute on.                                                                                                               |
-| parameters         |    [parameters](_index#specifying-parameters)    |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement.                                           |
-| templateParameters | [templateParameters](_index#template-parameters) |    false     | List of [templateParameters](_index#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |
+| parameters         |    [parameters](..#specifying-parameters)    |    false     | List of [parameters](..#specifying-parameters) that will be inserted into the SQL statement.                                           |
+| templateParameters | [templateParameters](..#template-parameters) |    false     | List of [templateParameters](..#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |

--- a/docs/en/resources/tools/oceanbase/oceanbase-execute-sql.md
+++ b/docs/en/resources/tools/oceanbase/oceanbase-execute-sql.md
@@ -13,7 +13,7 @@ aliases:
 An `oceanbase-execute-sql` tool executes a SQL statement against an OceanBase
 database. It's compatible with the following source:
 
-- [oceanbase](../sources/oceanbase.md)
+- [oceanbase](../../sources/oceanbase.md)
 
 `oceanbase-execute-sql` takes one input parameter `sql` and runs the sql
 statement against the `source`.

--- a/docs/en/resources/tools/oceanbase/oceanbase-sql.md
+++ b/docs/en/resources/tools/oceanbase/oceanbase-sql.md
@@ -13,7 +13,7 @@ aliases:
 An `oceanbase-sql` tool executes a pre-defined SQL statement against an
 OceanBase database. It's compatible with the following source:
 
-- [oceanbase](../sources/oceanbase.md)
+- [oceanbase](../../sources/oceanbase.md)
 
 The specified SQL statement is executed as a [prepared
 statement][mysql-prepare], and expects parameters in the SQL query to be in the
@@ -125,5 +125,5 @@ tools:
 | source             |                      string                      |     true     | Name of the source the SQL should execute on.                                                                                              |
 | description        |                      string                      |     true     | Description of the tool that is passed to the LLM.                                                                                         |
 | statement          |                      string                      |     true     | SQL statement to execute on.                                                                                                               |
-| parameters         |    [parameters](_index#specifying-parameters)    |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement.                                           |
-| templateParameters | [templateParameters](_index#template-parameters) |    false     | List of [templateParameters](_index#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |
+| parameters         |    [parameters](..#specifying-parameters)    |    false     | List of [parameters](..#specifying-parameters) that will be inserted into the SQL statement.                                           |
+| templateParameters | [templateParameters](..#template-parameters) |    false     | List of [templateParameters](..#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |

--- a/docs/en/resources/tools/tidb/tidb-execute-sql.md
+++ b/docs/en/resources/tools/tidb/tidb-execute-sql.md
@@ -14,7 +14,7 @@ aliases:
 A `tidb-execute-sql` tool executes a SQL statement against a TiDB
 database. It's compatible with the following source:
 
-- [tidb](../sources/tidb.md)
+- [tidb](../../sources/tidb.md)
 
 `tidb-execute-sql` takes one input parameter `sql` and run the sql
 statement against the `source`.

--- a/docs/en/resources/tools/tidb/tidb-sql.md
+++ b/docs/en/resources/tools/tidb/tidb-sql.md
@@ -72,7 +72,7 @@ tools:
 > including identifiers, column names, and table names. **This makes it more
 > vulnerable to SQL injections**. Using basic parameters only (see above) is
 > recommended for performance and safety reasons. For more details, please check
-> [templateParameters](_index#template-parameters).
+> [templateParameters](..#template-parameters).
 
 ```yaml
 tools:
@@ -101,5 +101,5 @@ tools:
 | source             |                   string                         |     true     | Name of the source the SQL should execute on.                                                                                              |
 | description        |                   string                         |     true     | Description of the tool that is passed to the LLM.                                                                                         |
 | statement          |                   string                         |     true     | SQL statement to execute on.                                                                                                               |
-| parameters         | [parameters](_index#specifying-parameters)       |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement.                                           |
-| templateParameters | [templateParameters](_index#template-parameters) |    false     | List of [templateParameters](_index#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |
+| parameters         | [parameters](..#specifying-parameters)       |    false     | List of [parameters](..#specifying-parameters) that will be inserted into the SQL statement.                                           |
+| templateParameters | [templateParameters](..#template-parameters) |    false     | List of [templateParameters](..#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |

--- a/docs/en/resources/tools/yugabytedb-sql.md
+++ b/docs/en/resources/tools/yugabytedb-sql.md
@@ -69,7 +69,7 @@ tools:
 > including identifiers, column names, and table names. **This makes it more
 > vulnerable to SQL injections**. Using basic parameters  only (see above) is
 > recommended for performance and safety reasons. For more details, please check
-> [templateParameters](_index#template-parameters).
+> [templateParameters](_..#template-parameters).
 
 ```yaml
 tools:
@@ -98,5 +98,5 @@ tools:
 | source             |                      string                      |     true     | Name of the source the SQL should execute on.                                                                                              |
 | description        |                      string                      |     true     | Description of the tool that is passed to the LLM.                                                                                         |
 | statement          |                      string                      |     true     | SQL statement to execute on.                                                                                                               |
-| parameters         |    [parameters](_index#specifying-parameters)    |    false     | List of [parameters](_index#specifying-parameters) that will be inserted into the SQL statement.                                           |
-| templateParameters | [templateParameters](_index#template-parameters) |    false     | List of [templateParameters](_index#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |
+| parameters         |    [parameters](..#specifying-parameters)    |    false     | List of [parameters](..#specifying-parameters) that will be inserted into the SQL statement.                                           |
+| templateParameters | [templateParameters](_..#template-parameters) |    false     | List of [templateParameters](_..#template-parameters) that will be inserted into the SQL statement before executing prepared statement. |

--- a/docs/en/samples/alloydb/ai-nl/alloydb_ai_nl.ipynb
+++ b/docs/en/samples/alloydb/ai-nl/alloydb_ai_nl.ipynb
@@ -19,7 +19,7 @@
         "NL to SQL capabilities in agentic applications.\n",
         "\n",
         "For detailed information on the AlloyDB capability, please see [AlloyDB AI\n",
-        "Natural Language Overview](https://cloud.google.com/alloydb/docs/ai/natural-language-overview).\n",
+        "Natural Language Overview](https://cloud.google.com/alloydb/docs/ai/natural-language-landing).\n",
         "\n",
         "\n",
         "## Before you Begin\n",

--- a/docs/en/samples/alloydb/mcp_quickstart.md
+++ b/docs/en/samples/alloydb/mcp_quickstart.md
@@ -276,7 +276,7 @@ to the `tools` section in your `tools.yaml`:
     {{< notice tip >}}Before using NL2SQL tools,
     you must first install the `alloydb_ai_nl` extension and
     create the [semantic
-    layer](https://cloud.google.com/alloydb/docs/ai/natural-language-overview)
+    layer](https://cloud.google.com/alloydb/docs/ai/natural-language-landing)
     under a configuration named `flower_shop`.
     {{< /notice >}}
 

--- a/docs/en/samples/looker/looker_mcp_inspector/_index.md
+++ b/docs/en/samples/looker/looker_mcp_inspector/_index.md
@@ -10,7 +10,7 @@ description: >
 
 [Model Context Protocol](https://modelcontextprotocol.io) is an open protocol
 that standardizes how applications provide context to LLMs. Check out this page
-on how to [connect to Toolbox via MCP](../../how-to/connect_via_mcp.md).
+on how to [connect to Toolbox via MCP](../../../how-to/connect_via_mcp.md).
 
 ## Step 1: Get a Looker Client ID and Client Secret
 


### PR DESCRIPTION
fixes a set of broken path links that were causing issues when navigating the documentation or referencing internal files.