### PR TITLE
ci: add worker pool to release

### DIFF
--- a/.ci/continuous.release.cloudbuild.yaml
+++ b/.ci/continuous.release.cloudbuild.yaml
@@ -186,7 +186,8 @@ options:
   automapSubstitutions: true
   dynamicSubstitutions: true
   logging: CLOUD_LOGGING_ONLY # Necessary for custom service account
-  machineType: 'E2_HIGHCPU_32'
+  pool:
+    name: projects/$PROJECT_ID/locations/us-central1/workerPools/run-release # to increase resource for running releases
 
 substitutions:
   _REGION: us-central1

--- a/.ci/versioned.release.cloudbuild.yaml
+++ b/.ci/versioned.release.cloudbuild.yaml
@@ -233,7 +233,9 @@ options:
   automapSubstitutions: true
   dynamicSubstitutions: true
   logging: CLOUD_LOGGING_ONLY # Necessary for custom service account
-  machineType: 'E2_HIGHCPU_32'
+  pool:
+    name: projects/$PROJECT_ID/locations/us-central1/workerPools/run-release # to increase resource for running releases
+
 
 substitutions:
   _REGION: us-central1


### PR DESCRIPTION
Added a new worker pool in release cloud build that uses `n2d-standard-64` machine, with disk size 100GB. removed the `machineType` since it's indicated in the worker pool.

Release-As: 0.20.0