### PR TITLE
fix(mcp): prevent panic when SSE session is missing

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -61,7 +61,9 @@ func (m *sseManager) get(id string) (*sseSession, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	session, ok := m.sseSessions[id]
-	session.lastActive = time.Now()
+	if ok {
+		session.lastActive = time.Now()
+	}
 	return session, ok
 }
 

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -1168,3 +1168,18 @@ func TestStdioSession(t *testing.T) {
 		t.Fatalf("unexpected read: got %s, want %s", read, want)
 	}
 }
+
+func TestSseManagerGetUnknownSession(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	manager := newSseManager(ctx)
+
+	session, ok := manager.get("unknown-session-id")
+	if ok {
+		t.Fatal("expected unknown session lookup to return ok=false")
+	}
+	if session != nil {
+		t.Fatal("expected unknown session lookup to return nil session")
+	}
+}


### PR DESCRIPTION
## Summary
- fix `sseManager.get` to only update `lastActive` when the session exists
- return `(nil, false)` cleanly for unknown `sessionId` lookups
- add a regression test for unknown session retrieval

## Why
Issue #2548 reports a nil pointer dereference in `sseManager.get()` when `sessionId` is unknown. The map lookup can return `nil`, and unguarded field assignment panics.

## Fix
Guard the `lastActive` update behind `ok`, preserving existing behavior for valid sessions and avoiding panic for invalid IDs.

## Testing
- Added `TestSseManagerGetUnknownSession` in `internal/server/mcp_test.go`
- Local `go test` could not run in this environment because `go` is not installed (`zsh: command not found: go`)

Fixes #2548
