### PR TITLE
docs: Update the ADK quickstart sample

### DIFF
--- a/docs/en/getting-started/quickstart/python/adk/quickstart.py
+++ b/docs/en/getting-started/quickstart/python/adk/quickstart.py
@@ -3,7 +3,7 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
 from google.genai import types
-from toolbox_core import ToolboxSyncClient
+from toolbox_core import ToolboxClient
 
 import asyncio
 import os
@@ -14,7 +14,7 @@ api_key = os.environ.get("GOOGLE_API_KEY") or "your-api-key" # Set your API key 
 os.environ["GOOGLE_API_KEY"] = api_key
 
 async def main():
-  with ToolboxSyncClient("http://127.0.0.1:5000") as toolbox_client:
+  async with ToolboxClient("http://127.0.0.1:5000") as toolbox_client:
 
       prompt = """
         You're a helpful hotel assistant. You handle hotel searching, booking and
@@ -27,11 +27,11 @@ async def main():
       """
 
       root_agent = Agent(
-          model='gemini-2.0-flash-001',
+          model='gemini-2.5-flash',
           name='hotel_agent',
           description='A helpful AI assistant.',
           instruction=prompt,
-          tools=toolbox_client.load_toolset("my-toolset"),
+          tools=await toolbox_client.load_toolset("my-toolset"),
       )
 
       session_service = InMemorySessionService()


### PR DESCRIPTION
Addresses https://github.com/googleapis/genai-toolbox/issues/1705

## Description

The current ADK quickstart example used the `ToolboxSyncClient` while most of the examples use the async `ToolboxClient`. This PR updates the quickstart to make it use the `ToolboxClient` and making it consistent with the other samples.
