### PR TITLE
docs: Update guides to require Python 3.10+ following Python 3.9 drop

### DIFF
--- a/docs/en/getting-started/local_quickstart.md
+++ b/docs/en/getting-started/local_quickstart.md
@@ -13,7 +13,7 @@ description: >
 
 This guide assumes you have already done the following:
 
-1. Installed [Python 3.9+][install-python] (including [pip][install-pip] and
+1. Installed [Python 3.10+][install-python] (including [pip][install-pip] and
    your preferred virtual environment tool for managing dependencies e.g.
    [venv][install-venv]).
 1. Installed [PostgreSQL 16+ and the `psql` client][install-postgres].

--- a/docs/en/samples/bigquery/local_quickstart.md
+++ b/docs/en/samples/bigquery/local_quickstart.md
@@ -14,7 +14,7 @@ Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.
 
 This guide assumes you have already done the following:
 
-1. Installed [Python 3.9+][install-python] (including [pip][install-pip] and
+1. Installed [Python 3.10+][install-python] (including [pip][install-pip] and
     your preferred virtual environment tool for managing dependencies e.g.
     [venv][install-venv]).
 1. Installed and configured the [Google Cloud SDK (gcloud CLI)][install-gcloud].


### PR DESCRIPTION
## Description

This PR updates the installation guides and documentation to reflect that Python 3.9 is no longer supported. Users are now instructed to install Python 3.10+.

## Context
This is a follow-up to https://github.com/googleapis/mcp-toolbox-sdk-python/pull/422, which officially removed support for Python 3.9 from the Python SDKs codebase. This change ensures the documentation aligns with the current package requirements.
