### PR TITLE
chore(tools/serverlessspark): decouple source config from tools

### DIFF
--- a/internal/sources/serverlessspark/serverlessspark.go
+++ b/internal/sources/serverlessspark/serverlessspark.go
@@ -96,6 +96,14 @@ func (s *Source) ToConfig() sources.SourceConfig {
 	return s.Config
 }
 
+func (s *Source) GetProject() string {
+	return s.Project
+}
+
+func (s *Source) GetLocation() string {
+	return s.Location
+}
+
 func (s *Source) GetBatchControllerClient() *dataproc.BatchControllerClient {
 	return s.Client
 }

--- a/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"strings"
 
+	longrunning "cloud.google.com/go/longrunning/autogen"
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	"github.com/googleapis/genai-toolbox/internal/sources/serverlessspark"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 )
@@ -43,6 +43,12 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	GetOperationsClient(context.Context) (*longrunning.OperationsClient, error)
+	GetProject() string
+	GetLocation() string
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -61,16 +67,6 @@ func (cfg Config) ToolConfigKind() string {
 
 // Initialize creates a new Tool instance.
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("source %q not found", cfg.Source)
-	}
-
-	ds, ok := rawS.(*serverlessspark.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `%s`", kind, serverlessspark.SourceKind)
-	}
-
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Cancels a running Serverless Spark (aka Dataproc Serverless) batch operation. Note that the batch state will not change immediately after the tool returns; it can take a minute or so for the cancellation to be reflected."
@@ -89,7 +85,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	return &Tool{
 		Config:      cfg,
-		Source:      ds,
 		manifest:    tools.Manifest{Description: desc, Parameters: allParameters.Manifest()},
 		mcpManifest: mcpManifest,
 		Parameters:  allParameters,
@@ -99,9 +94,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 // Tool is the implementation of the tool.
 type Tool struct {
 	Config
-
-	Source *serverlessspark.Source
-
 	manifest    tools.Manifest
 	mcpManifest tools.McpManifest
 	Parameters  parameters.Parameters
@@ -109,7 +101,16 @@ type Tool struct {
 
 // Invoke executes the tool's operation.
 func (t *Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
-	client, err := t.Source.GetOperationsClient(ctx)
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
+	client, err := source.GetOperationsClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operations client: %w", err)
 	}
@@ -125,7 +126,7 @@ func (t *Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, par
 	}
 
 	req := &longrunningpb.CancelOperationRequest{
-		Name: fmt.Sprintf("projects/%s/locations/%s/operations/%s", t.Source.Project, t.Source.Location, operation),
+		Name: fmt.Sprintf("projects/%s/locations/%s/operations/%s", source.GetProject(), source.GetLocation(), operation),
 	}
 
 	err = client.CancelOperation(ctx, req)
@@ -152,15 +153,15 @@ func (t *Tool) Authorized(services []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, services)
 }
 
-func (t *Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
+func (t *Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
 	// Client OAuth not supported, rely on ADCs.
-	return false
+	return false, nil
 }
 
 func (t *Tool) ToConfig() tools.ToolConfig {
 	return t.Config
 }
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return "Authorization"
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	return "Authorization", nil
 }

--- a/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"strings"
 
+	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"cloud.google.com/go/dataproc/v2/apiv1/dataprocpb"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
-	"github.com/googleapis/genai-toolbox/internal/sources/serverlessspark"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -45,6 +45,12 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 	return actual, nil
 }
 
+type compatibleSource interface {
+	GetBatchControllerClient() *dataproc.BatchControllerClient
+	GetProject() string
+	GetLocation() string
+}
+
 type Config struct {
 	Name         string   `yaml:"name" validate:"required"`
 	Kind         string   `yaml:"kind" validate:"required"`
@@ -63,16 +69,6 @@ func (cfg Config) ToolConfigKind() string {
 
 // Initialize creates a new Tool instance.
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
-	rawS, ok := srcs[cfg.Source]
-	if !ok {
-		return nil, fmt.Errorf("source %q not found", cfg.Source)
-	}
-
-	ds, ok := rawS.(*serverlessspark.Source)
-	if !ok {
-		return nil, fmt.Errorf("invalid source for %q tool: source kind must be `%s`", kind, serverlessspark.SourceKind)
-	}
-
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Gets a Serverless Spark (aka Dataproc Serverless) batch"
@@ -91,7 +87,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 
 	return Tool{
 		Config:      cfg,
-		Source:      ds,
 		manifest:    tools.Manifest{Description: desc, Parameters: allParameters.Manifest()},
 		mcpManifest: mcpManifest,
 		Parameters:  allParameters,
@@ -101,9 +96,6 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 // Tool is the implementation of the tool.
 type Tool struct {
 	Config
-
-	Source *serverlessspark.Source
-
 	manifest    tools.Manifest
 	mcpManifest tools.McpManifest
 	Parameters  parameters.Parameters
@@ -111,7 +103,16 @@ type Tool struct {
 
 // Invoke executes the tool's operation.
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
-	client := t.Source.GetBatchControllerClient()
+	s, ok := resourceMgr.GetSource(t.Source)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve source %s in tool %s", t.Source, t.Name)
+	}
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q not compatible", kind, t.Source)
+	}
+
+	client := source.GetBatchControllerClient()
 
 	paramMap := params.AsMap()
 	name, ok := paramMap["name"].(string)
@@ -124,7 +125,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	req := &dataprocpb.GetBatchRequest{
-		Name: fmt.Sprintf("projects/%s/locations/%s/batches/%s", t.Source.Project, t.Source.Location, name),
+		Name: fmt.Sprintf("projects/%s/locations/%s/batches/%s", source.GetProject(), source.GetLocation(), name),
 	}
 
 	batchPb, err := client.GetBatch(ctx, req)
@@ -161,15 +162,15 @@ func (t Tool) Authorized(services []string) bool {
 	return tools.IsAuthorized(t.AuthRequired, services)
 }
 
-func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) bool {
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
 	// Client OAuth not supported, rely on ADCs.
-	return false
+	return false, nil
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Config
 }
 
-func (t Tool) GetAuthTokenHeaderName() string {
-	return "Authorization"
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	return "Authorization", nil
 }


### PR DESCRIPTION
Within Invoke() and RequiresClientAuthorization(), get Source from ResourceManager and use it to call functions directly.