### PR TITLE
fix:githubaction broken links

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -1,0 +1,37 @@
+name: Link Check
+
+on:
+  push:
+
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --verbose
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            README.md
+            docs/
+
+          output: /tmp/foo.txt
+          fail: true
+          jobSummary: true
+          debug: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,15 @@
+
+
+^https?:\\/\\/([a-zA-Z0-9-]+\\.)?example\\.com(:\\d+)?(\\/.*)?$
+^https:\\/\\/img\\.shields\\.io\\/.*
+^mailto:
+^https?:\\/\\/(127\\.0\\.0\\.1|localhost)(:\\d+)?(\\/.*)?$
+^https:\/\/localhost:8080\/$
+
+^http://localhost
+^https?://127\.0\.0\.1
+^http://example.net
+
+\.pdf$
+
+^https://some-old-api-documentation.io/v1/deprecated$


### PR DESCRIPTION
The githubAction Tests the broken links and creates the test for the repo  , The  *action.yaml* file runs the GitHub action ,   _.lycheeignore_ has the links which need to be excluded while checking 