### PR TITLE
ci(tools/postgres-list-active-queries): exclude background applicatio…

### DIFF
--- a/tests/postgres/postgres_integration_test.go
+++ b/tests/postgres/postgres_integration_test.go
@@ -423,6 +423,7 @@ func runPostgresListActiveQueriesTest(t *testing.T, ctx context.Context, pool *p
 		wantStatusCode      int
 		want                any
 	}{
+		// exclude background monitoring apps such as "wal_uploader"
 		{
 			name:                "invoke list_active_queries when the system is idle",
 			requestBody:         bytes.NewBufferString(`{"exclude_application_names": "wal_uploader"}`),


### PR DESCRIPTION
The `postgres-list-active-queries` tool integration test is failing because of background admin queries for logging.