### PR TITLE
docs: refine SQL tool descriptions for clarity on security & usage

### DIFF
--- a/docs/en/resources/sources/alloydb-pg.md
+++ b/docs/en/resources/sources/alloydb-pg.md
@@ -28,10 +28,10 @@ cluster][alloydb-free-trial].
   Use natural language queries on AlloyDB, powered by AlloyDB AI.
 
 - [`postgres-sql`](../tools/postgres/postgres-sql.md)
-  Execute SQL queries as prepared statements in AlloyDB Postgres.
+  Runs PostgreSQL queries safely by using prepared statements.
 
 - [`postgres-execute-sql`](../tools/postgres/postgres-execute-sql.md)
-  Run parameterized SQL statements in AlloyDB Postgres.
+  Executes a PostgreSQL statement securely using named parameter binding.
 
 - [`postgres-list-tables`](../tools/postgres/postgres-list-tables.md)
   List tables in an AlloyDB for PostgreSQL database.

--- a/docs/en/resources/sources/bigquery.md
+++ b/docs/en/resources/sources/bigquery.md
@@ -45,7 +45,7 @@ avoiding full table scans or complex filters.
   Allows conversational interaction with a BigQuery source.
 
 - [`bigquery-execute-sql`](../tools/bigquery/bigquery-execute-sql.md)  
-  Execute structured queries using parameters.
+  Executes a provided BigQuery SQL statement, with source-level security controls.
 
 - [`bigquery-forecast`](../tools/bigquery/bigquery-forecast.md)
   Forecasts time series data in BigQuery.
@@ -63,7 +63,7 @@ avoiding full table scans or complex filters.
   List tables in a given dataset.
 
 - [`bigquery-sql`](../tools/bigquery/bigquery-sql.md)  
-  Run SQL queries directly against BigQuery datasets.
+  Executes a pre-defined BigQuery SQL statement using secure parameter binding.
 
 - [`bigquery-search-catalog`](../tools/bigquery/bigquery-search-catalog.md)
   List all entries in Dataplex Catalog (e.g. tables, views, models) that matches

--- a/docs/en/resources/sources/cloud-sql-mssql.md
+++ b/docs/en/resources/sources/cloud-sql-mssql.md
@@ -22,10 +22,10 @@ to a database by following these instructions][csql-mssql-connect].
 ## Available Tools
 
 - [`mssql-sql`](../tools/mssql/mssql-sql.md)  
-  Execute pre-defined SQL Server queries with placeholder parameters.
+  Execute pre-defined SQL Server queries securely using parameter binding.
 
 - [`mssql-execute-sql`](../tools/mssql/mssql-execute-sql.md)  
-  Run parameterized SQL Server queries in Cloud SQL for SQL Server.
+  Executes a SQL statement against a SQL Server database.
 
 - [`mssql-list-tables`](../tools/mssql/mssql-list-tables.md)  
   List tables in a Cloud SQL for SQL Server database.

--- a/docs/en/resources/sources/mysql.md
+++ b/docs/en/resources/sources/mysql.md
@@ -17,10 +17,10 @@ reliability, performance, and ease of use.
 ## Available Tools
 
 - [`mysql-sql`](../tools/mysql/mysql-sql.md)
-  Execute pre-defined prepared SQL queries in MySQL.
+  Executes a pre-defined MySQL statement securely using prepared statement parameters.
 
 - [`mysql-execute-sql`](../tools/mysql/mysql-execute-sql.md)
-  Run parameterized SQL queries in MySQL.
+  Run a provided MySQL SQL statement against a MySQL database.
 
 - [`mysql-list-active-queries`](../tools/mysql/mysql-list-active-queries.md)
   List active queries in MySQL.

--- a/docs/en/resources/sources/postgres.md
+++ b/docs/en/resources/sources/postgres.md
@@ -18,10 +18,10 @@ reputation for reliability, feature robustness, and performance.
 ## Available Tools
 
 - [`postgres-sql`](../tools/postgres/postgres-sql.md)
-  Execute SQL queries as prepared statements in PostgreSQL.
+  Runs PostgreSQL queries safely by using prepared statements.
 
 - [`postgres-execute-sql`](../tools/postgres/postgres-execute-sql.md)
-  Run parameterized SQL statements in PostgreSQL.
+  Executes a PostgreSQL statement securely using named parameter binding.
 
 - [`postgres-list-tables`](../tools/postgres/postgres-list-tables.md)
   List tables in a PostgreSQL database.


### PR DESCRIPTION
## Description

This Pull Request refines the descriptions for the `*-sql` and `*-execute-sql` tools across PostgreSQL, BigQuery, MS SQL, and Spanner. While previous efforts improved these descriptions, this update aims to provide even better clarity on:

1.  **Security Best Practices:** Explicitly highlighting which tools support secure parameterization to prevent SQL injection, in line with Google's guidelines for Safe SQL APIs.
2.  **Intended Usage:** Clearly differentiating b/w tools designed for secure execution of pre-defined, parameterized queries and those intended for developer-only workflows.

Related PR: #914 