### PR TITLE
docs: migration of tbadk package samples from go sdk

### DIFF
--- a/docs/en/sdks/go-sdk/tbadk/_index.md
+++ b/docs/en/sdks/go-sdk/tbadk/_index.md
@@ -1,13 +1,13 @@
 ---
-title: "tbADK Package"
-linkTitle: "tbADK"
+title: "ADK Package"
+linkTitle: "ADK"
 type: docs
 weight: 1
 ---
 
 ![MCP Toolbox Logo](https://raw.githubusercontent.com/googleapis/genai-toolbox/main/logo.png)
 
-# MCP Toolbox tbadk SDK
+# MCP Toolbox For Go ADK SDK
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
@@ -19,52 +19,6 @@ applications.
 This simplifies integrating external functionalities (like APIs, databases, or
 custom logic) managed by the Toolbox into your workflows, especially those
 involving Large Language Models (LLMs).
-
-<!-- TOC ignore:true -->
-<!-- TOC -->
-
-- [MCP Toolbox tbadk SDK](#mcp-toolbox-tbadk-sdk)
-  - [Installation](#installation)
-  - [Quickstart](#quickstart)
-  - [Usage](#usage)
-  - [Transport Protocols](#transport-protocols)
-    - [Supported Protocols](#supported-protocols)
-    - [Example](#example)
-  - [Loading Tools](#loading-tools)
-    - [Load a toolset](#load-a-toolset)
-    - [Load a single tool](#load-a-single-tool)
-  - [Invoking Tools](#invoking-tools)
-  - [Client to Server Authentication](#client-to-server-authentication)
-    - [When is Client-to-Server Authentication Needed?](#when-is-client-to-server-authentication-needed)
-    - [How it works](#how-it-works)
-    - [Configuration](#configuration)
-    - [Authenticating with Google Cloud Servers](#authenticating-with-google-cloud-servers)
-    - [Step by Step Guide for Cloud Run](#step-by-step-guide-for-cloud-run)
-  - [Authenticating Tools](#authenticating-tools)
-    - [When is Authentication Needed?](#when-is-authentication-needed)
-    - [Supported Authentication Mechanisms](#supported-authentication-mechanisms)
-    - [Step 1: Configure Tools in Toolbox Service](#step-1-configure-tools-in-toolbox-service)
-    - [Step 2: Configure SDK Client](#step-2-configure-sdk-client)
-      - [Provide an ID Token Retriever Function](#provide-an-id-token-retriever-function)
-      - [Option A: Add Default Authentication to a Client](#option-a-add-default-authentication-to-a-client)
-      - [Option B: Add Authentication to a Loaded Tool](#option-b-add-authentication-to-a-loaded-tool)
-      - [Option C: Add Authentication While Loading Tools](#option-c-add-authentication-while-loading-tools)
-    - [Complete Authentication Example](#complete-authentication-example)
-  - [Binding Parameter Values](#binding-parameter-values)
-    - [Why Bind Parameters?](#why-bind-parameters)
-      - [Option A: Add Default Bound Parameters to a Client](#option-a-add-default-bound-parameters-to-a-client)
-    - [Option B: Binding Parameters to a Loaded Tool](#option-b-binding-parameters-to-a-loaded-tool)
-    - [Option C: Binding Parameters While Loading Tools](#option-c-binding-parameters-while-loading-tools)
-    - [Binding Dynamic Values](#binding-dynamic-values)
-  - [Using with ADK Go](#using-with-adk-go)
-    - [For a single tool](#for-a-single-tool)
-    - [For a toolset](#for-a-toolset)
-- [Contributing](#contributing)
-- [License](#license)
-- [Support](#support)
-- [Samples for Reference](#samples-for-reference)
-
-<!-- /TOC -->
 
 ## Installation
 
@@ -612,25 +566,9 @@ llmagent, err := llmagent.New(llmagent.Config{
 
 The reason we have to type assert it before passing it to ADK Go, is because it requires a generic `tool.Tool` interface. You can always convert it back to `ToolboxTool` format to access the specialized  methods.
 
-To see how the MCP Toolbox Go SDK works with ADK Go, check out the end-to-end example in the [/samples/](https://github.com/googleapis/mcp-toolbox-sdk-go/tree/main/tbadk/samples) folder.
+# Using with Orchestration Frameworks
 
-# Contributing
-
-Contributions are welcome! Please refer to the [DEVELOPER.md](/DEVELOPER.md)
-file for guidelines on how to set up a development environment and run tests.
-
-# License
-
-This project is licensed under the Apache License 2.0. See the
-[LICENSE](https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/LICENSE) file for details.
-
-# Support
-
-If you encounter issues or have questions, check the existing [GitHub Issues](https://github.com/googleapis/genai-toolbox/issues) for the main Toolbox project.
-
-# Samples for Reference
-
-These samples demonstrate how to integrate the MCP Toolbox Go tbADK SDK with popular orchestration frameworks.
+To see how the MCP Toolbox Go SDK works with orchestration frameworks, check out these end-to-end examples given below.
 
 <details>
 <summary>ADK Go</summary>


### PR DESCRIPTION
This PR migrates the Go SDK documentation and tbadk technical samples from the [mcp-toolbox-sdk-go] repository to the main genai-toolbox documentation site. This consolidation ensures that conceptual guides, package overviews, and interactive code examples are available in a centralized "one-stop-shop".