### PR TITLE
fix(mysql): use QueryEscape instead of PathEscape for DSN credentials

### DIFF
--- a/internal/sources/mysql/mysql.go
+++ b/internal/sources/mysql/mysql.go
@@ -127,7 +127,7 @@ func initMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, name, hos
 	if err != nil {
 		return nil, err
 	}
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true&connectionAttributes=program_name:%s", user, pass, host, port, dbname, url.QueryEscape(userAgent))
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true&connectionAttributes=program_name:%s", url.QueryEscape(user), url.QueryEscape(pass), host, port, url.QueryEscape(dbname), url.QueryEscape(userAgent))
 	if enc := values.Encode(); enc != "" {
 		dsn += "&" + enc
 	}


### PR DESCRIPTION
## Description

- Replace `url.PathEscape` with `url.QueryEscape` for user and password
- Add `url.QueryEscape` for database name
- Fixes issue where credentials with `:` or `@` characters fail to connect

PathEscape does not escape `:` and `@` characters which are DSN delimiters, causing malformed connection strings when credentials contain these chars.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [X] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [X] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
- [X] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #1746
