### PR TITLE
docs: link check only on .md files

### DIFF
--- a/.github/workflows/link_checker.yaml
+++ b/.github/workflows/link_checker.yaml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: |
           git fetch origin main
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/main...HEAD -- '*.md' 'docs/**/*.md')
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/main...HEAD -- '*.md')
 
           if [ -z "$CHANGED_FILES" ]; then
             echo "No markdown files changed. Skipping checks."


### PR DESCRIPTION
Previously, the link checker ran on all changed files; it has now been restricted to changed .md files only.