### PR TITLE
fix(tools/alloydbcreateuser): remove duplication of project praram

### DIFF
--- a/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
+++ b/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
@@ -81,7 +81,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	allParameters := parameters.Parameters{
 		projectParam,
-		parameters.NewStringParameter("project", "The GCP project ID."),
 		parameters.NewStringParameter("location", "The location of the cluster (e.g., 'us-central1')."),
 		parameters.NewStringParameter("cluster", "The ID of the cluster where the user will be created."),
 		parameters.NewStringParameter("user", "The name for the new user. Must be unique within the cluster."),


### PR DESCRIPTION
## Description

The project parameter was defined within an if-else statement before the other parameters were defined.
