### PR TITLE
ci(tools/alloydb): remove AlloyDB `alloydb-list-users` test user count comparison

### DIFF
--- a/tests/alloydb/alloydb_integration_test.go
+++ b/tests/alloydb/alloydb_integration_test.go
@@ -580,7 +580,6 @@ func runAlloyDBListUsersTest(t *testing.T, vars map[string]string) {
 	}
 }
 
-
 func runAlloyDBListInstancesTest(t *testing.T, vars map[string]string) {
 	type ListInstancesResponse struct {
 		Instances []struct {


### PR DESCRIPTION
If users are added or removed, this comparison breaks the integration test.