### PR TITLE
docs: python toolbox-llamaindex sdk doc migration

### DIFF
--- a/docs/en/sdks/python-sdk/llamaindex/index.md
+++ b/docs/en/sdks/python-sdk/llamaindex/index.md
@@ -284,7 +284,7 @@ For Toolbox servers hosted on Google Cloud (e.g., Cloud Run) and requiring
 
 ## Authenticating Tools
 
-{{< notice note >}}
+{{< notice info >}}
 Always use HTTPS to connect your application with the Toolbox service, especially when using tools with authentication configured. Using HTTP exposes your application to serious security risks.
 {{< /notice >}}
 


### PR DESCRIPTION
## Description

Migrating docs from python Sdk to the main docsite for `toolbox-llamaindex`