### PR TITLE
feat(tools/looker): Enable searching permission sets in Looker

### DIFF
--- a/cmd/internal/imports.go
+++ b/cmd/internal/imports.go
@@ -138,6 +138,7 @@ import (
 	_ "github.com/googleapis/genai-toolbox/internal/tools/looker/lookerqueryurl"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/looker/lookerrundashboard"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/looker/lookerrunlook"
+	_ "github.com/googleapis/genai-toolbox/internal/tools/looker/lookersearchpermissionsets"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/looker/lookerupdateprojectfile"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/looker/lookervalidateproject"
 	_ "github.com/googleapis/genai-toolbox/internal/tools/mindsdb/mindsdbexecutesql"

--- a/cmd/internal/tools_file_test.go
+++ b/cmd/internal/tools_file_test.go
@@ -1478,6 +1478,7 @@ func TestPrebuiltTools(t *testing.T) {
 	mysql_config, _ := prebuiltconfigs.Get("mysql")
 	mssql_config, _ := prebuiltconfigs.Get("mssql")
 	looker_config, _ := prebuiltconfigs.Get("looker")
+	lookeradmin_config, _ := prebuiltconfigs.Get("looker-admin")
 	lookerca_config, _ := prebuiltconfigs.Get("looker-conversational-analytics")
 	postgresconfig, _ := prebuiltconfigs.Get("postgres")
 	spanner_config, _ := prebuiltconfigs.Get("spanner")
@@ -1779,6 +1780,16 @@ func TestPrebuiltTools(t *testing.T) {
 				"looker_tools": tools.ToolsetConfig{
 					Name:      "looker_tools",
 					ToolNames: []string{"get_models", "get_explores", "get_dimensions", "get_measures", "get_filters", "get_parameters", "query", "query_sql", "query_url", "get_looks", "run_look", "make_look", "get_dashboards", "run_dashboard", "make_dashboard", "add_dashboard_element", "add_dashboard_filter", "generate_embed_url", "health_pulse", "health_analyze", "health_vacuum", "dev_mode", "get_projects", "get_project_files", "get_project_file", "create_project_file", "update_project_file", "delete_project_file", "get_project_directories", "create_project_directory", "delete_project_directory", "validate_project", "get_connections", "get_connection_schemas", "get_connection_databases", "get_connection_tables", "get_connection_table_columns"},
+				},
+			},
+		},
+		{
+			name: "looker-admin prebuilt tools",
+			in:   lookeradmin_config,
+			wantToolset: server.ToolsetConfigs{
+				"looker_admin_tools": tools.ToolsetConfig{
+					Name:      "looker_admin_tools",
+					ToolNames: []string{"search_permission_sets"},
 				},
 			},
 		},

--- a/docs/en/resources/tools/looker/looker-search-permission-sets.md
+++ b/docs/en/resources/tools/looker/looker-search-permission-sets.md
@@ -1,0 +1,50 @@
+---
+title: "looker-search-permission-sets"
+type: docs
+weight: 1
+description: >
+  A "looker-search-permission-sets" tool searches for permission sets in the Looker instance.
+aliases:
+- /resources/tools/looker-search-permission-sets
+---
+
+## About
+
+A `looker-search-permission-sets` tool searches for permission sets in the Looker instance. Permission sets define what actions a user or group can perform.
+
+It's compatible with the following sources:
+
+- [looker](../../sources/looker.md)
+
+`looker-search-permission-sets` accepts the following parameters:
+- `name` (optional): The name of the permission set.
+- `id` (optional): The unique id of the permission set.
+- `limit` (optional): The number of results to return.
+- `offset` (optional): The number of results to skip before returning.
+
+## Example
+
+```yaml
+tools:
+    search_permission_sets:
+        kind: looker-search-permission-sets
+        source: looker-source
+        description: |
+          This tool searches for permission sets in the Looker instance.
+          Permission sets define what actions a user or group can perform.
+          The output includes details like the permission set's `id`, `name`, `permissions`, and `all_access`.
+          Parameters:
+          - name (optional): The name of the permission set.
+          - id (optional): The unique id of the permission set.
+          - limit (optional): The number of results to return.
+          - offset (optional): The number of results to skip before returning.
+          Output:
+          A JSON array of objects, where each object represents a permission set and contains details
+          such as `id`, `name`, `permissions` (list of permission strings), and `all_access` (boolean).
+```
+## Reference
+| **field**   | **type** | **required** | **description**                                    |
+|-------------|:--------:|:------------:|----------------------------------------------------|
+| kind        |  string  |     true     | Must be "looker-search-permission-sets".           |
+| source      |  string  |     true     | Name of the source Looker instance.                |
+| description |  string  |     true     | Description of the tool that is passed to the LLM. |

--- a/internal/prebuiltconfigs/prebuiltconfigs_test.go
+++ b/internal/prebuiltconfigs/prebuiltconfigs_test.go
@@ -40,6 +40,7 @@ var expectedToolSources = []string{
 	"dataplex",
 	"elasticsearch",
 	"firestore",
+	"looker-admin",
 	"looker-conversational-analytics",
 	"looker",
 	"mindsdb",
@@ -118,6 +119,7 @@ func TestGetPrebuiltTool(t *testing.T) {
 	dataplex_config := getOrFatal(t, "dataplex")
 	firestoreconfig := getOrFatal(t, "firestore")
 	looker_config := getOrFatal(t, "looker")
+	looker_admin_config := getOrFatal(t, "looker-admin")
 	lookerca_config := getOrFatal(t, "looker-conversational-analytics")
 	mysql_config := getOrFatal(t, "mysql")
 	mssql_config := getOrFatal(t, "mssql")
@@ -184,6 +186,9 @@ func TestGetPrebuiltTool(t *testing.T) {
 	}
 	if len(looker_config) <= 0 {
 		t.Fatalf("unexpected error: could not fetch looker prebuilt tools yaml")
+	}
+	if len(looker_admin_config) <= 0 {
+		t.Fatalf("unexpected error: could not fetch looker-admin prebuilt tools yaml")
 	}
 	if len(lookerca_config) <= 0 {
 		t.Fatalf("unexpected error: could not fetch looker-conversational-analytics prebuilt tools yaml")

--- a/internal/prebuiltconfigs/tools/looker-admin.yaml
+++ b/internal/prebuiltconfigs/tools/looker-admin.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sources:
+    looker-source:
+        kind: looker
+        base_url: ${LOOKER_BASE_URL}
+        client_id: ${LOOKER_CLIENT_ID:}
+        client_secret: ${LOOKER_CLIENT_SECRET:}
+        verify_ssl: ${LOOKER_VERIFY_SSL:true}
+        timeout: 600s
+        use_client_oauth: ${LOOKER_USE_CLIENT_OAUTH:false}
+        show_hidden_models: ${LOOKER_SHOW_HIDDEN_MODELS:true}
+        show_hidden_explores: ${LOOKER_SHOW_HIDDEN_EXPLORES:true}
+        show_hidden_fields: ${LOOKER_SHOW_HIDDEN_FIELDS:true}
+
+tools:
+    search_permission_sets:
+        type: looker-search-permission-sets
+        source: looker-source
+        description: |
+          This tool searches for permission sets in the Looker instance.
+          Permission sets define what actions a user or group can perform.
+          The output includes details like the permission set's `id`, `name`, `permissions`, and `all_access`.
+          Parameters:
+          - name (optional): The name of the permission set.
+          - id (optional): The unique id of the permission set.
+          - limit (optional): The number of results to return.
+          - offset (optional): The number of results to skip before returning.
+          Output:
+          A JSON array of objects, where each object represents a permission set and contains details
+          such as `id`, `name`, `permissions` (list of permission strings) and `all_access` (boolean).
+
+toolsets:
+    looker_admin_tools:
+        - search_permission_sets

--- a/internal/prebuiltconfigs/tools/looker-admin.yaml
+++ b/internal/prebuiltconfigs/tools/looker-admin.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 sources:
-    looker-source:
+    looker-admin-source:
         kind: looker
         base_url: ${LOOKER_BASE_URL}
         client_id: ${LOOKER_CLIENT_ID:}
@@ -28,7 +28,7 @@ sources:
 tools:
     search_permission_sets:
         type: looker-search-permission-sets
-        source: looker-source
+        source: looker-admin-source
         description: |
           This tool searches for permission sets in the Looker instance.
           Permission sets define what actions a user or group can perform.

--- a/internal/tools/looker/lookersearchpermissionsets/lookersearchpermissionsets.go
+++ b/internal/tools/looker/lookersearchpermissionsets/lookersearchpermissionsets.go
@@ -1,0 +1,225 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lookersearchpermissionsets
+
+import (
+	"context"
+	"fmt"
+
+	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/googleapis/genai-toolbox/internal/util"
+	"github.com/googleapis/genai-toolbox/internal/util/parameters"
+	"github.com/looker-open-source/sdk-codegen/go/rtl"
+	v4 "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
+)
+
+const (
+	kind = "looker-search-permission-sets"
+)
+
+func init() {
+	if !tools.Register(kind, newConfig) {
+		panic(fmt.Sprintf("tool kind %q already registered", kind))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+type compatibleSource interface {
+	UseClientAuthorization() bool
+	GetAuthTokenHeaderName() string
+	LookerClient() *v4.LookerSDK
+	LookerApiSettings() *rtl.ApiSettings
+	GetLookerSDK(string) (*v4.LookerSDK, error)
+}
+
+type Config struct {
+	Name         string                 `yaml:"name" validate:"required"`
+	Type         string                 `yaml:"type" validate:"required"`
+	Source       string                 `yaml:"source" validate:"required"`
+	Description  string                 `yaml:"description" validate:"required"`
+	AuthRequired []string               `yaml:"authRequired"`
+	Annotations  *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigType() string {
+	return kind
+}
+
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	params := parameters.Parameters{
+		parameters.NewStringParameterWithRequired("name", "The name of the permission set.", false),
+		parameters.NewIntParameterWithRequired("id", "The unique id of the permission set.", false),
+		parameters.NewIntParameterWithDefault("limit", 100, "The number of permission sets to fetch. Default is 100"),
+		parameters.NewIntParameterWithDefault("offset", 0, "The number of permission sets to skip before fetching. Default 0"),
+	}
+
+	annotations := cfg.Annotations
+	if annotations == nil {
+		readOnlyHint := true
+		annotations = &tools.ToolAnnotations{
+			ReadOnlyHint: &readOnlyHint,
+		}
+	}
+
+	return Tool{
+		Config:     cfg,
+		Parameters: params,
+		manifest: tools.Manifest{
+			Description:  cfg.Description,
+			Parameters:   params.Manifest(),
+			AuthRequired: cfg.AuthRequired,
+		},
+		mcpManifest: tools.GetMcpManifest(cfg.Name, cfg.Description, cfg.AuthRequired, params, annotations),
+	}, nil
+}
+
+// validate interface
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	Config
+	Parameters  parameters.Parameters
+	manifest    tools.Manifest
+	mcpManifest tools.McpManifest
+}
+
+func (t Tool) ToConfig() tools.ToolConfig {
+	return t.Config
+}
+
+func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Source, t.Name, t.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	logger, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
+	}
+
+	paramsMap := params.AsMap()
+
+	var namePtr *string
+	if name, ok := paramsMap["name"].(string); ok && name != "" {
+		namePtr = &name
+	}
+
+	var idPtr *string
+	if id, ok := paramsMap["id"].(int); ok {
+		idStr := fmt.Sprintf("%d", id)
+		idPtr = &idStr
+	}
+
+	var limitPtr *int64
+	if limit, ok := paramsMap["limit"].(int); ok {
+		limit64 := int64(limit)
+		limitPtr = &limit64
+	}
+
+	var offsetPtr *int64
+	if offset, ok := paramsMap["offset"].(int); ok {
+		offset64 := int64(offset)
+		offsetPtr = &offset64
+	}
+
+	sdk, err := source.GetLookerSDK(string(accessToken))
+	if err != nil {
+		return nil, fmt.Errorf("error getting sdk: %w", err)
+	}
+
+	req := v4.RequestSearchPermissionSets{
+		Name:   namePtr,
+		Id:     idPtr,
+		Limit:  limitPtr,
+		Offset: offsetPtr,
+	}
+
+	resp, err := sdk.SearchPermissionSets(req, source.LookerApiSettings())
+	if err != nil {
+		return nil, fmt.Errorf("error searching permission sets: %w", err)
+	}
+
+	var data []map[string]any
+	for _, v := range resp {
+		vMap := make(map[string]any)
+		if v.Id != nil {
+			vMap["id"] = *v.Id
+		}
+		if v.Name != nil {
+			vMap["name"] = *v.Name
+		}
+		if v.Permissions != nil {
+			vMap["permissions"] = *v.Permissions
+		}
+		if v.AllAccess != nil {
+			vMap["all_access"] = *v.AllAccess
+		}
+		logger.DebugContext(ctx, "Converted to %v\n", vMap)
+		data = append(data, vMap)
+	}
+	logger.DebugContext(ctx, "data = ", data)
+
+	return data, nil
+}
+
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.Parameters, paramValues, embeddingModelsMap, nil)
+}
+
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+func (t Tool) McpManifest() tools.McpManifest {
+	return t.mcpManifest
+}
+
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+}
+
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Source, t.Name, t.Type)
+	if err != nil {
+		return false, err
+	}
+	return source.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Source, t.Name, t.Type)
+	if err != nil {
+		return "", err
+	}
+	return source.GetAuthTokenHeaderName(), nil
+}
+
+func (t Tool) GetParameters() parameters.Parameters {
+	return t.Parameters
+}

--- a/internal/tools/looker/lookersearchpermissionsets/lookersearchpermissionsets.go
+++ b/internal/tools/looker/lookersearchpermissionsets/lookersearchpermissionsets.go
@@ -17,6 +17,7 @@ package lookersearchpermissionsets
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
@@ -29,12 +30,12 @@ import (
 )
 
 const (
-	kind = "looker-search-permission-sets"
+	resourceType = "looker-search-permission-sets"
 )
 
 func init() {
-	if !tools.Register(kind, newConfig) {
-		panic(fmt.Sprintf("tool kind %q already registered", kind))
+	if !tools.Register(resourceType, newConfig) {
+		panic(fmt.Sprintf("tool type %q already registered", resourceType))
 	}
 }
 
@@ -67,7 +68,7 @@ type Config struct {
 var _ tools.ToolConfig = Config{}
 
 func (cfg Config) ToolConfigType() string {
-	return kind
+	return resourceType
 }
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
@@ -112,15 +113,15 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Config
 }
 
-func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, error) {
+func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Source, t.Name, t.Type)
 	if err != nil {
-		return nil, err
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
 	}
 
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
+		return nil, util.NewClientServerError(fmt.Sprintf("unable to get logger from ctx: %s", err), http.StatusInternalServerError, err)
 	}
 
 	paramsMap := params.AsMap()
@@ -150,7 +151,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	sdk, err := source.GetLookerSDK(string(accessToken))
 	if err != nil {
-		return nil, fmt.Errorf("error getting sdk: %w", err)
+		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
 	}
 
 	req := v4.RequestSearchPermissionSets{
@@ -162,7 +163,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.SearchPermissionSets(req, source.LookerApiSettings())
 	if err != nil {
-		return nil, fmt.Errorf("error searching permission sets: %w", err)
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	var data []map[string]any

--- a/internal/tools/looker/lookersearchpermissionsets/lookersearchpermissionsets_test.go
+++ b/internal/tools/looker/lookersearchpermissionsets/lookersearchpermissionsets_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lookersearchpermissionsets_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	lkr "github.com/googleapis/genai-toolbox/internal/tools/looker/lookersearchpermissionsets"
+)
+
+func TestParseFromYamlLookerSearchPermissionSets(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+				kind: tools
+				name: example_tool
+				type: looker-search-permission-sets
+				source: my-instance
+				description: some description
+			`,
+			want: server.ToolConfigs{
+				"example_tool": lkr.Config{
+					Name:         "example_tool",
+					Type:         "looker-search-permission-sets",
+					Source:       "my-instance",
+					Description:  "some description",
+					AuthRequired: []string{},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Parse contents
+			_, _, _, got, _, _, err := server.UnmarshalResourceConfig(ctx, testutils.FormatYaml(tc.in))
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+
+}
+
+func TestFailParseFromYamlLookerSearchPermissionSets(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		err  string
+	}{
+		{
+			desc: "Invalid method",
+			in: `
+				kind: tools
+				name: example_tool
+				type: looker-search-permission-sets
+				source: my-instance
+				method: GOT
+				description: some description
+			`,
+			err: "error unmarshaling tools: unable to parse tool \"example_tool\" as type \"looker-search-permission-sets\": [3:1] unknown field \"method\"\n   1 | authRequired: []\n   2 | description: some description\n>  3 | method: GOT\n       ^\n   4 | name: example_tool\n   5 | source: my-instance\n   6 | type: looker-search-permission-sets",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Parse contents
+			_, _, _, _, _, _, err := server.UnmarshalResourceConfig(ctx, testutils.FormatYaml(tc.in))
+			if err == nil {
+				t.Fatalf("expect parsing to fail")
+			}
+			errStr := err.Error()
+			if !strings.Contains(errStr, tc.err) {
+				t.Fatalf("unexpected error string: got %q, want substring %q", errStr, tc.err)
+			}
+		})
+	}
+
+}

--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -272,6 +272,11 @@ func TestLooker(t *testing.T) {
 				"source":      "my-instance",
 				"description": "Simple tool to test end to end functionality.",
 			},
+			"search_permission_sets": map[string]any{
+				"type":        "looker-search-permission-sets",
+				"source":      "my-instance",
+				"description": "Simple tool to test end to end functionality.",
+			},
 		},
 	}
 
@@ -1799,6 +1804,9 @@ func TestLooker(t *testing.T) {
 
 	wantResult = "/login/embed?t=" // testing for specific substring, since url is dynamic
 	tests.RunToolInvokeParametersTest(t, "generate_embed_url", []byte(`{"type": "dashboards", "id": "1"}`), wantResult)
+
+	wantResult = "Admin"
+	tests.RunToolInvokeParametersTest(t, "search_permission_sets", []byte(`{"name": "Admin"}`), wantResult)
 
 	runConversationalAnalytics(t, "system__activity", "content_usage")
 


### PR DESCRIPTION

## Description

The search_permission_set tool will search for permission sets based on the name and return the full set of permission sets. It enables the agent to answer questions like "search permission sets which contain Viewer in the name".

