### PR TITLE
docs: Fix rendering issue with a note in the docs

### DIFF
--- a/docs/en/getting-started/quickstart/shared/configure_toolbox.md
+++ b/docs/en/getting-started/quickstart/shared/configure_toolbox.md
@@ -116,7 +116,7 @@ In this section, we will download Toolbox, configure our tools in a
     ```
 
     {{< notice note >}}
-    Toolbox enables dynamic reloading by default. To disable, use the
-    `--disable-reload` flag.
+Toolbox enables dynamic reloading by default. To disable, use the
+`--disable-reload` flag.
     {{< /notice >}}
 <!-- [END configure_toolbox] -->

--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -294,8 +294,8 @@ to use BigQuery, and then run the Toolbox server.
     ```
 
     {{< notice note >}}
-    Toolbox enables dynamic reloading by default. To disable, use the
-    `--disable-reload` flag.
+Toolbox enables dynamic reloading by default. To disable, use the
+`--disable-reload` flag.
     {{< /notice >}}
 
 ## Step 3: Connect your agent to Toolbox


### PR DESCRIPTION
## Description

A note related to `--disable-reload` flag was not rendering properly. This PR fixes that by removing the incorrect indentation.

## Before
<img width="1792" height="650" alt="image" src="https://github.com/user-attachments/assets/564fce34-893e-4aa8-9da3-1401ae69188a" />

## After
<img width="1808" height="532" alt="image" src="https://github.com/user-attachments/assets/ee17973f-3191-4519-8855-6389f9567926" />
