### PR TITLE
ci(postgres): Fix `postgres-list-triggers` flakey integration test

### DIFF
--- a/tests/tool.go
+++ b/tests/tool.go
@@ -1562,14 +1562,14 @@ func RunPostgresListTriggersTest(t *testing.T, ctx context.Context, pool *pgxpoo
 		requestBody    io.Reader
 		wantStatusCode int
 		want           []map[string]any
-		compareSubset bool
+		compareSubset  bool
 	}{
 		{
 			name:           "list all triggers (expecting the one we created)",
 			requestBody:    bytes.NewBuffer([]byte(`{}`)),
 			wantStatusCode: http.StatusOK,
 			want:           []map[string]any{wantTrigger},
-			compareSubset: true, // avoid test flakiness in race condition
+			compareSubset:  true, // avoid test flakiness in race condition
 		},
 		{
 			name:           "filter by trigger_name",


### PR DESCRIPTION
The list trigger test sometimes include extra triggers in the returned result due to parallel test execution. Update the logic to only look for created trigger during the current test session.