### PR TITLE
docs: Fix binary install commands for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ To install Toolbox as a binary:
 > To install Toolbox as a binary on Windows (AMD64):
 >
 > ```powershell
-> # see releases page for other versions
-> $VERSION = "0.21.0"
-> Invoke-WebRequest -Uri "https://storage.googleapis.com/genai-toolbox/v$VERSION/windows/amd64/toolbox.exe" -OutFile "toolbox.exe"
+> :: see releases page for other versions
+> set VERSION=0.21.0
+> curl -o toolbox.exe "https://storage.googleapis.com/genai-toolbox/v%VERSION%/windows/amd64/toolbox.exe"
 > ```
 >
 > </details>

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -119,9 +119,9 @@ chmod +x toolbox
 To install Toolbox as a binary on Windows (AMD64):
 
 ```powershell
-# see releases page for other versions
-$VERSION = "0.21.0"
-Invoke-WebRequest -Uri "https://storage.googleapis.com/genai-toolbox/v$VERSION/windows/amd64/toolbox.exe" -OutFile "toolbox.exe"
+:: see releases page for other versions
+set VERSION=0.21.0
+curl -o toolbox.exe "https://storage.googleapis.com/genai-toolbox/v%VERSION%/windows/amd64/toolbox.exe"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
This PR updates the documentation to fix installation commands compatible with the standard Windows Command Prompt (`cmd.exe`). Earlier it was targeted towards Powershell, which might not be used by many users using a Windows machine.