### PR TITLE
fix: instructions to quote filters that include commas

### DIFF
--- a/docs/en/resources/tools/looker/looker-query.md
+++ b/docs/en/resources/tools/looker/looker-query.md
@@ -61,6 +61,8 @@ tools:
           "field.id2": "condition2", ...}. Do not put the field.id in
           quotes. Filter expressions can be found at
           https://cloud.google.com/looker/docs/filter-expressions.
+          If the condition is a string that contains a comma, use a second
+          set of quotes. For example, {"user.city": "'New York, NY'"}.
 
           Sorts can be specified like [ "field.id desc 0" ].
 

--- a/internal/prebuiltconfigs/tools/looker.yaml
+++ b/internal/prebuiltconfigs/tools/looker.yaml
@@ -118,6 +118,8 @@ tools:
           quotes. Filter expressions can be found at
           https://cloud.google.com/looker/docs/filter-expressions. There
           is one mistake in that, however, Use `not null` instead of `-NULL`.
+          If the condition is a string that contains a comma, use a second
+          set of quotes. For example, {"user.city": "'New York, NY'"}.
 
           Sorts can be specified like [ "field.id desc 0" ].
 


### PR DESCRIPTION
## Description

A filter value like `{"user.city": "New York, NY"}` gets interpretted by Looker as a list of values, and so becomes SQL like
`IN ('New York', 'NY')`. Need to pass a filter value like `{"user.city": "'New York, NY'"}`.

Add instructions to agents to properly quote filter values that contain commas.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [X] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [X] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
- [X] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #1790
