### PR TITLE
chore(tools/looker): decouple source config from tools

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -119,8 +119,8 @@ func (t MockTool) McpManifest() tools.McpManifest {
 	return mcpManifest
 }
 
-func (t MockTool) GetAuthTokenHeaderName() string {
-	return "Authorization"
+func (t MockTool) GetAuthTokenHeaderName(tools.SourceProvider) (string, error) {
+	return "Authorization", nil
 }
 
 // MockPrompt is used to mock prompts in tests

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -102,7 +102,12 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *re
 	}
 
 	// Get access token
-	accessToken := tools.AccessToken(header.Get(tool.GetAuthTokenHeaderName()))
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(resourceMgr)
+	if err != nil {
+		errMsg := fmt.Errorf("error during invocation: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
+	}
+	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -102,7 +102,12 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *re
 	}
 
 	// Get access token
-	accessToken := tools.AccessToken(header.Get(tool.GetAuthTokenHeaderName()))
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(resourceMgr)
+	if err != nil {
+		errMsg := fmt.Errorf("error during invocation: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
+	}
+	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -102,7 +102,12 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *re
 	}
 
 	// Get access token
-	accessToken := tools.AccessToken(header.Get(tool.GetAuthTokenHeaderName()))
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(resourceMgr)
+	if err != nil {
+		errMsg := fmt.Errorf("error during invocation: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
+	}
+	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)

--- a/internal/sources/looker/looker.go
+++ b/internal/sources/looker/looker.go
@@ -160,10 +160,6 @@ func (s *Source) ToConfig() sources.SourceConfig {
 	return s.Config
 }
 
-func (s *Source) GetApiSettings() *rtl.ApiSettings {
-	return s.ApiSettings
-}
-
 func (s *Source) UseClientAuthorization() bool {
 	return strings.ToLower(s.UseClientOAuth) != "false"
 }
@@ -186,6 +182,30 @@ func (s *Source) GoogleCloudTokenSource() oauth2.TokenSource {
 
 func (s *Source) GoogleCloudTokenSourceWithScope(ctx context.Context, scope string) (oauth2.TokenSource, error) {
 	return google.DefaultTokenSource(ctx, scope)
+}
+
+func (s *Source) LookerClient() *v4.LookerSDK {
+	return s.Client
+}
+
+func (s *Source) LookerApiSettings() *rtl.ApiSettings {
+	return s.ApiSettings
+}
+
+func (s *Source) LookerShowHiddenFields() bool {
+	return s.ShowHiddenFields
+}
+
+func (s *Source) LookerShowHiddenModels() bool {
+	return s.ShowHiddenModels
+}
+
+func (s *Source) LookerShowHiddenExplores() bool {
+	return s.ShowHiddenExplores
+}
+
+func (s *Source) LookerSessionLength() int64 {
+	return s.SessionLength
 }
 
 func initGoogleCloudConnection(ctx context.Context) (oauth2.TokenSource, error) {

--- a/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
+++ b/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetQueryParameters()
 
 	dashIdParameter := parameters.NewStringParameter("dashboard_id", "The id of the dashboard where this tile will exist")
@@ -90,12 +84,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -110,13 +100,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -129,6 +115,15 @@ var (
 )
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -148,12 +143,12 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	qrespFields := "id"
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
 
-	qresp, err := sdk.CreateQuery(*wq, qrespFields, t.ApiSettings)
+	qresp, err := sdk.CreateQuery(*wq, qrespFields, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making create query request: %w", err)
 	}
@@ -177,7 +172,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Fields: &fields,
 	}
 
-	resp, err := sdk.CreateDashboardElement(req, t.ApiSettings)
+	resp, err := sdk.CreateDashboardElement(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making create dashboard element request: %w", err)
 	}
@@ -202,14 +197,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -26,7 +26,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookerds "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
@@ -56,12 +55,12 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
-	GetApiSettings() *rtl.ApiSettings
 	GoogleCloudTokenSourceWithScope(ctx context.Context, scope string) (oauth2.TokenSource, error)
 	GoogleCloudProject() string
 	GoogleCloudLocation() string
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
+	LookerApiSettings() *rtl.ApiSettings
 }
 
 // Structs for building the JSON payload
@@ -124,11 +123,6 @@ type CAPayload struct {
 	ClientIdEnum  string        `json:"clientIdEnum"`
 }
 
-// validate compatible sources are still compatible
-var _ compatibleSource = &lookerds.Source{}
-
-var compatibleSources = [...]string{lookerds.SourceKind}
-
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -154,7 +148,7 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	// verify the source is compatible
 	s, ok := rawS.(compatibleSource)
 	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be one of %q", kind, compatibleSources)
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, cfg.Source)
 	}
 
 	if s.GoogleCloudProject() == "" {
@@ -186,16 +180,11 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	t := Tool{
-		Config:              cfg,
-		ApiSettings:         s.GetApiSettings(),
-		Project:             s.GoogleCloudProject(),
-		Location:            s.GoogleCloudLocation(),
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		TokenSource:         ts,
-		manifest:            tools.Manifest{Description: cfg.Description, Parameters: params.Manifest(), AuthRequired: cfg.AuthRequired},
-		mcpManifest:         mcpManifest,
+		Config:      cfg,
+		Parameters:  params,
+		TokenSource: ts,
+		manifest:    tools.Manifest{Description: cfg.Description, Parameters: params.Manifest(), AuthRequired: cfg.AuthRequired},
+		mcpManifest: mcpManifest,
 	}
 	return t, nil
 }
@@ -205,15 +194,10 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	ApiSettings         *rtl.ApiSettings
-	UseClientOAuth      bool `yaml:"useClientOAuth"`
-	AuthTokenHeaderName string
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	Project             string
-	Location            string
-	TokenSource         oauth2.TokenSource
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	TokenSource oauth2.TokenSource
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -221,6 +205,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	var tokenStr string
 	var err error
 
@@ -243,16 +236,16 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	ler := make([]LookerExploreReference, 0)
 	for _, er := range exploreReferences {
 		ler = append(ler, LookerExploreReference{
-			LookerInstanceUri: t.ApiSettings.BaseUrl,
+			LookerInstanceUri: source.LookerApiSettings().BaseUrl,
 			LookmlModel:       er.(map[string]any)["model"].(string),
 			Explore:           er.(map[string]any)["explore"].(string),
 		})
 	}
 	oauth_creds := OAuthCredentials{}
-	if t.UseClientOAuth {
+	if source.UseClientAuthorization() {
 		oauth_creds.Token = TokenBased{AccessToken: string(accessToken)}
 	} else {
-		oauth_creds.Secret = SecretBased{ClientId: t.ApiSettings.ClientId, ClientSecret: t.ApiSettings.ClientSecret}
+		oauth_creds.Secret = SecretBased{ClientId: source.LookerApiSettings().ClientId, ClientSecret: source.LookerApiSettings().ClientSecret}
 	}
 
 	lers := LookerExploreReferences{
@@ -263,8 +256,8 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	// Construct URL, headers, and payload
-	projectID := t.Project
-	location := t.Location
+	projectID := source.GoogleCloudProject()
+	location := source.GoogleCloudLocation()
 	caURL := fmt.Sprintf("https://geminidataanalytics.googleapis.com/v1beta/projects/%s/locations/%s:chat", url.PathEscape(projectID), url.PathEscape(location))
 
 	headers := map[string]string{
@@ -305,12 +298,21 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
-func (t Tool) Authorized(verifiedAuthServices []string) bool {
-	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
 // StreamMessage represents a single message object from the streaming API response.
@@ -553,6 +555,15 @@ func appendMessage(messages []map[string]any, newMessage map[string]any) []map[s
 	return append(messages, newMessage)
 }
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
+++ b/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
@@ -44,6 +43,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -60,18 +66,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	projectIdParameter := parameters.NewStringParameter("project_id", "The id of the project containing the files")
 	filePathParameter := parameters.NewStringParameter("file_path", "The path of the file within the project")
 	fileContentParameter := parameters.NewStringParameter("file_content", "The content of the file")
@@ -81,12 +75,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -101,13 +91,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -115,7 +101,16 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -139,7 +134,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Content: fileContent,
 	}
 
-	err = lookercommon.CreateProjectFile(sdk, projectId, req, t.ApiSettings)
+	err = lookercommon.CreateProjectFile(sdk, projectId, req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making create_project_file request: %s", err)
 	}
@@ -163,14 +158,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
+++ b/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
@@ -44,6 +43,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -60,18 +66,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	projectIdParameter := parameters.NewStringParameter("project_id", "The id of the project containing the files")
 	filePathParameter := parameters.NewStringParameter("file_path", "The path of the file within the project")
 	params := parameters.Parameters{projectIdParameter, filePathParameter}
@@ -80,12 +74,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -100,13 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -114,7 +100,16 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -129,7 +124,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("'file_path' must be a string, got %T", mapParams["file_path"])
 	}
 
-	err = lookercommon.DeleteProjectFile(sdk, projectId, filePath, t.ApiSettings)
+	err = lookercommon.DeleteProjectFile(sdk, projectId, filePath, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making delete_project_file request: %s", err)
 	}
@@ -153,14 +148,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerdevmode/lookerdevmode.go
+++ b/internal/tools/looker/lookerdevmode/lookerdevmode.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	devModeParameter := parameters.NewBooleanParameterWithDefault("devMode", true, "Whether to set Dev Mode.")
 	params := parameters.Parameters{devModeParameter}
 
@@ -80,19 +74,14 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
 			AuthRequired: cfg.AuthRequired,
 		},
-		mcpManifest:        mcpManifest,
-		ShowHiddenExplores: s.ShowHiddenExplores,
+		mcpManifest: mcpManifest,
 	}, nil
 }
 
@@ -101,14 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
-	ShowHiddenExplores  bool
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -116,6 +100,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -126,7 +119,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("'devMode' must be a boolean, got %T", mapParams["devMode"])
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -139,7 +132,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	req := v4.WriteApiSession{
 		WorkspaceId: &devModeString,
 	}
-	resp, err := sdk.UpdateSession(req, t.ApiSettings)
+	resp, err := sdk.UpdateSession(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error setting/resetting dev mode: %w", err)
 	}
@@ -160,14 +153,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
+++ b/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
@@ -44,6 +43,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -60,18 +66,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	connParameter := parameters.NewStringParameter("conn", "The connection containing the databases.")
 	params := parameters.Parameters{connParameter}
 
@@ -79,12 +73,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -99,13 +89,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -113,17 +99,26 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	mapParams := params.AsMap()
 	conn, ok := mapParams["conn"].(string)
 	if !ok {
 		return nil, fmt.Errorf("'conn' must be a string, got %T", mapParams["conn"])
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
-	resp, err := sdk.ConnectionDatabases(conn, t.ApiSettings)
+	resp, err := sdk.ConnectionDatabases(conn, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_connection_databases request: %s", err)
 	}
@@ -144,14 +139,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnections/lookergetconnections.go
+++ b/internal/tools/looker/lookergetconnections/lookergetconnections.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,30 +67,14 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := parameters.Parameters{}
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -99,13 +89,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -113,16 +99,25 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
-	resp, err := sdk.AllConnections("name, dialect(name), database, schema", t.ApiSettings)
+	resp, err := sdk.AllConnections("name, dialect(name), database, schema", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_connections request: %s", err)
 	}
@@ -138,7 +133,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		if v.Schema != nil {
 			vMap["schema"] = *v.Schema
 		}
-		conn, err := sdk.ConnectionFeatures(*v.Name, "multiple_databases", t.ApiSettings)
+		conn, err := sdk.ConnectionFeatures(*v.Name, "multiple_databases", source.LookerApiSettings())
 		if err != nil {
 			return nil, fmt.Errorf("error making get_connection_features request: %s", err)
 		}
@@ -163,14 +158,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
+++ b/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
@@ -44,6 +43,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -60,18 +66,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	connParameter := parameters.NewStringParameter("conn", "The connection containing the schemas.")
 	dbParameter := parameters.NewStringParameterWithRequired("db", "The optional database to search", false)
 	params := parameters.Parameters{connParameter, dbParameter}
@@ -80,12 +74,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -100,13 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -114,6 +100,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	mapParams := params.AsMap()
 	conn, ok := mapParams["conn"].(string)
 	if !ok {
@@ -121,7 +116,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	db, _ := mapParams["db"].(string)
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -131,7 +126,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if db != "" {
 		req.Database = &db
 	}
-	resp, err := sdk.ConnectionSchemas(req, t.ApiSettings)
+	resp, err := sdk.ConnectionSchemas(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_connection_schemas request: %s", err)
 	}
@@ -150,14 +145,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
+++ b/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	connParameter := parameters.NewStringParameter("conn", "The connection containing the tables.")
 	dbParameter := parameters.NewStringParameterWithRequired("db", "The optional database to search", false)
 	schemaParameter := parameters.NewStringParameter("schema", "The schema containing the tables.")
@@ -83,12 +77,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -103,13 +93,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -117,6 +103,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -136,7 +131,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("'tables' must be a string, got %T", mapParams["tables"])
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -148,7 +143,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if db != "" {
 		req.Database = &db
 	}
-	resp, err := sdk.ConnectionColumns(req, t.ApiSettings)
+	resp, err := sdk.ConnectionColumns(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_connection_table_columns request: %s", err)
 	}
@@ -187,14 +182,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
+++ b/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	connParameter := parameters.NewStringParameter("conn", "The connection containing the tables.")
 	dbParameter := parameters.NewStringParameterWithRequired("db", "The optional database to search", false)
 	schemaParameter := parameters.NewStringParameter("schema", "The schema containing the tables.")
@@ -82,12 +76,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -102,13 +92,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -116,6 +102,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -131,7 +126,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("'schema' must be a string, got %T", mapParams["schema"])
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -142,7 +137,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if db != "" {
 		req.Database = &db
 	}
-	resp, err := sdk.ConnectionTables(req, t.ApiSettings)
+	resp, err := sdk.ConnectionTables(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_connection_tables request: %s", err)
 	}
@@ -178,14 +173,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
+++ b/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	titleParameter := parameters.NewStringParameterWithDefault("title", "", "The title of the dashboard.")
 	descParameter := parameters.NewStringParameterWithDefault("desc", "", "The description of the dashboard.")
 	limitParameter := parameters.NewIntParameterWithDefault("limit", 100, "The number of dashboards to fetch. Default 100")
@@ -88,12 +82,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -108,13 +98,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -122,6 +108,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -140,7 +135,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	limit := int64(paramsMap["limit"].(int))
 	offset := int64(paramsMap["offset"].(int))
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -151,7 +146,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Offset:      &offset,
 	}
 	logger.ErrorContext(ctx, "Making request %v", req)
-	resp, err := sdk.SearchDashboards(req, t.ApiSettings)
+	resp, err := sdk.SearchDashboards(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_dashboards request: %s", err)
 	}
@@ -189,14 +184,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetexplores/lookergetexplores.go
+++ b/internal/tools/looker/lookergetexplores/lookergetexplores.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+	LookerShowHiddenExplores() bool
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +68,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	modelParameter := parameters.NewStringParameter("model", "The model containing the explores.")
 	params := parameters.Parameters{modelParameter}
 
@@ -80,19 +75,14 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
 			AuthRequired: cfg.AuthRequired,
 		},
-		mcpManifest:        mcpManifest,
-		ShowHiddenExplores: s.ShowHiddenExplores,
+		mcpManifest: mcpManifest,
 	}, nil
 }
 
@@ -101,14 +91,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
-	ShowHiddenExplores  bool
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -116,6 +101,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -126,11 +120,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("'model' must be a string, got %T", mapParams["model"])
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
-	resp, err := sdk.LookmlModel(model, "explores(name,description,label,group_label,hidden)", t.ApiSettings)
+	resp, err := sdk.LookmlModel(model, "explores(name,description,label,group_label,hidden)", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_explores request: %s", err)
 	}
@@ -138,7 +132,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	var data []any
 	for _, v := range *resp.Explores {
 		logger.DebugContext(ctx, "Got response element of %v\n", v)
-		if !t.ShowHiddenExplores && v.Hidden != nil && *v.Hidden {
+		if !source.LookerShowHiddenExplores() && v.Hidden != nil && *v.Hidden {
 			continue
 		}
 		vMap := make(map[string]any)
@@ -174,14 +168,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetfilters/lookergetfilters.go
+++ b/internal/tools/looker/lookergetfilters/lookergetfilters.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+	LookerShowHiddenFields() bool
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,37 +68,20 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetFieldParameters()
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
 			AuthRequired: cfg.AuthRequired,
 		},
-		mcpManifest:      mcpManifest,
-		ShowHiddenFields: s.ShowHiddenFields,
+		mcpManifest: mcpManifest,
 	}, nil
 }
 
@@ -100,14 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
-	ShowHiddenFields    bool
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -115,6 +100,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -125,7 +119,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	fields := lookercommon.FiltersFields
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -134,7 +128,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		ExploreName:     *explore,
 		Fields:          &fields,
 	}
-	resp, err := sdk.LookmlModelExplore(req, t.ApiSettings)
+	resp, err := sdk.LookmlModelExplore(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_filters request: %w", err)
 	}
@@ -143,7 +137,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("error processing get_filters response: %w", err)
 	}
 
-	data, err := lookercommon.ExtractLookerFieldProperties(ctx, resp.Fields.Filters, t.ShowHiddenFields)
+	data, err := lookercommon.ExtractLookerFieldProperties(ctx, resp.Fields.Filters, source.LookerShowHiddenFields())
 	if err != nil {
 		return nil, fmt.Errorf("error extracting get_filters response: %w", err)
 	}
@@ -164,14 +158,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetlooks/lookergetlooks.go
+++ b/internal/tools/looker/lookergetlooks/lookergetlooks.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	titleParameter := parameters.NewStringParameterWithDefault("title", "", "The title of the look.")
 	descParameter := parameters.NewStringParameterWithDefault("desc", "", "The description of the look.")
 	limitParameter := parameters.NewIntParameterWithDefault("limit", 100, "The number of looks to fetch. Default 100")
@@ -88,12 +82,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -108,13 +98,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -122,6 +108,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -140,7 +135,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	limit := int64(paramsMap["limit"].(int))
 	offset := int64(paramsMap["offset"].(int))
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -150,7 +145,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Limit:       &limit,
 		Offset:      &offset,
 	}
-	resp, err := sdk.SearchLooks(req, t.ApiSettings)
+	resp, err := sdk.SearchLooks(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_looks request: %s", err)
 	}
@@ -189,14 +184,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
+++ b/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+	LookerShowHiddenFields() bool
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,37 +68,20 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetFieldParameters()
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
 			AuthRequired: cfg.AuthRequired,
 		},
-		mcpManifest:      mcpManifest,
-		ShowHiddenFields: s.ShowHiddenFields,
+		mcpManifest: mcpManifest,
 	}, nil
 }
 
@@ -100,14 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
-	ShowHiddenFields    bool
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -115,6 +100,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -125,7 +119,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	fields := lookercommon.MeasuresFields
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -134,7 +128,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		ExploreName:     *explore,
 		Fields:          &fields,
 	}
-	resp, err := sdk.LookmlModelExplore(req, t.ApiSettings)
+	resp, err := sdk.LookmlModelExplore(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_measures request: %w", err)
 	}
@@ -143,7 +137,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("error processing get_measures response: %w", err)
 	}
 
-	data, err := lookercommon.ExtractLookerFieldProperties(ctx, resp.Fields.Measures, t.ShowHiddenFields)
+	data, err := lookercommon.ExtractLookerFieldProperties(ctx, resp.Fields.Measures, source.LookerShowHiddenFields())
 	if err != nil {
 		return nil, fmt.Errorf("error extracting get_measures response: %w", err)
 	}
@@ -164,14 +158,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetmodels/lookergetmodels.go
+++ b/internal/tools/looker/lookergetmodels/lookergetmodels.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+	LookerShowHiddenModels() bool
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,37 +68,20 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := parameters.Parameters{}
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
 			AuthRequired: cfg.AuthRequired,
 		},
-		mcpManifest:      mcpManifest,
-		ShowHiddenModels: s.ShowHiddenModels,
+		mcpManifest: mcpManifest,
 	}, nil
 }
 
@@ -100,14 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
-	ShowHiddenModels    bool
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -115,16 +100,25 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 
 	excludeEmpty := false
-	excludeHidden := !t.ShowHiddenModels
+	excludeHidden := !source.LookerShowHiddenModels()
 	includeInternal := true
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -133,7 +127,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		ExcludeHidden:   &excludeHidden,
 		IncludeInternal: &includeInternal,
 	}
-	resp, err := sdk.AllLookmlModels(req, t.ApiSettings)
+	resp, err := sdk.AllLookmlModels(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_models request: %s", err)
 	}
@@ -166,14 +160,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetparameters/lookergetparameters.go
+++ b/internal/tools/looker/lookergetparameters/lookergetparameters.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+	LookerShowHiddenFields() bool
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,37 +68,20 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetFieldParameters()
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
 			AuthRequired: cfg.AuthRequired,
 		},
-		mcpManifest:      mcpManifest,
-		ShowHiddenFields: s.ShowHiddenFields,
+		mcpManifest: mcpManifest,
 	}, nil
 }
 
@@ -100,14 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
-	ShowHiddenFields    bool
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -115,6 +100,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -125,7 +119,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	fields := lookercommon.ParametersFields
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -134,7 +128,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		ExploreName:     *explore,
 		Fields:          &fields,
 	}
-	resp, err := sdk.LookmlModelExplore(req, t.ApiSettings)
+	resp, err := sdk.LookmlModelExplore(req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_parameters request: %w", err)
 	}
@@ -143,7 +137,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("error processing get_parameters response: %w", err)
 	}
 
-	data, err := lookercommon.ExtractLookerFieldProperties(ctx, resp.Fields.Parameters, t.ShowHiddenFields)
+	data, err := lookercommon.ExtractLookerFieldProperties(ctx, resp.Fields.Parameters, source.LookerShowHiddenFields())
 	if err != nil {
 		return nil, fmt.Errorf("error extracting get_parameters response: %w", err)
 	}
@@ -164,14 +158,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
+++ b/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	projectIdParameter := parameters.NewStringParameter("project_id", "The id of the project containing the files")
 	filePathParameter := parameters.NewStringParameter("file_path", "The path of the file within the project")
 	params := parameters.Parameters{projectIdParameter, filePathParameter}
@@ -81,12 +75,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -101,13 +91,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -115,12 +101,21 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -135,7 +130,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("'file_path' must be a string, got %T", mapParams["file_path"])
 	}
 
-	resp, err := lookercommon.GetProjectFileContent(sdk, projectId, filePath, t.ApiSettings)
+	resp, err := lookercommon.GetProjectFileContent(sdk, projectId, filePath, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_project_file request: %s", err)
 	}
@@ -160,14 +155,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
+++ b/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	projectIdParameter := parameters.NewStringParameter("project_id", "The id of the project containing the files")
 	params := parameters.Parameters{projectIdParameter}
 
@@ -80,12 +74,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -100,13 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -114,12 +100,21 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -130,7 +125,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("'project_id' must be a string, got %T", mapParams["project_id"])
 	}
 
-	resp, err := sdk.AllProjectFiles(projectId, "", t.ApiSettings)
+	resp, err := sdk.AllProjectFiles(projectId, "", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_project_files request: %s", err)
 	}
@@ -177,14 +172,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojects/lookergetprojects.go
+++ b/internal/tools/looker/lookergetprojects/lookergetprojects.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,30 +67,14 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := parameters.Parameters{}
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Parameters:          params,
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -99,13 +89,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -113,17 +99,26 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
 
-	resp, err := sdk.AllProjects("id,name", t.ApiSettings)
+	resp, err := sdk.AllProjects("id,name", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making get_models request: %s", err)
 	}
@@ -154,14 +149,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
+++ b/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
@@ -22,7 +22,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -50,6 +49,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string         `yaml:"name" validate:"required"`
 	Kind         string         `yaml:"kind" validate:"required"`
@@ -66,16 +72,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	actionParameter := parameters.NewStringParameterWithRequired("action", "The analysis to run. Can be 'projects', 'models', or 'explores'.", true)
 	projectParameter := parameters.NewStringParameterWithRequired("project", "The Looker project to analyze (optional).", false)
 	modelParameter := parameters.NewStringParameterWithRequired("model", "The Looker model to analyze (optional).", false)
@@ -95,12 +91,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -114,13 +106,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -128,12 +116,21 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -202,12 +199,21 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
-func (t Tool) Authorized(verifiedAuthServices []string) bool {
-	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
 // =================================================================================================================
@@ -557,6 +563,15 @@ func (t *analyzeTool) explores(ctx context.Context, model, explore string) ([]ma
 // END LOOKER HEALTH ANALYZE CORE LOGIC
 // =================================================================================================================
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
+++ b/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
@@ -21,7 +21,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -50,6 +49,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string         `yaml:"name" validate:"required"`
 	Kind         string         `yaml:"kind" validate:"required"`
@@ -66,16 +72,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	actionParameter := parameters.NewStringParameterWithRequired("action", "The health check to run. Can be either: `check_db_connections`, `check_dashboard_performance`,`check_dashboard_errors`,`check_explore_performance`,`check_schedule_failures`, or `check_legacy_features`", true)
 
 	params := parameters.Parameters{
@@ -86,12 +82,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -105,13 +97,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -119,18 +107,27 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
 
 	pulseTool := &pulseTool{
-		ApiSettings: t.ApiSettings,
+		ApiSettings: source.LookerApiSettings(),
 		SdkClient:   sdk,
 	}
 
@@ -144,7 +141,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Action: action,
 	}
 
-	result, err := pulseTool.RunPulse(ctx, pulseParams)
+	result, err := pulseTool.RunPulse(ctx, source, pulseParams)
 	if err != nil {
 		return nil, fmt.Errorf("error running pulse: %w", err)
 	}
@@ -166,12 +163,21 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
-func (t Tool) Authorized(verifiedAuthServices []string) bool {
-	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
 // =================================================================================================================
@@ -192,27 +198,27 @@ type pulseTool struct {
 	SdkClient   *v4.LookerSDK
 }
 
-func (t *pulseTool) RunPulse(ctx context.Context, params PulseParams) (interface{}, error) {
+func (t *pulseTool) RunPulse(ctx context.Context, source compatibleSource, params PulseParams) (interface{}, error) {
 	switch params.Action {
 	case "check_db_connections":
-		return t.checkDBConnections(ctx)
+		return t.checkDBConnections(ctx, source)
 	case "check_dashboard_performance":
-		return t.checkDashboardPerformance(ctx)
+		return t.checkDashboardPerformance(ctx, source)
 	case "check_dashboard_errors":
-		return t.checkDashboardErrors(ctx)
+		return t.checkDashboardErrors(ctx, source)
 	case "check_explore_performance":
-		return t.checkExplorePerformance(ctx)
+		return t.checkExplorePerformance(ctx, source)
 	case "check_schedule_failures":
-		return t.checkScheduleFailures(ctx)
+		return t.checkScheduleFailures(ctx, source)
 	case "check_legacy_features":
-		return t.checkLegacyFeatures(ctx)
+		return t.checkLegacyFeatures(ctx, source)
 	default:
 		return nil, fmt.Errorf("unknown action: %s", params.Action)
 	}
 }
 
 // Check DB connections and run tests
-func (t *pulseTool) checkDBConnections(ctx context.Context) (interface{}, error) {
+func (t *pulseTool) checkDBConnections(ctx context.Context, source compatibleSource) (interface{}, error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -226,7 +232,7 @@ func (t *pulseTool) checkDBConnections(ctx context.Context) (interface{}, error)
 		"looker__ilooker":                      {},
 	}
 
-	connections, err := t.SdkClient.AllConnections("", t.ApiSettings)
+	connections, err := t.SdkClient.AllConnections("", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error fetching connections: %w", err)
 	}
@@ -245,7 +251,7 @@ func (t *pulseTool) checkDBConnections(ctx context.Context) (interface{}, error)
 	for _, conn := range filteredConnections {
 		var errors []string
 		// Test connection (simulate test_connection endpoint)
-		resp, err := t.SdkClient.TestConnection(*conn.Name, nil, t.ApiSettings)
+		resp, err := t.SdkClient.TestConnection(*conn.Name, nil, source.LookerApiSettings())
 		if err != nil {
 			errors = append(errors, "API JSONDecode Error")
 		} else {
@@ -269,7 +275,7 @@ func (t *pulseTool) checkDBConnections(ctx context.Context) (interface{}, error)
 			},
 			Limit: &limit,
 		}
-		raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", t.ApiSettings)
+		raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", source.LookerApiSettings())
 		if err != nil {
 			return nil, err
 		}
@@ -290,7 +296,7 @@ func (t *pulseTool) checkDBConnections(ctx context.Context) (interface{}, error)
 	return results, nil
 }
 
-func (t *pulseTool) checkDashboardPerformance(ctx context.Context) (interface{}, error) {
+func (t *pulseTool) checkDashboardPerformance(ctx context.Context, source compatibleSource) (interface{}, error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -311,7 +317,7 @@ func (t *pulseTool) checkDashboardPerformance(ctx context.Context) (interface{},
 		Sorts: &[]string{"query.count desc"},
 		Limit: &limit,
 	}
-	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", t.ApiSettings)
+	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", source.LookerApiSettings())
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +328,7 @@ func (t *pulseTool) checkDashboardPerformance(ctx context.Context) (interface{},
 	return dashboards, nil
 }
 
-func (t *pulseTool) checkDashboardErrors(ctx context.Context) (interface{}, error) {
+func (t *pulseTool) checkDashboardErrors(ctx context.Context, source compatibleSource) (interface{}, error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -343,7 +349,7 @@ func (t *pulseTool) checkDashboardErrors(ctx context.Context) (interface{}, erro
 		Sorts: &[]string{"history.query_run_count desc"},
 		Limit: &limit,
 	}
-	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", t.ApiSettings)
+	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", source.LookerApiSettings())
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +360,7 @@ func (t *pulseTool) checkDashboardErrors(ctx context.Context) (interface{}, erro
 	return dashboards, nil
 }
 
-func (t *pulseTool) checkExplorePerformance(ctx context.Context) (interface{}, error) {
+func (t *pulseTool) checkExplorePerformance(ctx context.Context, source compatibleSource) (interface{}, error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -373,7 +379,7 @@ func (t *pulseTool) checkExplorePerformance(ctx context.Context) (interface{}, e
 		Sorts: &[]string{"history.average_runtime desc"},
 		Limit: &limit,
 	}
-	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", t.ApiSettings)
+	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", source.LookerApiSettings())
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +390,7 @@ func (t *pulseTool) checkExplorePerformance(ctx context.Context) (interface{}, e
 
 	// Average query runtime
 	query.Fields = &[]string{"history.average_runtime"}
-	rawAvg, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", t.ApiSettings)
+	rawAvg, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", source.LookerApiSettings())
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +405,7 @@ func (t *pulseTool) checkExplorePerformance(ctx context.Context) (interface{}, e
 	return explores, nil
 }
 
-func (t *pulseTool) checkScheduleFailures(ctx context.Context) (interface{}, error) {
+func (t *pulseTool) checkScheduleFailures(ctx context.Context, source compatibleSource) (interface{}, error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -418,7 +424,7 @@ func (t *pulseTool) checkScheduleFailures(ctx context.Context) (interface{}, err
 		Sorts: &[]string{"scheduled_job.count desc"},
 		Limit: &limit,
 	}
-	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", t.ApiSettings)
+	raw, err := lookercommon.RunInlineQuery(ctx, t.SdkClient, query, "json", source.LookerApiSettings())
 	if err != nil {
 		return nil, err
 	}
@@ -429,14 +435,14 @@ func (t *pulseTool) checkScheduleFailures(ctx context.Context) (interface{}, err
 	return schedules, nil
 }
 
-func (t *pulseTool) checkLegacyFeatures(ctx context.Context) (interface{}, error) {
+func (t *pulseTool) checkLegacyFeatures(ctx context.Context, source compatibleSource) (interface{}, error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 	logger.InfoContext(ctx, "Test 6/6: Checking for enabled legacy features")
 
-	features, err := t.SdkClient.AllLegacyFeatures(t.ApiSettings)
+	features, err := t.SdkClient.AllLegacyFeatures(source.LookerApiSettings())
 	if err != nil {
 		if strings.Contains(err.Error(), "Unsupported in Looker (Google Cloud core)") {
 			return []map[string]string{{"Feature": "Unsupported in Looker (Google Cloud core)"}}, nil
@@ -457,6 +463,15 @@ func (t *pulseTool) checkLegacyFeatures(ctx context.Context) (interface{}, error
 // END LOOKER HEALTH PULSE CORE LOGIC
 // =================================================================================================================
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
+++ b/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
@@ -22,7 +22,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -50,6 +49,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string         `yaml:"name" validate:"required"`
 	Kind         string         `yaml:"kind" validate:"required"`
@@ -66,16 +72,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	actionParameter := parameters.NewStringParameterWithRequired("action", "The vacuum action to run. Can be 'models', or 'explores'.", true)
 	projectParameter := parameters.NewStringParameterWithDefault("project", "", "The Looker project to vacuum (optional).")
 	modelParameter := parameters.NewStringParameterWithDefault("model", "", "The Looker model to vacuum (optional).")
@@ -95,12 +91,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -114,13 +106,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -128,7 +116,16 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -180,12 +177,21 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
-func (t Tool) Authorized(verifiedAuthServices []string) bool {
-	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
 // =================================================================================================================
@@ -461,6 +467,15 @@ func (t *vacuumTool) getUsedExploreFields(ctx context.Context, model, explore st
 // END LOOKER HEALTH VACUUM CORE LOGIC
 // =================================================================================================================
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
+++ b/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
@@ -21,7 +21,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -47,6 +46,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -63,18 +69,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := parameters.Parameters{}
 
 	titleParameter := parameters.NewStringParameter("title", "The title of the Dashboard")
@@ -86,12 +80,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -106,13 +96,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -120,18 +106,27 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
 	}
 	logger.DebugContext(ctx, "params = ", params)
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
 	mrespFields := "id,personal_folder_id"
-	mresp, err := sdk.Me(mrespFields, t.ApiSettings)
+	mresp, err := sdk.Me(mrespFields, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making me request: %s", err)
 	}
@@ -144,7 +139,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("user does not have a personal folder. cannot continue")
 	}
 
-	dashs, err := sdk.FolderDashboards(*mresp.PersonalFolderId, "title", t.ApiSettings)
+	dashs, err := sdk.FolderDashboards(*mresp.PersonalFolderId, "title", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error getting existing dashboards in folder: %s", err)
 	}
@@ -163,13 +158,13 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Description: &description,
 		FolderId:    mresp.PersonalFolderId,
 	}
-	resp, err := sdk.CreateDashboard(wd, t.ApiSettings)
+	resp, err := sdk.CreateDashboard(wd, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making create dashboard request: %s", err)
 	}
 	logger.DebugContext(ctx, "resp = %v", resp)
 
-	setting, err := sdk.GetSetting("host_url", t.ApiSettings)
+	setting, err := sdk.GetSetting("host_url", source.LookerApiSettings())
 	if err != nil {
 		logger.ErrorContext(ctx, "error getting settings: %s", err)
 	}
@@ -202,14 +197,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookermakelook/lookermakelook.go
+++ b/internal/tools/looker/lookermakelook/lookermakelook.go
@@ -21,7 +21,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -47,6 +46,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -63,18 +69,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetQueryParameters()
 
 	titleParameter := parameters.NewStringParameter("title", "The title of the Look")
@@ -92,12 +86,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -112,13 +102,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -126,6 +112,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -136,12 +131,12 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, fmt.Errorf("error building query request: %w", err)
 	}
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
 	mrespFields := "id,personal_folder_id"
-	mresp, err := sdk.Me(mrespFields, t.ApiSettings)
+	mresp, err := sdk.Me(mrespFields, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making me request: %s", err)
 	}
@@ -150,7 +145,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	title := paramsMap["title"].(string)
 	description := paramsMap["description"].(string)
 
-	looks, err := sdk.FolderLooks(*mresp.PersonalFolderId, "title", t.ApiSettings)
+	looks, err := sdk.FolderLooks(*mresp.PersonalFolderId, "title", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error getting existing looks in folder: %s", err)
 	}
@@ -168,7 +163,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	wq.VisConfig = &visConfig
 
 	qrespFields := "id"
-	qresp, err := sdk.CreateQuery(*wq, qrespFields, t.ApiSettings)
+	qresp, err := sdk.CreateQuery(*wq, qrespFields, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making create query request: %s", err)
 	}
@@ -180,13 +175,13 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		QueryId:     qresp.Id,
 		FolderId:    mresp.PersonalFolderId,
 	}
-	resp, err := sdk.CreateLook(wlwq, "", t.ApiSettings)
+	resp, err := sdk.CreateLook(wlwq, "", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making create look request: %s", err)
 	}
 	logger.DebugContext(ctx, "resp = %v", resp)
 
-	setting, err := sdk.GetSetting("host_url", t.ApiSettings)
+	setting, err := sdk.GetSetting("host_url", source.LookerApiSettings())
 	if err != nil {
 		logger.ErrorContext(ctx, "error getting settings: %s", err)
 	}
@@ -219,14 +214,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerquery/lookerquery.go
+++ b/internal/tools/looker/lookerquery/lookerquery.go
@@ -20,7 +20,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -46,6 +45,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -62,30 +68,14 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetQueryParameters()
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -100,13 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -114,6 +100,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -122,11 +117,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if err != nil {
 		return nil, fmt.Errorf("error building WriteQuery request: %w", err)
 	}
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
-	resp, err := lookercommon.RunInlineQuery(ctx, sdk, wq, "json", t.ApiSettings)
+	resp, err := lookercommon.RunInlineQuery(ctx, sdk, wq, "json", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making query request: %s", err)
 	}
@@ -156,14 +151,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerquerysql/lookerquerysql.go
+++ b/internal/tools/looker/lookerquerysql/lookerquerysql.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,30 +67,14 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetQueryParameters()
 
 	mcpManifest := tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -99,13 +89,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -113,6 +99,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -121,11 +116,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if err != nil {
 		return nil, fmt.Errorf("error building query request: %w", err)
 	}
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
-	resp, err := lookercommon.RunInlineQuery(ctx, sdk, wq, "sql", t.ApiSettings)
+	resp, err := lookercommon.RunInlineQuery(ctx, sdk, wq, "sql", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making query request: %s", err)
 	}
@@ -146,14 +141,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
+++ b/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -45,6 +44,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,18 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	params := lookercommon.GetQueryParameters()
 
 	vizParameter := parameters.NewMapParameterWithDefault("vis_config",
@@ -86,12 +80,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -106,13 +96,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -120,6 +106,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -134,12 +129,12 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	visConfig := paramsMap["vis_config"].(map[string]any)
 	wq.VisConfig = &visConfig
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
 	respFields := "id,slug,share_url,expanded_share_url"
-	resp, err := sdk.CreateQuery(*wq, respFields, t.ApiSettings)
+	resp, err := sdk.CreateQuery(*wq, respFields, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making query request: %s", err)
 	}
@@ -175,14 +170,32 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
+}
+
 func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
-}
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
+++ b/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
@@ -21,7 +21,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -47,6 +46,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -63,18 +69,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	dashboardidParameter := parameters.NewStringParameter("dashboard_id", "The id of the dashboard to run.")
 
 	params := parameters.Parameters{
@@ -85,12 +79,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -105,13 +95,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -119,6 +105,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -128,11 +123,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	dashboard_id := paramsMap["dashboard_id"].(string)
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
-	dashboard, err := sdk.Dashboard(dashboard_id, "", t.ApiSettings)
+	dashboard, err := sdk.Dashboard(dashboard_id, "", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error getting dashboard: %w", err)
 	}
@@ -148,7 +143,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	channels := make([]<-chan map[string]any, len(*dashboard.DashboardElements))
 	for i, element := range *dashboard.DashboardElements {
-		channels[i] = tileQueryWorker(ctx, sdk, t.ApiSettings, i, element)
+		channels[i] = tileQueryWorker(ctx, sdk, source.LookerApiSettings(), i, element)
 	}
 
 	for resp := range merge(channels...) {
@@ -172,12 +167,21 @@ func (t Tool) McpManifest() tools.McpManifest {
 	return t.mcpManifest
 }
 
-func (t Tool) Authorized(verifiedAuthServices []string) bool {
-	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
 func tileQueryWorker(ctx context.Context, sdk *v4.LookerSDK, options *rtl.ApiSettings, index int, element v4.DashboardElement) <-chan map[string]any {
@@ -269,6 +273,15 @@ func merge(channels ...<-chan map[string]any) <-chan map[string]any {
 	return out
 }
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerrunlook/lookerrunlook.go
+++ b/internal/tools/looker/lookerrunlook/lookerrunlook.go
@@ -20,7 +20,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util"
@@ -46,6 +45,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -62,18 +68,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	lookidParameter := parameters.NewStringParameter("look_id", "The id of the look to run.")
 	limitParameter := parameters.NewIntParameterWithDefault("limit", 500, "The row limit. Default 500")
 
@@ -86,12 +80,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -106,13 +96,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -120,6 +106,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
@@ -131,12 +126,12 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	limit := int64(paramsMap["limit"].(int))
 	limitStr := fmt.Sprintf("%d", limit)
 
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
 
-	look, err := sdk.Look(look_id, "", t.ApiSettings)
+	look, err := sdk.Look(look_id, "", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error getting look definition: %s", err)
 	}
@@ -152,7 +147,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Limit:         &limitStr,
 	}
 
-	resp, err := lookercommon.RunInlineQuery(ctx, sdk, &wq, "json", t.ApiSettings)
+	resp, err := lookercommon.RunInlineQuery(ctx, sdk, &wq, "json", source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making run_look request: %s", err)
 	}
@@ -185,10 +180,28 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
+++ b/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
@@ -19,7 +19,6 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	lookersrc "github.com/googleapis/genai-toolbox/internal/sources/looker"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
@@ -44,6 +43,12 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+}
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -60,18 +65,6 @@ func (cfg Config) ToolConfigKind() string {
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	// verify source exists
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("no source named %q configured", cfg.Source)
-	}
-
-	// verify the source is compatible
-	s, ok := rawS.(*lookersrc.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `looker`", kind)
-	}
-
 	projectIdParameter := parameters.NewStringParameter("project_id", "The id of the project containing the files")
 	filePathParameter := parameters.NewStringParameter("file_path", "The path of the file within the project")
 	fileContentParameter := parameters.NewStringParameter("file_content", "The content of the file")
@@ -81,12 +74,8 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	// finish tool setup
 	return Tool{
-		Config:              cfg,
-		Parameters:          params,
-		UseClientOAuth:      s.UseClientAuthorization(),
-		AuthTokenHeaderName: s.GetAuthTokenHeaderName(),
-		Client:              s.Client,
-		ApiSettings:         s.ApiSettings,
+		Config:     cfg,
+		Parameters: params,
 		manifest: tools.Manifest{
 			Description:  cfg.Description,
 			Parameters:   params.Manifest(),
@@ -101,13 +90,9 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
-	UseClientOAuth      bool
-	AuthTokenHeaderName string
-	Client              *v4.LookerSDK
-	ApiSettings         *rtl.ApiSettings
-	Parameters          parameters.Parameters `yaml:"parameters"`
-	manifest            tools.Manifest
-	mcpManifest         tools.McpManifest
+	Parameters  parameters.Parameters `yaml:"parameters"`
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -115,7 +100,16 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
-	sdk, err := lookercommon.GetLookerSDK(t.UseClientOAuth, t.ApiSettings, t.Client, accessToken)
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
+	sdk, err := lookercommon.GetLookerSDK(source.UseClientAuthorization(), source.LookerApiSettings(), source.LookerClient(), accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("error getting sdk: %w", err)
 	}
@@ -139,7 +133,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		Content: fileContent,
 	}
 
-	err = lookercommon.UpdateProjectFile(sdk, projectId, req, t.ApiSettings)
+	err = lookercommon.UpdateProjectFile(sdk, projectId, req, source.LookerApiSettings())
 	if err != nil {
 		return nil, fmt.Errorf("error making update_project_file request: %s", err)
 	}
@@ -167,10 +161,28 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
-	return t.UseClientOAuth
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return false, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return t.AuthTokenHeaderName
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -84,7 +84,7 @@ type Tool interface {
 	Authorized([]string) bool
 	RequiresClientAuthorization(SourceProvider) (bool, error)
 	ToConfig() ToolConfig
-	GetAuthTokenHeaderName() string
+	GetAuthTokenHeaderName(SourceProvider) (string, error)
 }
 
 // SourceProvider defines the minimal view of the server.ResourceManager


### PR DESCRIPTION
Within Invoke() and RequiresClientAuthorization(), get Source from ResourceManager and use it to call functions directly.