### PR TITLE
test(source/postgres): fix list_database_stats integration test

### DIFF
--- a/tests/tool.go
+++ b/tests/tool.go
@@ -2401,10 +2401,10 @@ func RunPostgresListPgSettingsTest(t *testing.T, ctx context.Context, pool *pgxp
 // RunPostgresDatabaseStatsTest tests the database_stats tool by comparing API results
 // against a direct query to the database.
 func RunPostgresListDatabaseStatsTest(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
-	dbName1 := "test_db_stats_1"
-	dbOwner1 := "test_user1"
-	dbName2 := "test_db_stats_2"
-	dbOwner2 := "test_user2"
+	dbName1 := "test_db_stats_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	dbOwner1 := "test_user_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	dbName2 := "test_db_stats_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	dbOwner2 := "test_user_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 
 	cleanup1 := setUpDatabase(t, ctx, pool, dbName1, dbOwner1)
 	defer cleanup1()


### PR DESCRIPTION
## Description

> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

The list_database_stats test is flaky when run in parallel on the same shared instance. It fails with the error: failed to create test_user1: ERROR: role "test_user1" already exists. This test is updates to create a random role and database name to avoid conflicts with other simultaneously running tests.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<1738>
