### PR TITLE
test(source/postgres): fix list_database_stats integration test

### DIFF
--- a/tests/tool.go
+++ b/tests/tool.go
@@ -2452,15 +2452,15 @@ func RunPostgresListDatabaseStatsTest(t *testing.T, ctx context.Context, pool *p
 		},
 		{
 			name:           "filter by tablespace",
-			requestBody:    bytes.NewBuffer([]byte(`{"default_tablespace": "pg_default"}`)),
+			requestBody:    bytes.NewBuffer([]byte(fmt.Sprintf(`{"default_tablespace": "pg_default", "database_name": "%s"}`, dbName1))),
 			wantStatusCode: http.StatusOK,
-			want:           []map[string]interface{}{db1Want, db2Want},
+			want:           []map[string]interface{}{db1Want},
 		},
 		{
-			name:           "sort by size (desc)",
-			requestBody:    bytes.NewBuffer([]byte(`{"sort_by": "size"}`)),
+			name:           "sort by size",
+			requestBody:    bytes.NewBuffer([]byte(fmt.Sprintf(`{"sort_by": "size", "database_name": "%s"}`, dbName2))),
 			wantStatusCode: http.StatusOK,
-			want:           []map[string]interface{}{db1Want, db2Want},
+			want:           []map[string]interface{}{db2Want},
 		},
 	}
 
@@ -2472,7 +2472,6 @@ func RunPostgresListDatabaseStatsTest(t *testing.T, ctx context.Context, pool *p
 			if resp.StatusCode != tc.wantStatusCode {
 				t.Fatalf("wrong status code: got %d, want %d, body: %s", resp.StatusCode, tc.wantStatusCode, string(body))
 			}
-
 			var bodyWrapper struct {
 				Result json.RawMessage `json:"result"`
 			}


### PR DESCRIPTION
## Description
The list_database_stats test fails intermittently when run in parallel on shared instances. Specifically, the "filter by tablespace" and "sort by size" test cases fail because they encounter unexpected databases in the pg_default tablespace created by concurrent test runs.
This PR narrows the scope of these test cases by filtering for specific database names. This ensures assertions remain isolated to the current test run regardless of other databases present in the shared environment.

```
 go test -tags=integration tests/postgres/postgres_integration_test.go
ok      command-line-arguments  14.455s
```

> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change
