### PR TITLE
feat: support `allowedValues`, `escape`, `minValue` and `maxValue` for parameters

### DIFF
--- a/docs/en/resources/tools/_index.md
+++ b/docs/en/resources/tools/_index.md
@@ -86,6 +86,8 @@ the parameter.
 | required      |      bool      |    false     | Indicate if the parameter is required. Default to `true`.                                                                                                                                                                              |
 | allowedValues |    []string    |    false     | Input value will be checked against this field. Regex is also supported.                                                                                                                                                               |
 | escape        |     string     |    false     | Only available for type `string`. Indicate the escaping delimiters used for the parameter. This field is intended to be used with templateParameters. Must be one of "single-quotes", "double-quotes", "backticks", "square-brackets". |
+| minValue      |  int or float  |    false     | Only available for type `integer` and `float`. Indicate the minimum value allowed.                                                                                                                                                     |
+| maxValue      |  int or float  |    false     | Only available for type `integer` and `float`. Indicate the maximum value allowed.                                                                                                                                                     |
 
 ### Array Parameters
 
@@ -213,7 +215,8 @@ for performance and safety reasons.
 To minimize SQL injection risk when using template parameters, always provide
 the `allowedValues` field within the parameter to restrict inputs.
 Alternatively, for `string` type parameters, you can use the `escape` field to
-add delimiters to the identifier.
+add delimiters to the identifier. For `integer` or `float` type parameters, you
+can use `minValue` and `maxValue` to define the allowable range.
 {{< /notice >}}
 
 ```yaml

--- a/internal/tools/parameters.go
+++ b/internal/tools/parameters.go
@@ -670,6 +670,20 @@ func NewIntParameter(name string, desc string) *IntParameter {
 	}
 }
 
+// NewIntParameterWithRange is a convenience function for initializing a IntParameter.
+func NewIntParameterWithRange(name string, desc string, minValue *int, maxValue *int) *IntParameter {
+	return &IntParameter{
+		CommonParameter: CommonParameter{
+			Name:         name,
+			Type:         typeInt,
+			Desc:         desc,
+			AuthServices: nil,
+		},
+		MinValue: minValue,
+		MaxValue: maxValue,
+	}
+}
+
 // NewIntParameterWithDefault is a convenience function for initializing a IntParameter with default value.
 func NewIntParameterWithDefault(name string, defaultV int, desc string) *IntParameter {
 	return &IntParameter{
@@ -727,6 +741,8 @@ var _ Parameter = &IntParameter{}
 type IntParameter struct {
 	CommonParameter `yaml:",inline"`
 	Default         *int `yaml:"default"`
+	MinValue        *int `yaml:"minValue"`
+	MaxValue        *int `yaml:"maxValue"`
 }
 
 func (p *IntParameter) Parse(v any) (any, error) {
@@ -749,6 +765,12 @@ func (p *IntParameter) Parse(v any) (any, error) {
 	}
 	if !p.IsAllowedValues(out) {
 		return nil, fmt.Errorf("%d is not an allowed value", out)
+	}
+	if p.MinValue != nil && out < *p.MinValue {
+		return nil, fmt.Errorf("%d is under the minimum value", out)
+	}
+	if p.MaxValue != nil && out > *p.MaxValue {
+		return nil, fmt.Errorf("%d is above the maximum value", out)
 	}
 	return out, nil
 }
@@ -787,6 +809,20 @@ func NewFloatParameter(name string, desc string) *FloatParameter {
 			Desc:         desc,
 			AuthServices: nil,
 		},
+	}
+}
+
+// NewFloatParameterWithRange is a convenience function for initializing a FloatParameter.
+func NewFloatParameterWithRange(name string, desc string, minValue *float64, maxValue *float64) *FloatParameter {
+	return &FloatParameter{
+		CommonParameter: CommonParameter{
+			Name:         name,
+			Type:         typeFloat,
+			Desc:         desc,
+			AuthServices: nil,
+		},
+		MinValue: minValue,
+		MaxValue: maxValue,
 	}
 }
 
@@ -847,6 +883,8 @@ var _ Parameter = &FloatParameter{}
 type FloatParameter struct {
 	CommonParameter `yaml:",inline"`
 	Default         *float64 `yaml:"default"`
+	MinValue        *float64 `yaml:"minValue"`
+	MaxValue        *float64 `yaml:"maxValue"`
 }
 
 func (p *FloatParameter) Parse(v any) (any, error) {
@@ -867,6 +905,12 @@ func (p *FloatParameter) Parse(v any) (any, error) {
 	}
 	if !p.IsAllowedValues(out) {
 		return nil, fmt.Errorf("%g is not an allowed value", out)
+	}
+	if p.MinValue != nil && out < *p.MinValue {
+		return nil, fmt.Errorf("%g is under the minimum value", out)
+	}
+	if p.MaxValue != nil && out > *p.MaxValue {
+		return nil, fmt.Errorf("%g is above the maximum value", out)
 	}
 	return out, nil
 }

--- a/internal/tools/parameters_test.go
+++ b/internal/tools/parameters_test.go
@@ -693,6 +693,8 @@ func TestAuthParametersMarshal(t *testing.T) {
 }
 
 func TestParametersParse(t *testing.T) {
+	intValue := 2
+	floatValue := 1.5
 	tcs := []struct {
 		name   string
 		params tools.Parameters
@@ -837,6 +839,44 @@ func TestParametersParse(t *testing.T) {
 			},
 		},
 		{
+			name: "int minValue",
+			params: tools.Parameters{
+				tools.NewIntParameterWithRange("my_int", "this param is an int", &intValue, nil),
+			},
+			in: map[string]any{
+				"my_int": 3,
+			},
+			want: tools.ParamValues{tools.ParamValue{Name: "my_int", Value: 3}},
+		},
+		{
+			name: "int minValue disallow",
+			params: tools.Parameters{
+				tools.NewIntParameterWithRange("my_int", "this param is an int", &intValue, nil),
+			},
+			in: map[string]any{
+				"my_int": 1,
+			},
+		},
+		{
+			name: "int maxValue",
+			params: tools.Parameters{
+				tools.NewIntParameterWithRange("my_int", "this param is an int", nil, &intValue),
+			},
+			in: map[string]any{
+				"my_int": 1,
+			},
+			want: tools.ParamValues{tools.ParamValue{Name: "my_int", Value: 1}},
+		},
+		{
+			name: "int maxValue disallow",
+			params: tools.Parameters{
+				tools.NewIntParameterWithRange("my_int", "this param is an int", nil, &intValue),
+			},
+			in: map[string]any{
+				"my_int": 3,
+			},
+		},
+		{
 			name: "float",
 			params: tools.Parameters{
 				tools.NewFloatParameter("my_float", "this param is a float"),
@@ -872,6 +912,44 @@ func TestParametersParse(t *testing.T) {
 			},
 			in: map[string]any{
 				"my_float": 1.2,
+			},
+		},
+		{
+			name: "float minValue",
+			params: tools.Parameters{
+				tools.NewFloatParameterWithRange("my_float", "this param is a float", &floatValue, nil),
+			},
+			in: map[string]any{
+				"my_float": 1.8,
+			},
+			want: tools.ParamValues{tools.ParamValue{Name: "my_float", Value: 1.8}},
+		},
+		{
+			name: "float minValue disallow",
+			params: tools.Parameters{
+				tools.NewFloatParameterWithRange("my_float", "this param is a float", &floatValue, nil),
+			},
+			in: map[string]any{
+				"my_float": 1.2,
+			},
+		},
+		{
+			name: "float maxValue",
+			params: tools.Parameters{
+				tools.NewFloatParameterWithRange("my_float", "this param is a float", nil, &floatValue),
+			},
+			in: map[string]any{
+				"my_float": 1.2,
+			},
+			want: tools.ParamValues{tools.ParamValue{Name: "my_float", Value: 1.2}},
+		},
+		{
+			name: "float maxValue disallow",
+			params: tools.Parameters{
+				tools.NewFloatParameterWithRange("my_float", "this param is a float", nil, &floatValue),
+			},
+			in: map[string]any{
+				"my_float": 1.8,
 			},
 		},
 		{


### PR DESCRIPTION
## Description

To minimize SQL injection risks when using template parameters, it is highly recommended that user utilizes the following added fields for parameters.

### Allow user to indicate allowed values via list or regex
Add new `allowedValues` field to all parameter type. It can be used as follows (can be used in the `parameter` field or `templateParameter` field):

```
templateParameters:
    - name: tableName
       type: string
       description: table name.
       allowedValues:
            - flights_table
            - tickets_table
            - "^h.*" # support any words starting with the letter h
```

### Support escaping delimiters for identifiers in string parameters
Supporting `backticks`, `double-quotes`, `single-quotes`, `square-brackets` as escaping delimiters. Example to apply escaping delimiters:
```
# other fields
statement: SELECT {{array .columnName}} FROM {{ .tableName }}
templateParameters:
      - name: tableName
        type: string
        description: table name.
        escape: double-quotes
      - name: columnName
        type: array
        description: column names.
        items:
          name: column
          type: string
          description: Name of the column to select
          escape: double-quotes
```
This example will resolve to following: - 
* Data provided: `{"tableName": "table_name", "columnName": ["foo", "bar"]}`
* Statement with escape: `SELECT "foo", "bar" FROM "table_name"`
* Statement without escape: `SELECT foo, bar FROM table_name`

Escaping delimiters can be used for identifiers (in template parameters) or string literals. If `allowedValues` were used, Toolbox will check for allowed values before applying delimiters.

### Support value range in numeric parameters
Supporting `minValue` and `maxValue` for parameters of type `integer` and `float`. Example:
```
parameters:
      - name: price
        type: integer
        description: price of item
        minValue: 1
        maxValue: 50
```

If `allowedValues` were used, Toolbox will check for allowed values before checking for min and max values.

### References


| parameter name | type | required | description |
|------------------|-----|---------|-------------|
| allowedValues | []string | true | We will check input value against this. User can either provide a list of allowed values or regex string. | 
| escape        |     string     |    false     | Only available for type `string`. Indicate the escaping delimiters used for the parameter. This field is intended to be used with templateParameters. Must be one of "single-quotes", "double-quotes", "backticks", "square-brackets". |
| minValue      |  int or float  |    false     | Only available for type `integer` and `float`. Indicate the minimum value allowed.                                                                                                                                                     |
| maxValue      |  int or float  |    false     | Only available for type `integer` and `float`. Indicate the maximum value allowed.                                                                                                                                                     |

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #779
