### PR TITLE
docs: Improve Python async example for ToolboxClient usage

### DIFF
--- a/docs/en/how-to/deploy_toolbox.md
+++ b/docs/en/how-to/deploy_toolbox.md
@@ -162,18 +162,23 @@ You can connect to Toolbox Cloud Run instances directly through the SDK.
 
     {{< tabpane persist=header >}}
 {{< tab header="Python" lang="python" >}}
+import asyncio
 from toolbox_core import ToolboxClient, auth_methods
 
 # Replace with the Cloud Run service URL generated in the previous step
-
 URL = "https://cloud-run-url.app"
 
 auth_token_provider = auth_methods.aget_google_id_token(URL) # can also use sync method
 
-async with ToolboxClient(
-    URL,
-    client_headers={"Authorization": auth_token_provider},
-) as toolbox:
+async def main():
+  async with ToolboxClient(
+      URL,
+      client_headers={"Authorization": auth_token_provider},
+  ) as toolbox:
+    toolset = await toolbox.load_toolset()
+    # ...
+
+asyncio.run(main())
 {{< /tab >}}
 {{< tab header="Javascript" lang="javascript" >}}
 import { ToolboxClient } from '@toolbox-sdk/core';


### PR DESCRIPTION
Refactor Python example to use an async main function for `ToolboxClient`, which is an async client and needs to be called from an `async` function. This PR fixes that by putting this function call in an async `main` function.