### PR TITLE
test: update bigquery and mindsdb integration tests

### DIFF
--- a/internal/sources/serverlessspark/serverlessspark.go
+++ b/internal/sources/serverlessspark/serverlessspark.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
+	longrunning "cloud.google.com/go/longrunning/autogen"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/util"
-	"cloud.google.com/go/longrunning/autogen"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/option"
 )

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -976,7 +976,7 @@ func runBigQueryExecuteSqlToolInvokeTest(t *testing.T, select1Want, invokeParamW
 			name:          "invoke my-exec-sql-tool with data present in table",
 			api:           "http://127.0.0.1:5000/api/tool/my-exec-sql-tool/invoke",
 			requestHeader: map[string]string{},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"sql\":\"SELECT * FROM %s WHERE id = 3 OR name = 'Alice' ORDER BY id\"}", tableNameParam))),
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"sql\":\"SELECT id, name FROM %s WHERE id = 3 OR name = 'Alice' ORDER BY id\"}", tableNameParam))),
 			want:          invokeParamWant,
 			isErr:         false,
 		},
@@ -1164,7 +1164,7 @@ func runBigQueryWriteModeBlockedTest(t *testing.T, tableNameParam, datasetName s
 		wantInError    string
 		wantResult     string
 	}{
-		{"SELECT statement should succeed", fmt.Sprintf("SELECT * FROM %s WHERE id = 1", tableNameParam), http.StatusOK, "", `[{"id":1,"name":"Alice"}]`},
+		{"SELECT statement should succeed", fmt.Sprintf("SELECT id, name FROM %s WHERE id = 1", tableNameParam), http.StatusOK, "", `[{"id":1,"name":"Alice"}]`},
 		{"INSERT statement should fail", fmt.Sprintf("INSERT INTO %s (id, name) VALUES (10, 'test')", tableNameParam), http.StatusBadRequest, "write mode is 'blocked', only SELECT statements are allowed", ""},
 		{"CREATE TABLE statement should fail", fmt.Sprintf("CREATE TABLE %s.new_table (x INT64)", datasetName), http.StatusBadRequest, "write mode is 'blocked', only SELECT statements are allowed", ""},
 	}

--- a/tests/mindsdb/mindsdb_integration_test.go
+++ b/tests/mindsdb/mindsdb_integration_test.go
@@ -351,6 +351,9 @@ func TestMindsDBToolEndpoints(t *testing.T) {
 				[]byte(`{"sql": "`+caseSQL+`"}`), "")
 		})
 
+		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
+			[]byte(`{"sql": "DROP TABLE IF EXISTS files.test_product_summary"}`), "")
+
 		t.Run("data_manipulation", func(t *testing.T) {
 			summarySQL := `CREATE TABLE files.test_product_summary (SELECT p.product_id, p.product_name, p.category, COUNT(r.review) as total_reviews, AVG(r.rating) as avg_rating, MAX(r.rating) as max_rating, MIN(r.rating) as min_rating FROM files.test_products p LEFT JOIN files.test_reviews r ON p.product_id = r.product_id GROUP BY p.product_id, p.product_name, p.category)`
 			tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
@@ -377,6 +380,11 @@ func TestMindsDBToolEndpoints(t *testing.T) {
 		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
 			[]byte(`{"sql": "SHOW TABLES FROM files"}`), "")
 
+		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
+			[]byte(`{"sql": "DROP TABLE IF EXISTS files.test_integration_data"}`), "")
+		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
+			[]byte(`{"sql": "DROP TABLE IF EXISTS files.test_local_data"}`), "")
+
 		createIntegrationTableSQL := `CREATE TABLE files.test_integration_data (SELECT 1 as id, 'Data from integration' as description, CURDATE() as created_at UNION ALL SELECT 2, 'Another record', CURDATE() UNION ALL SELECT 3, 'Third record', CURDATE())`
 		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
 			[]byte(`{"sql": "`+createIntegrationTableSQL+`"}`), "")
@@ -400,6 +408,11 @@ func TestMindsDBToolEndpoints(t *testing.T) {
 
 	// Test data transformation with customer order data
 	t.Run("mindsdb_data_transformation", func(t *testing.T) {
+		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
+			[]byte(`{"sql": "DROP TABLE IF EXISTS files.test_orders"}`), "")
+		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
+			[]byte(`{"sql": "DROP TABLE IF EXISTS files.test_customer_summary"}`), "")
+
 		createOrdersSQL := `CREATE TABLE files.test_orders (SELECT 1 as order_id, 'CUST001' as customer_id, 100.50 as amount, '2024-01-15' as order_date UNION ALL SELECT 2, 'CUST001', 250.00, '2024-02-20' UNION ALL SELECT 3, 'CUST002', 75.25, '2024-01-18' UNION ALL SELECT 4, 'CUST003', 500.00, '2024-03-10' UNION ALL SELECT 5, 'CUST002', 150.00, '2024-02-25')`
 		tests.RunToolInvokeParametersTest(t, "my-exec-sql-tool",
 			[]byte(`{"sql": "`+createOrdersSQL+`"}`), "")


### PR DESCRIPTION
Update bigquery test to include column order for SELECT statement.
Update mindsdb tests to drop table before creating. The whole integration test pause when there's a failure from any one of integration tests. If the test pause after `CREATE` and before `DROP`, the int test will fail when running it again. 