### PR TITLE
docs: separate Windows installation instructions for Command Prompt and PowerShell

### DIFF
--- a/.hugo/assets/scss/_styles_project.scss
+++ b/.hugo/assets/scss/_styles_project.scss
@@ -1,1 +1,9 @@
 @import 'td/code-dark';
+
+// Make tabs scrollable horizontally instead of wrapping
+.nav-tabs {
+  flex-wrap: nowrap;
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+}

--- a/README.md
+++ b/README.md
@@ -158,14 +158,26 @@ To install Toolbox as a binary:
 >
 > </details>
 > <details>
-> <summary>Windows (AMD64)</summary>
+> <summary>Windows (Command Prompt)</summary>
 >
-> To install Toolbox as a binary on Windows (AMD64):
+> To install Toolbox as a binary on Windows (Command Prompt):
 >
-> ```powershell
+> ```cmd
 > :: see releases page for other versions
 > set VERSION=0.22.0
 > curl -o toolbox.exe "https://storage.googleapis.com/genai-toolbox/v%VERSION%/windows/amd64/toolbox.exe"
+> ```
+>
+> </details>
+> <details>
+> <summary>Windows (PowerShell)</summary>
+>
+> To install Toolbox as a binary on Windows (PowerShell):
+>
+> ```powershell
+> # see releases page for other versions
+> $VERSION = "0.21.0"
+> curl.exe -o toolbox.exe "https://storage.googleapis.com/genai-toolbox/v$VERSION/windows/amd64/toolbox.exe"
 > ```
 >
 > </details>

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -115,13 +115,23 @@ chmod +x toolbox
 ```
 
 {{% /tab %}}
-{{% tab header="Windows (AMD64)" lang="en" %}}
-To install Toolbox as a binary on Windows (AMD64):
+{{% tab header="Windows (Command Prompt)" lang="en" %}}
+To install Toolbox as a binary on Windows (Command Prompt):
 
-```powershell
+```cmd
 :: see releases page for other versions
 set VERSION=0.22.0
 curl -o toolbox.exe "https://storage.googleapis.com/genai-toolbox/v%VERSION%/windows/amd64/toolbox.exe"
+```
+
+{{% /tab %}}
+{{% tab header="Windows (PowerShell)" lang="en" %}}
+To install Toolbox as a binary on Windows (PowerShell):
+
+```powershell
+# see releases page for other versions
+$VERSION = "0.21.0"
+curl.exe -o toolbox.exe "https://storage.googleapis.com/genai-toolbox/v$VERSION/windows/amd64/toolbox.exe"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
## Description
Updates the Windows installation instructions in `README.md` and the Hugo documentation to provide separate, clear steps for Command Prompt and PowerShell.

## Before
<img width="1836" height="1054" alt="image" src="https://github.com/user-attachments/assets/46856ba5-e99f-4ea1-b851-921c1f885c40" />

## After
<img width="1842" height="1046" alt="image" src="https://github.com/user-attachments/assets/80212630-1233-496e-98d2-9039de8e4cd0" />
<img width="1858" height="1070" alt="image" src="https://github.com/user-attachments/assets/348a879d-7337-41c1-8358-fbe341c80525" />
