### PR TITLE
refactor: remove explicit Protocol import and argument from ToolboxClient initialization example in deployment documentation

### DIFF
--- a/docs/en/how-to/deploy_toolbox.md
+++ b/docs/en/how-to/deploy_toolbox.md
@@ -207,7 +207,6 @@ You can connect to Toolbox Cloud Run instances directly through the SDK.
 {{< tab header="Python" lang="python" >}}
 import asyncio
 from toolbox_core import ToolboxClient, auth_methods
-from toolbox_core.protocol import Protocol
 
 # Replace with the Cloud Run service URL generated in the previous step
 URL = "https://cloud-run-url.app"
@@ -218,7 +217,6 @@ async def main():
   async with ToolboxClient(
       URL,
       client_headers={"Authorization": auth_token_provider},
-      protocol=Protocol.TOOLBOX,
   ) as toolbox:
     toolset = await toolbox.load_toolset()
     # ...


### PR DESCRIPTION
We now use `Protocol.MCP` as default and would be deprecating `Protocol.TOOLBOX` going forward. This PR makes the guide simpler and more future-proof by removing passing `Protocol.TOOLBOX`.
