### PR TITLE
fix: template parameter escaping

### DIFF
--- a/internal/util/parameters/parameters.go
+++ b/internal/util/parameters/parameters.go
@@ -783,13 +783,13 @@ func (p *StringParameter) Parse(v any) (any, error) {
 func applyEscape(escape, v string) (any, error) {
 	switch escape {
 	case escapeBackticks:
-		return fmt.Sprintf("`%s`", v), nil
+		return fmt.Sprintf("`%s`", strings.ReplaceAll(v, "`", "``")), nil
 	case escapeDoubleQuotes:
-		return fmt.Sprintf(`"%s"`, v), nil
+		return fmt.Sprintf(`"%s"`, strings.ReplaceAll(v, `"`, `""`)), nil
 	case escapeSingleQuotes:
-		return fmt.Sprintf(`'%s'`, v), nil
+		return fmt.Sprintf(`'%s'`, strings.ReplaceAll(v, `'`, `''`)), nil
 	case escapeSquareBrackets:
-		return fmt.Sprintf("[%s]", v), nil
+		return fmt.Sprintf("[%s]", strings.ReplaceAll(v, "]", "]]")), nil
 	default:
 		return nil, fmt.Errorf("%s is not an allowed escaping delimiter", escape)
 	}

--- a/internal/util/parameters/parameters_test.go
+++ b/internal/util/parameters/parameters_test.go
@@ -798,6 +798,16 @@ func TestParametersParse(t *testing.T) {
 			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: "`foo`"}},
 		},
 		{
+			name: "string with escape backticks (injection)",
+			params: parameters.Parameters{
+				parameters.NewStringParameterWithEscape("my_string", "this param is a string", "backticks"),
+			},
+			in: map[string]any{
+				"my_string": "foo ` bar",
+			},
+			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: "`foo `` bar`"}},
+		},
+		{
 			name: "string with escape double quotes",
 			params: parameters.Parameters{
 				parameters.NewStringParameterWithEscape("my_string", "this param is a string", "double-quotes"),
@@ -806,6 +816,16 @@ func TestParametersParse(t *testing.T) {
 				"my_string": "foo",
 			},
 			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: `"foo"`}},
+		},
+		{
+			name: "string with escape double quotes (injection)",
+			params: parameters.Parameters{
+				parameters.NewStringParameterWithEscape("my_string", "this param is a string", "double-quotes"),
+			},
+			in: map[string]any{
+				"my_string": `foo " bar`,
+			},
+			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: `"foo "" bar"`}},
 		},
 		{
 			name: "string with escape single quotes",
@@ -818,6 +838,16 @@ func TestParametersParse(t *testing.T) {
 			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: `'foo'`}},
 		},
 		{
+			name: "string with escape single quotes (injection)",
+			params: parameters.Parameters{
+				parameters.NewStringParameterWithEscape("my_string", "this param is a string", "single-quotes"),
+			},
+			in: map[string]any{
+				"my_string": "foo ' bar",
+			},
+			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: `'foo '' bar'`}},
+		},
+		{
 			name: "string with escape square brackets",
 			params: parameters.Parameters{
 				parameters.NewStringParameterWithEscape("my_string", "this param is a string", "square-brackets"),
@@ -826,6 +856,16 @@ func TestParametersParse(t *testing.T) {
 				"my_string": "foo",
 			},
 			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: "[foo]"}},
+		},
+		{
+			name: "string with escape square brackets (injection)",
+			params: parameters.Parameters{
+				parameters.NewStringParameterWithEscape("my_string", "this param is a string", "square-brackets"),
+			},
+			in: map[string]any{
+				"my_string": "foo ] bar",
+			},
+			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: "[foo ]] bar]"}},
 		},
 		{
 			name: "int",


### PR DESCRIPTION
### Description

**What does this PR do?**
This PR resolves two critical CodeQL `go/unsafe-quoting` security alerts (Alert #1 and #2) in `internal/util/parameters/parameters.go`. 

Previously, the `applyEscape` function used `fmt.Sprintf` to wrap user-provided `templateParameters` in quotes or brackets without escaping the underlying input. Since `templateParameters` are often injected directly into SQL query strings (e.g., for dynamic identifiers like table or column names that cannot be parameterized by database drivers), this allowed attackers to supply unescaped characters (like `"`, `'`, ``` ` ```, or `]`) to break out of the string context and execute malicious SQL commands.

**How was it fixed?**
We implemented standard SQL-safe escaping by doubling the enclosing character for all supported delimiters. This ensures that any user input is treated strictly as data or a literal identifier, completely mitigating the risk of injection across all supported SQL dialects (PostgreSQL, MySQL, SQL Server, etc.).

Specifically, the following escaping rules were applied:
*   **Single Quotes:** `strings.ReplaceAll(v, "'", "''")`
*   **Double Quotes:** `strings.ReplaceAll(v, "\"", "\"\"")`
*   **Backticks:** `strings.ReplaceAll(v, "\`", "\`\`")`
*   **Square Brackets:** `strings.ReplaceAll(v, "]", "]]")`

**Testing**
*   Updated `internal/util/parameters/parameters_test.go` to include four new test cases (`* (injection)`) that explicitly verify malicious inputs are safely escaped.
*   All tests in `internal/util/parameters/` pass successfully.

**Related Issues**
*   Fixes CodeQL Alert 1 (CWE-78, CWE-89, CWE-94)
*   Fixes CodeQL Alert 2 (CWE-78, CWE-89, CWE-94)