### PR TITLE
chore(deps): Fix typo in package dependency name

### DIFF
--- a/docs/en/getting-started/quickstart/python/langchain/requirements.txt
+++ b/docs/en/getting-started/quickstart/python/langchain/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.0.8
-langchain-google-vertexai==3.0.2
+langchain-google-vertexai==3.0.3
 langgraph==1.0.3
 toolbox-langchain==0.5.3
 pytest==9.0.1


### PR DESCRIPTION
Partially reverts googleapis/genai-toolbox#2011 to fix the typo in the package name.

The original PR breaks builds due to incorrect package name.

<img width="2254" height="522" alt="image" src="https://github.com/user-attachments/assets/d51aba16-a84e-46cb-b17c-4eab1576dd59" />
