### PR TITLE
chore: resolve golangci-lint QF1012

### DIFF
--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -107,15 +107,15 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 				return nil, fmt.Errorf("expected allowedDataset to have at least 2 parts (project.dataset): %s", datasetFQN)
 			}
 			datasetID := parts[1]
-			sqlDescriptionBuilder.WriteString(fmt.Sprintf(" The query must only access the `%s` dataset. "+
+			fmt.Fprintf(&sqlDescriptionBuilder, " The query must only access the `%s` dataset. "+
 				"To query a table within this dataset (e.g., `my_table`), "+
-				"qualify it with the dataset id (e.g., `%s.my_table`).", datasetFQN, datasetID))
+				"qualify it with the dataset id (e.g., `%s.my_table`).", datasetFQN, datasetID)
 		} else {
 			datasetIDs := []string{}
 			for _, ds := range allowedDatasets {
 				datasetIDs = append(datasetIDs, fmt.Sprintf("`%s`", ds))
 			}
-			sqlDescriptionBuilder.WriteString(fmt.Sprintf(" The query must only access datasets from the following list: %s.", strings.Join(datasetIDs, ", ")))
+			fmt.Fprintf(&sqlDescriptionBuilder, " The query must only access datasets from the following list: %s.", strings.Join(datasetIDs, ", "))
 		}
 	}
 

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -3201,7 +3201,7 @@ func RunMySQLListTablesMissingUniqueIndexes(t *testing.T, ctx context.Context, p
 
 	createTableHelper := func(t *testing.T, tableName, databaseName string, primaryKey, uniqueKey, nonUniqueKey bool, ctx context.Context, pool *sql.DB) func() {
 		var stmt strings.Builder
-		stmt.WriteString(fmt.Sprintf("CREATE TABLE %s (", tableName))
+		fmt.Fprintf(&stmt, "CREATE TABLE %s (", tableName)
 		stmt.WriteString("c1 INT")
 		if primaryKey {
 			stmt.WriteString(" PRIMARY KEY")


### PR DESCRIPTION
Latest golangci-lint version had included [QF1012](https://go.dev/gopls/analyzers#qf1012-use-fmtfprintfx--instead-of-xwritefmtsprintf) into static check.