### PR TITLE
fix(server): Add `embeddingModel` config initialization

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -947,6 +947,7 @@ func run(cmd *Command) error {
 
 	cmd.cfg.SourceConfigs = finalToolsFile.Sources
 	cmd.cfg.AuthServiceConfigs = finalToolsFile.AuthServices
+	cmd.cfg.EmbeddingModelConfigs = finalToolsFile.EmbeddingModels
 	cmd.cfg.ToolConfigs = finalToolsFile.Tools
 	cmd.cfg.ToolsetConfigs = finalToolsFile.Toolsets
 	cmd.cfg.PromptConfigs = finalToolsFile.Prompts


### PR DESCRIPTION
Embedding Models were only loaded in hot reload because it was not initialized properly.