### PR TITLE
oracle: support proxy usernames with brackets in go-ora DSN

### DIFF
--- a/internal/sources/oracle/oracle.go
+++ b/internal/sources/oracle/oracle.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -247,8 +248,6 @@ func initOracleConnection(ctx context.Context, tracer trace.Tracer, config Confi
 		panic(err)
 	}
 
-	hasWallet := strings.TrimSpace(config.WalletLocation) != ""
-
 	if config.TnsAdmin != "" {
 		originalTnsAdmin := os.Getenv("TNS_ADMIN")
 		os.Setenv("TNS_ADMIN", config.TnsAdmin)
@@ -288,19 +287,8 @@ func initOracleConnection(ctx context.Context, tracer trace.Tracer, config Confi
 	} else {
 		// Use go-ora driver (pure Go)
 		driverName = "oracle"
-
-		user := config.User
-		password := config.Password
-
-		if hasWallet {
-			finalConnStr = fmt.Sprintf("oracle://%s:%s@%s?ssl=true&wallet=%s",
-				user, password, connectStringBase, config.WalletLocation)
-		} else {
-			// Standard go-ora connection
-			finalConnStr = fmt.Sprintf("oracle://%s:%s@%s",
-				config.User, config.Password, connectStringBase)
-			logger.DebugContext(ctx, fmt.Sprintf("Using go-ora driver (pure-Go) with serverString: %s\n", connectStringBase))
-		}
+		finalConnStr = buildGoOraConnectionString(config.User, config.Password, connectStringBase, config.WalletLocation)
+		logger.DebugContext(ctx, fmt.Sprintf("Using go-ora driver (pure-Go) with serverString: %s\n", connectStringBase))
 	}
 
 	db, err := sql.Open(driverName, finalConnStr)
@@ -309,4 +297,17 @@ func initOracleConnection(ctx context.Context, tracer trace.Tracer, config Confi
 	}
 
 	return db, nil
+}
+
+func buildGoOraConnectionString(user, password, connectStringBase, walletLocation string) string {
+	userInfo := url.UserPassword(user, password).String()
+
+	if strings.TrimSpace(walletLocation) == "" {
+		return fmt.Sprintf("oracle://%s@%s", userInfo, connectStringBase)
+	}
+
+	query := url.Values{}
+	query.Set("ssl", "true")
+	query.Set("wallet", walletLocation)
+	return fmt.Sprintf("oracle://%s@%s?%s", userInfo, connectStringBase, query.Encode())
 }

--- a/internal/sources/oracle/oracle_conn_test.go
+++ b/internal/sources/oracle/oracle_conn_test.go
@@ -1,0 +1,50 @@
+// Copyright © 2026, Oracle and/or its affiliates.
+
+package oracle
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestBuildGoOraConnectionString_EncodesProxyUsername(t *testing.T) {
+	dsn := buildGoOraConnectionString("app[user]", "p@ss", "dbhost:1521/XEPDB1", "")
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse generated DSN: %v", err)
+	}
+
+	if got, want := parsed.User.Username(), "app[user]"; got != want {
+		t.Fatalf("unexpected username: got %q, want %q", got, want)
+	}
+	password, ok := parsed.User.Password()
+	if !ok {
+		t.Fatalf("expected password in generated DSN")
+	}
+	if got, want := password, "p@ss"; got != want {
+		t.Fatalf("unexpected password: got %q, want %q", got, want)
+	}
+	if got, want := parsed.Host, "dbhost:1521"; got != want {
+		t.Fatalf("unexpected host: got %q, want %q", got, want)
+	}
+	if got, want := parsed.Path, "/XEPDB1"; got != want {
+		t.Fatalf("unexpected path: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildGoOraConnectionString_WithWalletOptions(t *testing.T) {
+	dsn := buildGoOraConnectionString("app[user]", "pass", "dbhost:1521/XEPDB1", "/path with space/wallet")
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse generated DSN: %v", err)
+	}
+
+	if got, want := parsed.Query().Get("ssl"), "true"; got != want {
+		t.Fatalf("unexpected ssl query param: got %q, want %q", got, want)
+	}
+	if got, want := parsed.Query().Get("wallet"), "/path with space/wallet"; got != want {
+		t.Fatalf("unexpected wallet query param: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Fixes URL construction for the pure Go Oracle driver (`useOCI: false`) so usernames like `user[client]` work correctly.

What changed:
- Build go-ora DSN using `url.UserPassword(...).String()` for proper credential escaping
- Keep existing connection behavior for host/port/service, connectionString, and tnsAlias
- Use `url.Values` to build wallet query params
- Add unit tests to verify bracket usernames and wallet query handling

Tests run:
`go test -v ./internal/sources/oracle -count=1 -vet=off`

Fixes #2454