### PR TITLE
ci: add oceanbase link to lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -39,7 +39,7 @@ https://dev.mysql.com/doc/refman/8.4/en/user-names.html
 # npmjs links can occasionally trigger rate limiting during high-frequency CI builds
 https://www.npmjs.com/package/@toolbox-sdk/core
 https://www.npmjs.com/package/@toolbox-sdk/adk
-
+https://www.oceanbase.com/
 
 # Ignore social media and blog profiles to reduce external request overhead
 https://medium.com/@mcp_toolbox


### PR DESCRIPTION
oceanbase's link is hitting `Rejected status code (this depends on your "accept" configuration): Too Many Requests` error. It might have temporarily blocked Lychee due to the too many request being sent in a short time. Adding the link to lycheeignore to unblock GHA failure.