### PR TITLE
feat(tools/postgres-list-tablespaces): add new postgres-list-tablespaces tool

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,6 +192,7 @@ import (
 	_ "github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslistschemas"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslistsequences"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslisttables"
+	_ "github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslisttablespaces"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslisttriggers"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslistviews"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslongrunningtransactions"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1488,7 +1488,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"alloydb_postgres_database_tools": tools.ToolsetConfig{
 					Name:      "alloydb_postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables", "list_active_queries", "list_available_extensions", "list_installed_extensions", "list_autovacuum_configurations", "list_memory_configurations", "list_top_bloated_tables", "list_replication_slots", "list_invalid_indexes", "get_query_plan", "list_views", "list_schemas", "database_overview", "list_triggers", "list_indexes", "list_sequences", "long_running_transactions", "list_locks", "replication_stats", "list_query_stats", "get_column_cardinality", "list_publication_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_active_queries", "list_available_extensions", "list_installed_extensions", "list_autovacuum_configurations", "list_memory_configurations", "list_top_bloated_tables", "list_replication_slots", "list_invalid_indexes", "get_query_plan", "list_views", "list_schemas", "database_overview", "list_triggers", "list_indexes", "list_sequences", "long_running_transactions", "list_locks", "replication_stats", "list_query_stats", "get_column_cardinality", "list_publication_tables", "list_tablespaces"},
 				},
 			},
 		},
@@ -1518,7 +1518,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"cloud_sql_postgres_database_tools": tools.ToolsetConfig{
 					Name:      "cloud_sql_postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables", "list_active_queries", "list_available_extensions", "list_installed_extensions", "list_autovacuum_configurations", "list_memory_configurations", "list_top_bloated_tables", "list_replication_slots", "list_invalid_indexes", "get_query_plan", "list_views", "list_schemas", "database_overview", "list_triggers", "list_indexes", "list_sequences", "long_running_transactions", "list_locks", "replication_stats", "list_query_stats", "get_column_cardinality", "list_publication_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_active_queries", "list_available_extensions", "list_installed_extensions", "list_autovacuum_configurations", "list_memory_configurations", "list_top_bloated_tables", "list_replication_slots", "list_invalid_indexes", "get_query_plan", "list_views", "list_schemas", "database_overview", "list_triggers", "list_indexes", "list_sequences", "long_running_transactions", "list_locks", "replication_stats", "list_query_stats", "get_column_cardinality", "list_publication_tables", "list_tablespaces"},
 				},
 			},
 		},
@@ -1618,7 +1618,7 @@ func TestPrebuiltTools(t *testing.T) {
 			wantToolset: server.ToolsetConfigs{
 				"postgres_database_tools": tools.ToolsetConfig{
 					Name:      "postgres_database_tools",
-					ToolNames: []string{"execute_sql", "list_tables", "list_active_queries", "list_available_extensions", "list_installed_extensions", "list_autovacuum_configurations", "list_memory_configurations", "list_top_bloated_tables", "list_replication_slots", "list_invalid_indexes", "get_query_plan", "list_views", "list_schemas", "database_overview", "list_triggers", "list_indexes", "list_sequences", "long_running_transactions", "list_locks", "replication_stats", "list_query_stats", "get_column_cardinality", "list_publication_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_active_queries", "list_available_extensions", "list_installed_extensions", "list_autovacuum_configurations", "list_memory_configurations", "list_top_bloated_tables", "list_replication_slots", "list_invalid_indexes", "get_query_plan", "list_views", "list_schemas", "database_overview", "list_triggers", "list_indexes", "list_sequences", "long_running_transactions", "list_locks", "replication_stats", "list_query_stats", "get_column_cardinality", "list_publication_tables", "list_tablespaces"},
 				},
 			},
 		},

--- a/docs/en/reference/prebuilt-tools.md
+++ b/docs/en/reference/prebuilt-tools.md
@@ -51,6 +51,7 @@ details on how to connect your AI tools (IDEs) to databases via Toolbox and MCP.
     *   `list_indexes`: List available user indexes in a PostgreSQL database.
     *   `list_sequences`: List sequences in a PostgreSQL database.
     *   `list_publication_tables`: List publication tables in a PostgreSQL database.
+    *   `list_tablespaces`: Lists tablespaces in the database.
 
 ## AlloyDB Postgres Admin
 
@@ -229,6 +230,7 @@ details on how to connect your AI tools (IDEs) to databases via Toolbox and MCP.
     *   `list_indexes`: List available user indexes in a PostgreSQL database.
     *   `list_sequences`: List sequences in a PostgreSQL database.
     *   `list_publication_tables`: List publication tables in a PostgreSQL database.
+    *   `list_tablespaces`: Lists tablespaces in the database.
 
 ## Cloud SQL for PostgreSQL Observability
 
@@ -535,6 +537,7 @@ details on how to connect your AI tools (IDEs) to databases via Toolbox and MCP.
     *   `list_indexes`: List available user indexes in a PostgreSQL database.
     *   `list_sequences`: List sequences in a PostgreSQL database.
     *   `list_publication_tables`: List publication tables in a PostgreSQL database.
+    *   `list_tablespaces`: Lists tablespaces in the database.
 
 ## Google Cloud Serverless for Apache Spark
 

--- a/docs/en/resources/sources/alloydb-pg.md
+++ b/docs/en/resources/sources/alloydb-pg.md
@@ -80,6 +80,9 @@ cluster][alloydb-free-trial].
 - [`postgres-list-publication-tables`](../tools/postgres/postgres-list-publication-tables.md)
   List publication tables in a PostgreSQL database.
 
+- [`postgres-list-tablespaces`](../tools/postgres/postgres-list-tablespaces.md)
+  List tablespaces in an AlloyDB for PostgreSQL database.
+
 ### Pre-built Configurations
 
 - [AlloyDB using MCP](https://googleapis.github.io/genai-toolbox/how-to/connect-ide/alloydb_pg_mcp/)

--- a/docs/en/resources/sources/cloud-sql-pg.md
+++ b/docs/en/resources/sources/cloud-sql-pg.md
@@ -76,6 +76,9 @@ to a database by following these instructions][csql-pg-quickstart].
 - [`postgres-list-publication-tables`](../tools/postgres/postgres-list-publication-tables.md)
   List publication tables in a PostgreSQL database.
 
+- [`postgres-list-tablespaces`](../tools/postgres/postgres-list-tablespaces.md)
+  List tablespaces in a PostgreSQL database.
+
 ### Pre-built Configurations
 
 - [Cloud SQL for Postgres using

--- a/docs/en/resources/sources/postgres.md
+++ b/docs/en/resources/sources/postgres.md
@@ -71,6 +71,9 @@ reputation for reliability, feature robustness, and performance.
 - [`postgres-list-publication-tables`](../tools/postgres/postgres-list-publication-tables.md)
   List publication tables in a PostgreSQL database.
 
+- [`postgres-list-tablespaces`](../tools/postgres/postgres-list-tablespaces.md)
+  List tablespaces in a PostgreSQL database.
+
 ### Pre-built Configurations
 
 - [PostgreSQL using MCP](https://googleapis.github.io/genai-toolbox/how-to/connect-ide/postgres_mcp/)

--- a/docs/en/resources/tools/postgres/postgres-list-tablespaces.md
+++ b/docs/en/resources/tools/postgres/postgres-list-tablespaces.md
@@ -1,0 +1,56 @@
+---
+title: "postgres-list-tablespaces"
+type: docs
+weight: 1
+description: >
+ The "postgres-list-tablespaces" tool lists tablespaces in a Postgres database.
+aliases:
+- /resources/tools/postgres-list-tablespaces
+---
+
+## About
+
+The `postgres-list-tablespaces` tool lists available tablespaces in the database. It's compatible with any of the following sources:
+
+- [alloydb-postgres](../../sources/alloydb-pg.md)
+- [cloud-sql-postgres](../../sources/cloud-sql-pg.md)
+- [postgres](../../sources/postgres.md)
+
+`postgres-list-tablespaces` lists detailed information as JSON for tablespaces. The tool takes the following input parameters:
+
+- `tablespace_name` (optional): A text to filter results by tablespace name. Default: `""`
+- `limit` (optional): The maximum number of tablespaces to return. Default: `50`
+
+## Example
+
+```yaml
+tools:
+  list_tablespaces:
+    kind: postgres-list-tablespaces
+    source: postgres-source
+    description: |
+      Lists all tablespaces in the database. Returns the tablespace name,
+      owner name, size in bytes(if the current user has CREATE privileges on
+      the tablespace, otherwise NULL), internal object ID, the access control
+      list regarding permissions, and any specific tablespace options.
+```
+The response is a json array with the following elements:
+
+```json
+{
+ "tablespace_name": "name of the tablespace",
+ "owner_username": "owner of the tablespace",
+ "size_in_bytes": "size in bytes if the current user has CREATE privileges on the tablespace, otherwise NULL",
+ "oid": "Object ID of the tablespace",
+ "spcacl": "Access privileges",
+ "spcoptions": "Tablespace-level options (e.g., seq_page_cost, random_page_cost)"
+}
+```
+
+## Reference
+
+| **field**   | **type** | **required**  | **description**                                      |
+|-------------|:--------:|:-------------:|------------------------------------------------------|
+| kind        |  string  |     true      | Must be "postgres-list-tablespaces".                      |
+| source      |  string  |     true      | Name of the source the SQL should execute on.        |
+| description |  string  |     false     | Description of the tool that is passed to the agent. |

--- a/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
@@ -175,7 +175,7 @@ tools:
     list_schemas:
         kind: postgres-list-schemas
         source: alloydb-pg-source
-    
+
     list_indexes:
         kind: postgres-list-indexes
         source: alloydb-pg-source
@@ -204,6 +204,10 @@ tools:
         kind: postgres-list-publication-tables
         source: alloydb-pg-source
 
+    list_tablespaces:
+        kind: postgres-list-tablespaces
+        source: alloydb-pg-source
+
 toolsets:
     alloydb_postgres_database_tools:
         - execute_sql
@@ -229,3 +233,4 @@ toolsets:
         - list_query_stats
         - get_column_cardinality
         - list_publication_tables
+        - list_tablespaces

--- a/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
@@ -177,7 +177,7 @@ tools:
     list_schemas:
         kind: postgres-list-schemas
         source: cloudsql-pg-source
-
+    
     database_overview:
         kind: postgres-database-overview
         source: cloudsql-pg-source
@@ -206,6 +206,10 @@ tools:
         kind: postgres-list-publication-tables
         source: cloudsql-pg-source
 
+    list_tablespaces:
+        kind: postgres-list-tablespaces
+        source: cloudsql-pg-source
+
 toolsets:
     cloud_sql_postgres_database_tools:
         - execute_sql
@@ -231,3 +235,4 @@ toolsets:
         - list_query_stats
         - get_column_cardinality
         - list_publication_tables
+        - list_tablespaces

--- a/internal/prebuiltconfigs/tools/postgres.yaml
+++ b/internal/prebuiltconfigs/tools/postgres.yaml
@@ -176,7 +176,7 @@ tools:
     list_schemas:
         kind: postgres-list-schemas
         source: postgresql-source
-
+    
     database_overview:
         kind: postgres-database-overview
         source: postgresql-source
@@ -205,6 +205,10 @@ tools:
         kind: postgres-list-publication-tables
         source: postgresql-source
 
+    list_tablespaces:
+        kind: postgres-list-tablespaces
+        source: postgresql-source
+
 toolsets:
     postgres_database_tools:
         - execute_sql
@@ -230,3 +234,4 @@ toolsets:
         - list_query_stats
         - get_column_cardinality
         - list_publication_tables
+        - list_tablespaces

--- a/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
+++ b/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
@@ -1,0 +1,213 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgreslisttablespaces
+
+import (
+	"context"
+	"fmt"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
+	"github.com/googleapis/genai-toolbox/internal/sources/cloudsqlpg"
+	"github.com/googleapis/genai-toolbox/internal/sources/postgres"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/googleapis/genai-toolbox/internal/util/parameters"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const kind string = "postgres-list-tablespaces"
+
+const listTableSpacesStatement = `
+	WITH
+	tablespace_info AS (
+		SELECT
+		spcname AS tablespace_name,
+		pg_catalog.pg_get_userbyid(spcowner) AS owner_name,
+		CASE
+			WHEN pg_catalog.has_tablespace_privilege(oid, 'CREATE') THEN pg_tablespace_size(oid)
+			ELSE NULL
+			END AS size_in_bytes,
+		oid,
+		spcacl,
+		spcoptions
+		FROM
+		pg_tablespace
+	)
+	SELECT *
+	FROM
+		tablespace_info
+	WHERE
+		($1::text IS NULL OR tablespace_name LIKE '%' || $1::text || '%')
+	ORDER BY
+		tablespace_name
+	LIMIT COALESCE($2::int, 50);
+`
+
+func init() {
+	if !tools.Register(kind, newConfig) {
+		panic(fmt.Sprintf("tool kind %q already registered", kind))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+type compatibleSource interface {
+	PostgresPool() *pgxpool.Pool
+}
+
+// validate compatible sources are still compatible
+var _ compatibleSource = &alloydbpg.Source{}
+var _ compatibleSource = &cloudsqlpg.Source{}
+var _ compatibleSource = &postgres.Source{}
+
+var compatibleSources = [...]string{alloydbpg.SourceKind, cloudsqlpg.SourceKind, postgres.SourceKind}
+
+type Config struct {
+	Name         string   `yaml:"name" validate:"required"`
+	Kind         string   `yaml:"kind" validate:"required"`
+	Source       string   `yaml:"source" validate:"required"`
+	Description  string   `yaml:"description"`
+	AuthRequired []string `yaml:"authRequired"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigKind() string {
+	return kind
+}
+
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	// verify source exists
+	rawS, ok := srcs[cfg.Source]
+	if !ok {
+		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
+	}
+
+	// verify the source is compatible
+	s, ok := rawS.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", kind, compatibleSources)
+	}
+
+	allParameters := parameters.Parameters{
+		parameters.NewStringParameterWithDefault("tablespace_name", "", "Optional: a text to filter results by tablespace name. The input is used within a LIKE clause."),
+		parameters.NewIntParameterWithDefault("limit", 50, "Optional: The maximum number of rows to return."),
+	}
+	description := cfg.Description
+	if description == "" {
+		description = "Lists all tablespaces in the database. Returns the tablespace name, owner name, size in bytes(if the current user has CREATE privileges on the tablespace, otherwise NULL), internal object ID, the access control list regarding permissions, and any specific tablespace options."
+	}
+	mcpManifest := tools.GetMcpManifest(cfg.Name, description, cfg.AuthRequired, allParameters, nil)
+
+	// finish tool setup
+	return Tool{
+		Config:    cfg,
+		allParams: allParameters,
+		pool:      s.PostgresPool(),
+		manifest: tools.Manifest{
+			Description:  cfg.Description,
+			Parameters:   allParameters.Manifest(),
+			AuthRequired: cfg.AuthRequired,
+		},
+		mcpManifest: mcpManifest,
+	}, nil
+}
+
+// validate interface
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	Config
+	allParams   parameters.Parameters `yaml:"allParams"`
+	pool        *pgxpool.Pool
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+func (t Tool) ToConfig() tools.ToolConfig {
+	return t.Config
+}
+
+func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	paramsMap := params.AsMap()
+
+	tablespaceName, ok := paramsMap["tablespace_name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid 'tablespace_name' parameter; expected a string")
+	}
+	limit, ok := paramsMap["limit"].(int)
+	if !ok {
+		return nil, fmt.Errorf("invalid 'limit' parameter; expected an integer")
+	}
+
+	results, err := t.pool.Query(ctx, listTableSpacesStatement, tablespaceName, limit)
+	if err != nil {
+		return nil, fmt.Errorf("unable to execute query: %w", err)
+	}
+	defer results.Close()
+
+	fields := results.FieldDescriptions()
+	var out []map[string]any
+
+	for results.Next() {
+		values, err := results.Values()
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse row: %w", err)
+		}
+		rowMap := make(map[string]any)
+		for i, field := range fields {
+			rowMap[string(field.Name)] = values[i]
+		}
+		out = append(out, rowMap)
+	}
+	// this will catch actual query execution errors
+	if err := results.Err(); err != nil {
+		return nil, fmt.Errorf("unable to execute query: %w", err)
+	}
+
+	return out, nil
+}
+
+func (t Tool) ParseParams(data map[string]any, claims map[string]map[string]any) (parameters.ParamValues, error) {
+	return parameters.ParseParams(t.allParams, data, claims)
+}
+
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+}
+
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
+	return false
+}
+
+func (t Tool) GetAuthTokenHeaderName() string {
+	return "Authorization"
+}

--- a/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces_test.go
+++ b/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgreslisttablespaces_test
+
+import (
+	"testing"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/tools/postgres/postgreslisttablespaces"
+)
+
+func TestParseFromYamlPostgresListTablespaces(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			tools:
+				example_tool:
+					kind: postgres-list-tablespaces
+					source: my-postgres-instance
+					description: some description
+					authRequired:
+						- my-google-auth-service
+						- other-auth-service
+			`,
+			want: server.ToolConfigs{
+				"example_tool": postgreslisttablespaces.Config{
+					Name:         "example_tool",
+					Kind:         "postgres-list-tablespaces",
+					Source:       "my-postgres-instance",
+					Description:  "some description",
+					AuthRequired: []string{"my-google-auth-service", "other-auth-service"},
+				},
+			},
+		},
+		{
+			desc: "basic example",
+			in: `
+			tools:
+				example_tool:
+					kind: postgres-list-tablespaces
+					source: my-postgres-instance
+					description: some description
+			`,
+			want: server.ToolConfigs{
+				"example_tool": postgreslisttablespaces.Config{
+					Name:         "example_tool",
+					Kind:         "postgres-list-tablespaces",
+					Source:       "my-postgres-instance",
+					Description:  "some description",
+					AuthRequired: []string{},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := struct {
+				Tools server.ToolConfigs `yaml:"tools"`
+			}{}
+			// Parse contents
+			err := yaml.UnmarshalContext(ctx, testutils.FormatYaml(tc.in), &got)
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got.Tools); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+
+}

--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -196,6 +196,7 @@ func TestAlloyDBPgToolEndpoints(t *testing.T) {
 	tests.RunPostgresListQueryStatsTest(t, ctx, pool)
 	tests.RunPostgresGetColumnCardinalityTest(t, ctx, pool)
 	tests.RunPostgresListPublicationTablesTest(t, ctx, pool)
+	tests.RunPostgresListTableSpacesTest(t)
 }
 
 // Test connection with different IP type

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -180,6 +180,7 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 	tests.RunPostgresListQueryStatsTest(t, ctx, pool)
 	tests.RunPostgresGetColumnCardinalityTest(t, ctx, pool)
 	tests.RunPostgresListPublicationTablesTest(t, ctx, pool)
+	tests.RunPostgresListTableSpacesTest(t)
 }
 
 // Test connection with different IP type

--- a/tests/common.go
+++ b/tests/common.go
@@ -208,6 +208,7 @@ func AddPostgresPrebuiltConfig(t *testing.T, config map[string]any) map[string]a
 		PostgresListQueryStatsToolKind          = "postgres-list-query-stats"
 		PostgresGetColumnCardinalityToolKind    = "postgres-get-column-cardinality"
 		PostgresListPublicationTablesToolKind   = "postgres-list-publication-tables"
+		PostgresListTablespacesToolKind         = "postgres-list-tablespaces"
 	)
 
 	tools, ok := config["tools"].(map[string]any)
@@ -289,12 +290,14 @@ func AddPostgresPrebuiltConfig(t *testing.T, config map[string]any) map[string]a
 		"kind":   PostgresListQueryStatsToolKind,
 		"source": "my-instance",
 	}
-
 	tools["get_column_cardinality"] = map[string]any{
 		"kind":   PostgresGetColumnCardinalityToolKind,
 		"source": "my-instance",
 	}
-
+	tools["list_tablespaces"] = map[string]any{
+		"kind":   PostgresListTablespacesToolKind,
+		"source": "my-instance",
+	}
 	config["tools"] = tools
 	return config
 }

--- a/tests/postgres/postgres_integration_test.go
+++ b/tests/postgres/postgres_integration_test.go
@@ -159,4 +159,5 @@ func TestPostgres(t *testing.T) {
 	tests.RunPostgresListQueryStatsTest(t, ctx, pool)
 	tests.RunPostgresGetColumnCardinalityTest(t, ctx, pool)
 	tests.RunPostgresListPublicationTablesTest(t, ctx, pool)
+	tests.RunPostgresListTableSpacesTest(t)
 }

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -2244,6 +2244,33 @@ func RunPostgresListSequencesTest(t *testing.T, ctx context.Context, pool *pgxpo
 	}
 }
 
+func RunPostgresListTableSpacesTest(t *testing.T) {
+	invokeTcs := []struct {
+		name           string
+		api            string
+		requestBody    io.Reader
+		wantStatusCode int
+	}{
+		{
+			name:           "invoke list_tablespaces output",
+			api:            "http://127.0.0.1:5000/api/tool/list_tablespaces/invoke",
+			wantStatusCode: http.StatusOK,
+			requestBody:    bytes.NewBuffer([]byte(`{}`)),
+		},
+	}
+	for _, tc := range invokeTcs {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, respBody := RunRequest(t, http.MethodPost, tc.api, tc.requestBody, nil)
+			if resp.StatusCode != tc.wantStatusCode {
+				t.Fatalf("response status code is not 200, got %d: %s", resp.StatusCode, string(respBody))
+			}
+
+			// Intentionally not adding the output check as output depends on the postgres instance used where the the functional test runs.
+			// Adding the check will make the test flaky.
+		})
+	}
+}
+
 // RunMySQLListTablesTest run tests against the mysql-list-tables tool
 func RunMySQLListTablesTest(t *testing.T, databaseName, tableNameParam, tableNameAuth, expectedOwner string) {
 	var ownerWant any


### PR DESCRIPTION
## Description
Adds a postgresql custom list_tablespaces tool, that returns the details of tablespaces present in database.

<img width="1719" height="698" alt="Screenshot 2025-11-12 at 9 11 13 AM" src="https://github.com/user-attachments/assets/03964a1b-27e0-4da8-85a2-57db905163ed" />
<img width="1077" height="141" alt="Screenshot 2025-11-12 at 9 12 42 AM" src="https://github.com/user-attachments/assets/f93f5692-eb62-4f30-8192-40c8873d4d00" />


> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

Lists all tablespaces in the database. Returns the tablespace name, owner name, size in bytes, internal object ID, the access control list regarding permissions, and any specific tablespace options.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #1738 
