### PR TITLE
tests: fix tests

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -995,7 +995,8 @@ func TestParseToolFile(t *testing.T) {
 						ToolNames: []string{"example_tool"},
 					},
 				},
-				Prompts: nil,
+				AuthServices: nil,
+				Prompts:      nil,
 			},
 		},
 		{
@@ -1099,7 +1100,7 @@ func TestParseToolFile(t *testing.T) {
 					},
 				},
 				Prompts: server.PromptConfigs{
-					"code_review": custom.Config{
+					"code_review": &custom.Config{
 						Name:        "code_review",
 						Description: "ask llm to analyze code quality",
 						Arguments: prompts.Arguments{
@@ -1192,17 +1193,17 @@ func TestParseToolFileWithAuth(t *testing.T) {
 			database: my_db
 			user: my_user
 			password: my_pass
-			---
+---
 			kind: authServices
 			name: my-google-service
 			type: google
 			clientId: my-client-id
-			---
+---
 			kind: authServices
 			name: other-google-service
 			type: google
 			clientId: other-client-id
-			---
+---
 			kind: tools
 			name: example_tool
 			type: postgres-sql
@@ -1228,7 +1229,7 @@ func TestParseToolFileWithAuth(t *testing.T) {
 						field: email
 					- name: other-google-service
 						field: other_email
-			---
+---
 			kind: toolsets
 			name: example_toolset
 			tools:
@@ -1396,17 +1397,17 @@ func TestParseToolFileWithAuth(t *testing.T) {
 			database: my_db
 			user: my_user
 			password: my_pass
-			---
+---
 			kind: authServices
 			name: my-google-service
 			type: google
 			clientId: my-client-id
-			---
+---
 			kind: authServices
 			name: other-google-service
 			type: google
 			clientId: other-client-id
-			---
+---
 			kind: tools
 			name: example_tool
 			type: postgres-sql
@@ -1434,7 +1435,7 @@ func TestParseToolFileWithAuth(t *testing.T) {
 						field: email
 					- name: other-google-service
 						field: other_email
-			---
+---
 			kind: toolsets
 			name: example_toolset
 			tools:
@@ -1693,17 +1694,17 @@ func TestEnvVarReplacement(t *testing.T) {
 				Authorization: ${TestHeader}
 			queryParams:
 				api-key: ${API_KEY}
-			---
+---
 			kind: authServices
 			name: my-google-service
 			type: google
 			clientId: ${clientId}
-			---
+---
 			kind: authServices
 			name: other-google-service
 			type: google
 			clientId: ${clientId2}
-			---
+---
 			kind: tools
 			name: example_tool
 			type: http
@@ -1744,12 +1745,12 @@ func TestEnvVarReplacement(t *testing.T) {
 				- name: Language
 					type: string
 					description: language string
-			---
+---
 			kind: toolsets
 			name: ${toolset_name}
 			tools:
 				- example_tool
-			---
+---
 			kind: prompts
 			name: ${prompt_name}
 			description: A test prompt for {{.name}}.
@@ -2727,6 +2728,7 @@ description: "Dummy"
 ---
 kind: toolsets
 name: sqlite_database_tools
+tools:
 - dummy_tool
 `
 	toolsetConflictFile := filepath.Join(t.TempDir(), "toolset_conflict.yaml")

--- a/docs/en/getting-started/introduction/_index.md
+++ b/docs/en/getting-started/introduction/_index.md
@@ -16,6 +16,12 @@ Databases” as its initial development predated MCP, but was renamed to align
 with recently added MCP compatibility.
 {{< /notice >}}
 
+{{< notice note >}}
+This document has been updated to support the configuration file v2 format. To
+view documentation with configuration file v1 format, please navigate to the
+top-right menu and select versions v0.26.0 or older.
+{{< /notice >}}
+
 ## Why Toolbox?
 
 Toolbox helps you build Gen AI tools that let your agents access data in your

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -136,12 +136,12 @@ type PromptsetConfigs map[string]prompts.PromptsetConfig
 
 func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, AuthServiceConfigs, EmbeddingModelConfigs, ToolConfigs, ToolsetConfigs, PromptConfigs, error) {
 	// prepare configs map
-	sourceConfigs := make(map[string]sources.SourceConfig)
-	authServiceConfigs := make(AuthServiceConfigs)
-	embeddingModelConfigs := make(EmbeddingModelConfigs)
-	toolConfigs := make(ToolConfigs)
-	toolsetConfigs := make(ToolsetConfigs)
-	promptConfigs := make(PromptConfigs)
+	var sourceConfigs SourceConfigs
+	var authServiceConfigs AuthServiceConfigs
+	var embeddingModelConfigs EmbeddingModelConfigs
+	var toolConfigs ToolConfigs
+	var toolsetConfigs ToolsetConfigs
+	var promptConfigs PromptConfigs
 	// promptset configs is not yet supported
 
 	decoder := yaml.NewDecoder(bytes.NewReader(raw))
@@ -171,11 +171,17 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
 			}
+			if sourceConfigs == nil {
+				sourceConfigs = make(SourceConfigs)
+			}
 			sourceConfigs[name] = c
 		case "authServices":
 			c, err := UnmarshalYAMLAuthServiceConfig(ctx, name, resource)
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+			}
+			if authServiceConfigs == nil {
+				authServiceConfigs = make(AuthServiceConfigs)
 			}
 			authServiceConfigs[name] = c
 		case "tools":
@@ -183,11 +189,17 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
 			}
+			if toolConfigs == nil {
+				toolConfigs = make(ToolConfigs)
+			}
 			toolConfigs[name] = c
 		case "toolsets":
 			c, err := UnmarshalYAMLToolsetConfig(ctx, name, resource)
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+			}
+			if toolsetConfigs == nil {
+				toolsetConfigs = make(ToolsetConfigs)
 			}
 			toolsetConfigs[name] = c
 		case "embeddingModels":
@@ -195,11 +207,17 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
 			}
+			if embeddingModelConfigs == nil {
+				embeddingModelConfigs = make(EmbeddingModelConfigs)
+			}
 			embeddingModelConfigs[name] = c
 		case "prompts":
 			c, err := UnmarshalYAMLPromptConfig(ctx, name, resource)
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+			}
+			if promptConfigs == nil {
+				promptConfigs = make(PromptConfigs)
 			}
 			promptConfigs[name] = c
 		default:
@@ -289,7 +307,7 @@ func UnmarshalYAMLToolConfig(ctx context.Context, name string, r map[string]any)
 
 func UnmarshalYAMLToolsetConfig(ctx context.Context, name string, r map[string]any) (tools.ToolsetConfig, error) {
 	var toolsetConfig tools.ToolsetConfig
-	toolList, ok := r["tools"].([]string)
+	toolList, ok := r["tools"].([]any)
 	if !ok {
 		return toolsetConfig, fmt.Errorf("tools is missing or not a list of strings: %v", r)
 	}

--- a/tests/cloudsql/cloud_sql_get_instances_test.go
+++ b/tests/cloudsql/cloud_sql_get_instances_test.go
@@ -53,7 +53,7 @@ func (t *getInstancesTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 type instance struct {
 	Name string `json:"name"`
-	Type string `json:"type"`
+	Kind string `json:"kind"`
 }
 
 type handler struct {
@@ -95,7 +95,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func TestGetInstancesToolEndpoints(t *testing.T) {
 	h := &handler{
 		instances: map[string]*instance{
-			"instance-1": {Name: "instance-1", Type: "sql#instance"},
+			"instance-1": {Name: "instance-1", Kind: "sql#instance"},
 		},
 		t: t,
 	}
@@ -151,7 +151,7 @@ func TestGetInstancesToolEndpoints(t *testing.T) {
 			name:     "successful get instance",
 			toolName: "get-instance-1",
 			body:     `{"projectId": "p1", "instanceId": "instance-1"}`,
-			want:     `{"name":"instance-1","type":"sql#instance"}`,
+			want:     `{"name":"instance-1","kind":"sql#instance"}`,
 		},
 		{
 			name:        "failed get instance",


### PR DESCRIPTION
Fix previously failing test. During unmarshal, if the resources is not presented, return nil instead of empty struct.

Also added a note in docs to view the configuration file v1 version.