### PR TITLE
feat(labels): add functionality load and store labels for sources and tools

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -189,7 +189,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 
 	sseManager := newSseManager(ctx)
 
-	resourceManager := NewResourceManager(nil, nil, tools, toolsets)
+	resourceManager := NewResourceManager(nil, nil, tools, toolsets, nil)
 
 	server := Server{
 		version:         fakeVersionString,

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -955,7 +955,7 @@ func TestStdioSession(t *testing.T) {
 
 	sseManager := newSseManager(ctx)
 
-	resourceManager := NewResourceManager(nil, nil, toolsMap, toolsets)
+	resourceManager := NewResourceManager(nil, nil, toolsMap, toolsets, nil)
 
 	server := &Server{
 		version:         fakeVersionString,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -147,7 +147,15 @@ func TestUpdateServer(t *testing.T) {
 			Name: "example-toolset", Tools: []*tools.Tool{},
 		},
 	}
-	s.ResourceMgr.SetResources(newSources, newAuth, newTools, newToolsets)
+	newLabels := map[server.ResType]map[string]map[string]string{
+		server.ResSource: {
+			"example-source": {"env": "prod"},
+		},
+		server.ResTool: {
+			"example-tool": {"category": "analysis"},
+		},
+	}
+	s.ResourceMgr.SetResources(newSources, newAuth, newTools, newToolsets, newLabels)
 	if err != nil {
 		t.Errorf("error updating server: %s", err)
 	}
@@ -170,5 +178,10 @@ func TestUpdateServer(t *testing.T) {
 	gotToolset, _ := s.ResourceMgr.GetToolset("example-toolset")
 	if diff := cmp.Diff(gotToolset, newToolsets["example-toolset"]); diff != "" {
 		t.Errorf("error updating server, toolset (-want +got):\n%s", diff)
+	}
+
+	gotlabels := s.ResourceMgr.GetLabels(server.ResSource, "example-source")
+	if diff := cmp.Diff(gotlabels, newLabels[server.ResSource]["example-source"]); diff != "" {
+		t.Errorf("labels not updated (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Description
### Proposal
This PR intends to adds backend support for storing and propagating labels on `sources` and `tools`.
 
**Note**: Label exposure in the API/UI/MCP and documentation updates are not included in this PR. They will be added either here or in a follow-up PR, after maintainers confirm and approve the implementation approach,

**Pending Follow-up after approval:**
1. Documentation updates.
2. Label exposure in the API/UI/MCP (need input on this).

**Feats:**
1. Labels (annotations) are optional for both sources and tools, existing tool files remain backward compatible
3. Format supports multiple key–value **pairs** for each supported resource(tools, sources) taking implementation inspiration from [Google cloud](https://cloud.google.com/compute/docs/labeling-resources)

### Labels YAML Structure and Meaning
```
labels:                        # top-level section for metadata labels
  sources:                    # labels applied to data sources
    mysql-source:             # resource name
      env: prod               # arbitrary key:value metadata
      owner: data-team
      tier: critical
      region: us-central1

    bigquery-source:          # another source with different metadata
      env: staging
      owner: analytics
      cloud: bigquery

  tools:                      # labels applied to tools
    execute_sql:              # resource name
      category: write         # describe tool behavior or usage
      risk: high
      requires-approval: "true"

    get_query_plan:
      category: metadata
      visibility: internal

    list_active_queries:
      category: monitor
      frequency: hourly

``` 

### Design Discussion 
**Goal:** Add support for Labels(annotation) for sources and tools

**Benefits:** (as mentioned in issue  #1896)
- Adds metadata flexibility without breaking existing configurations.
- Improves organization, readability, and automation capabilities.
- Enables future tooling to leverage annotations for filtering or grouping.

### Explanation for sidecar pattern
Initial approach was to simply introduce Labels inside every Source and Tool config struct.
This would require
1. Code changes, unit test changes and documentation changes in each and every source and tool to make them compatible.
2. Would lead to Inconsistency in a metadata metric that should be universal but equally optional.
3. This approach would also require/force future contributions to include a Label field in config of sources and tools else it would lead to inconsistent behaviour of the metadata field.

Side car pattern:
1. Decouples Labels from Source config and tool config, ensuring every tool and source inherits this metadata field, Labels are stored separately and mapped to resources, so no change to existing config structs.
2. Introduces Labels as a resource in tools.yaml, provides flexibility in declaration and management. 
3. Does not require changes in every source, tool file and documentation for the same.

## PR Checklist
- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #1896

Looking forward to the feedback, I'll be available to make changes based on review and suggestions!