### PR TITLE
docs: migration of tbgenkit package samples from go sdk

### DIFF
--- a/docs/en/sdks/go-sdk/tbgenkit/_index.md
+++ b/docs/en/sdks/go-sdk/tbgenkit/_index.md
@@ -29,7 +29,7 @@ This SDK is supported on Go version 1.24.4 and higher.
 
 ## Quickstart
 
-For more information on how to load a ToolboxTool, see [the core package](https://github.com/googleapis/mcp-toolbox-sdk-go/tree/main/core)
+For more information on how to load a `ToolboxTool`, see [the core package](https://github.com/googleapis/mcp-toolbox-sdk-go/tree/main/core)
 
 ## Convert Toolbox Tool to a Genkit Tool
 


### PR DESCRIPTION
This PR migrates the Go SDK documentation and tbGenkit technical samples from the [mcp-toolbox-sdk-go] repository to the main genai-toolbox documentation site. This consolidation ensures that conceptual guides, package overviews, and interactive code examples are available in a centralized "one-stop-shop".