### PR TITLE
feat(tools/mongodb): add MongoDB database and collection discovery tools

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,6 +138,8 @@ import (
 	_ "github.com/googleapis/genai-toolbox/internal/tools/mongodb/mongodbfindone"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/mongodb/mongodbinsertmany"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/mongodb/mongodbinsertone"
+	_ "github.com/googleapis/genai-toolbox/internal/tools/mongodb/mongodblistcollectionnames"
+	_ "github.com/googleapis/genai-toolbox/internal/tools/mongodb/mongodblistdatabasenames"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/mongodb/mongodbupdatemany"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/mongodb/mongodbupdateone"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/mssql/mssqlexecutesql"

--- a/docs/en/resources/tools/mongodb/mongodb-list-collection-names.md
+++ b/docs/en/resources/tools/mongodb/mongodb-list-collection-names.md
@@ -1,0 +1,62 @@
+---
+title: "mongodb-list-collection-names"
+type: docs
+weight: 2
+description: >
+  A "mongodb-list-collection-names" tool returns all collection names from a specified database in the MongoDB source.
+aliases:
+- /resources/tools/mongodb-list-collection-names
+---
+
+## About
+
+A `mongodb-list-collection-names` tool returns all collection names from a specified database in the MongoDB source.
+It's compatible with the following sources:
+
+- [mongodb](../../sources/mongodb.md)
+
+`mongodb-list-collection-names` accepts the following parameter:
+- **`database`** (required if not specified in config): The name of the database to list collections from.
+
+The tool can be configured in two ways:
+1. **With database in config:** The database name is fixed in the tool configuration.
+2. **Without database in config:** The database name must be provided as a parameter when invoking the tool,
+   allowing agents to dynamically query different databases.
+
+## Examples
+
+### Example 1: Database specified in configuration
+
+```yaml
+tools:
+  mongodb_list_collections:
+    kind: mongodb-list-collection-names
+    source: my-mongodb-source
+    database: my_database
+    description: Use this tool to list all collections in the my_database database.
+```
+
+### Example 2: Database specified as parameter
+
+```yaml
+tools:
+  mongodb_list_collections:
+    kind: mongodb-list-collection-names
+    source: my-mongodb-source
+    description: Use this tool to list all collections in a specified database.
+    params:
+      - name: database
+        description: The name of the database to list collections from
+        type: string
+        required: true
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| kind        |                   string                   |     true     | Must be "mongodb-list-collection-names".                                                         |
+| source      |                   string                   |     true     | Name of the MongoDB source.                                                                      |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |
+| database    |                   string                   |    false     | Name of the database to list collections from. If not provided, must be passed as a parameter.   |
+| params      |            array of parameters             |    false     | Additional parameters for the tool.                                                              |

--- a/docs/en/resources/tools/mongodb/mongodb-list-database-names.md
+++ b/docs/en/resources/tools/mongodb/mongodb-list-database-names.md
@@ -1,0 +1,37 @@
+---
+title: "mongodb-list-database-names"
+type: docs
+weight: 1
+description: >
+  A "mongodb-list-database-names" tool returns all database names from the MongoDB source.
+aliases:
+- /resources/tools/mongodb-list-database-names
+---
+
+## About
+
+A `mongodb-list-database-names` tool returns all database names from the MongoDB source.
+It's compatible with the following sources:
+
+- [mongodb](../../sources/mongodb.md)
+
+This tool does not accept any parameters and returns a list of all database names
+accessible through the configured MongoDB connection.
+
+## Example
+
+```yaml
+tools:
+  mongodb_list_database_names:
+    kind: mongodb-list-database-names
+    source: my-mongodb-source
+    description: Use this tool to list all available databases in MongoDB.
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| kind        |                   string                   |     true     | Must be "mongodb-list-database-names".                                                           |
+| source      |                   string                   |     true     | Name of the MongoDB source.                                                                      |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |

--- a/internal/tools/mongodb/mongodblistcollectionnames/mongodblistcollectionnames.go
+++ b/internal/tools/mongodb/mongodblistcollectionnames/mongodblistcollectionnames.go
@@ -1,0 +1,182 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodblistcollectionnames
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	mongosrc "github.com/googleapis/genai-toolbox/internal/sources/mongodb"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const kind string = "mongodb-list-collection-names"
+
+func init() {
+	if !tools.Register(kind, newConfig) {
+		panic(fmt.Sprintf("tool kind %q already registered", kind))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+type Config struct {
+	Name         string           `yaml:"name" validate:"required"`
+	Kind         string           `yaml:"kind" validate:"required"`
+	Source       string           `yaml:"source" validate:"required"`
+	AuthRequired []string         `yaml:"authRequired" validate:"required"`
+	Description  string           `yaml:"description" validate:"required"`
+	Database     string           `yaml:"database"`
+	Params       tools.Parameters `yaml:"params"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigKind() string {
+	return kind
+}
+
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	// verify source exists
+	rawS, ok := srcs[cfg.Source]
+	if !ok {
+		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
+	}
+
+	// verify the source is compatible
+	s, ok := rawS.(*mongosrc.Source)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `mongodb`", kind)
+	}
+
+	// Check for duplicate parameters
+	err := tools.CheckDuplicateParameters(cfg.Params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine if database parameter is needed
+	var allParams tools.Parameters
+	if cfg.Database == "" {
+		// Database not specified in config, so add it as a parameter
+		databaseParam := tools.Parameter{
+			Name:        "database",
+			Description: "The name of the database to list collections from",
+			Type:        "string",
+			Required:    true,
+		}
+		allParams = append(tools.Parameters{databaseParam}, cfg.Params...)
+	} else {
+		// Database is specified in config, use provided params
+		allParams = cfg.Params
+	}
+
+	// Create Toolbox manifest
+	paramManifest := allParams.Manifest()
+	if paramManifest == nil {
+		paramManifest = make([]tools.ParameterManifest, 0)
+	}
+
+	// Create MCP manifest
+	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, allParams)
+
+	// finish tool setup
+	return Tool{
+		Name:          cfg.Name,
+		Kind:          kind,
+		Description:   cfg.Description,
+		AuthRequired:  cfg.AuthRequired,
+		Database:      cfg.Database,
+		AllParams:     allParams,
+		client:        s.Client,
+		manifest:      tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
+		mcpManifest:   mcpManifest,
+	}, nil
+}
+
+// validate interface
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	Name         string `yaml:"name"`
+	Kind         string `yaml:"kind"`
+	Description  string `yaml:"description"`
+	AuthRequired []string
+	Database     string
+	AllParams    tools.Parameters
+
+	client      *mongo.Client
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken tools.AccessToken) (any, error) {
+	// Determine database name
+	var databaseName string
+	if t.Database != "" {
+		databaseName = t.Database
+	} else {
+		// Get database name from parameters
+		paramsMap := params.AsMap()
+		dbParam, ok := paramsMap["database"]
+		if !ok {
+			return nil, fmt.Errorf("database parameter is required")
+		}
+		databaseName, ok = dbParam.(string)
+		if !ok {
+			return nil, fmt.Errorf("database parameter must be a string")
+		}
+	}
+
+	// List all collections in the database
+	database := t.client.Database(databaseName)
+	collectionNames, err := database.ListCollectionNames(ctx, bson.D{})
+	if err != nil {
+		return nil, fmt.Errorf("error listing collections in database %q: %w", databaseName, err)
+	}
+
+	return collectionNames, nil
+}
+
+func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {
+	return tools.ParseParams(t.AllParams, data, claims)
+}
+
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+}
+
+func (t Tool) RequiresClientAuthorization() bool {
+	return false
+}

--- a/internal/tools/mongodb/mongodblistdatabasenames/mongodblistdatabasenames.go
+++ b/internal/tools/mongodb/mongodblistdatabasenames/mongodblistdatabasenames.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodblistdatabasenames
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	mongosrc "github.com/googleapis/genai-toolbox/internal/sources/mongodb"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const kind string = "mongodb-list-database-names"
+
+func init() {
+	if !tools.Register(kind, newConfig) {
+		panic(fmt.Sprintf("tool kind %q already registered", kind))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+type Config struct {
+	Name         string   `yaml:"name" validate:"required"`
+	Kind         string   `yaml:"kind" validate:"required"`
+	Source       string   `yaml:"source" validate:"required"`
+	AuthRequired []string `yaml:"authRequired" validate:"required"`
+	Description  string   `yaml:"description" validate:"required"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigKind() string {
+	return kind
+}
+
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	// verify source exists
+	rawS, ok := srcs[cfg.Source]
+	if !ok {
+		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
+	}
+
+	// verify the source is compatible
+	s, ok := rawS.(*mongosrc.Source)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `mongodb`", kind)
+	}
+
+	// Create Toolbox manifest
+	paramManifest := make([]tools.ParameterManifest, 0)
+
+	// Create MCP manifest
+	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, nil)
+
+	// finish tool setup
+	return Tool{
+		Name:         cfg.Name,
+		Kind:         kind,
+		Description:  cfg.Description,
+		AuthRequired: cfg.AuthRequired,
+		client:       s.Client,
+		manifest:     tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
+		mcpManifest:  mcpManifest,
+	}, nil
+}
+
+// validate interface
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	Name         string `yaml:"name"`
+	Kind         string `yaml:"kind"`
+	Description  string `yaml:"description"`
+	AuthRequired []string
+
+	client      *mongo.Client
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+func (t Tool) Invoke(ctx context.Context, params tools.ParamValues, accessToken tools.AccessToken) (any, error) {
+	// List all databases
+	databases, err := t.client.ListDatabases(ctx, bson.D{})
+	if err != nil {
+		return nil, fmt.Errorf("error listing databases: %w", err)
+	}
+
+	// Extract database names
+	var databaseNames []string
+	for _, db := range databases.Databases {
+		databaseNames = append(databaseNames, db.Name)
+	}
+
+	return databaseNames, nil
+}
+
+func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (tools.ParamValues, error) {
+	return tools.ParseParams(nil, data, claims)
+}
+
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+}
+
+func (t Tool) RequiresClientAuthorization() bool {
+	return false
+}


### PR DESCRIPTION
Add two new MongoDB discovery tools similar to BigQuery's dataset and table discovery:

1. mongodb-list-database-names - Lists all database names accessible through the MongoDB connection
2. mongodb-list-collection-names - Lists all collection names in a specified database

These tools enable agents to discover MongoDB database structure dynamically, making it easier to work with MongoDB databases without prior knowledge of their schema.

Changes:
- Add mongodblistdatabasenames tool implementation
- Add mongodblistcollectionnames tool implementation
- Add documentation for both new tools
- Register new tools in cmd/root.go
- Add integration tests for discovery functionality

The mongodb-list-collection-names tool supports both config-based and parameter-based database specification, providing flexibility for different use cases.

## Description

> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
