### PR TITLE
fix(oracle): allow successful exec without rows-affected metadata

### DIFF
--- a/internal/sources/oracle/oracle.go
+++ b/internal/sources/oracle/oracle.go
@@ -143,15 +143,7 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any, rea
 			return nil, fmt.Errorf("unable to execute DML statement: %w", err)
 		}
 
-		rowsAffected, err := result.RowsAffected()
-		if err != nil {
-			return nil, fmt.Errorf("unable to get rows affected: %w", err)
-		}
-
-		return map[string]any{
-			"status":        "success",
-			"rows_affected": rowsAffected,
-		}, nil
+		return formatExecResponse(result), nil
 	}
 	rows, err := s.OracleDB().QueryContext(ctx, statement, params...)
 	if err != nil {
@@ -251,6 +243,19 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any, rea
 	}
 
 	return out, nil
+}
+
+func formatExecResponse(result sql.Result) map[string]any {
+	resp := map[string]any{
+		"status": "success",
+	}
+
+	// Some Oracle executions (e.g., PL/SQL blocks with RETURN) do not expose
+	// rows affected. Treat this as a successful execution without row metadata.
+	if rowsAffected, err := result.RowsAffected(); err == nil {
+		resp["rows_affected"] = rowsAffected
+	}
+	return resp
 }
 
 func initOracleConnection(ctx context.Context, tracer trace.Tracer, config Config) (*sql.DB, error) {

--- a/internal/sources/oracle/oracle_internal_test.go
+++ b/internal/sources/oracle/oracle_internal_test.go
@@ -1,0 +1,47 @@
+// Copyright © 2025, Oracle and/or its affiliates.
+package oracle
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeResult struct {
+	rows int64
+	err  error
+}
+
+func (f fakeResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+func (f fakeResult) RowsAffected() (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.rows, nil
+}
+
+func TestFormatExecResponseWithRowsAffected(t *testing.T) {
+	got := formatExecResponse(fakeResult{rows: 7})
+
+	if status, ok := got["status"]; !ok || status != "success" {
+		t.Fatalf("expected status=success, got %#v", got["status"])
+	}
+
+	if rows, ok := got["rows_affected"]; !ok || rows != int64(7) {
+		t.Fatalf("expected rows_affected=7, got %#v", got["rows_affected"])
+	}
+}
+
+func TestFormatExecResponseWithoutRowsAffected(t *testing.T) {
+	got := formatExecResponse(fakeResult{err: errors.New("rows affected unavailable")})
+
+	if status, ok := got["status"]; !ok || status != "success" {
+		t.Fatalf("expected status=success, got %#v", got["status"])
+	}
+
+	if _, ok := got["rows_affected"]; ok {
+		t.Fatalf("expected rows_affected to be omitted when unavailable, got %#v", got["rows_affected"])
+	}
+}


### PR DESCRIPTION
## Summary
- stop failing Oracle non-readOnly executions when `RowsAffected()` is unavailable
- return a success response without `rows_affected` metadata when the driver does not provide it
- add unit tests for both code paths (rows count available vs unavailable)

## Why
Issue #2044 reports failures when Oracle SQL includes `RETURN` in PL/SQL execution flows. In Oracle, some successful executions (including PL/SQL blocks) may not support `RowsAffected()`. The current code treats that as an error and fails the tool invocation.

## Fix
Refactor exec response formatting to treat missing rows-affected metadata as non-fatal. Successful execution now returns:
- `{ "status": "success", "rows_affected": <n> }` when available
- `{ "status": "success" }` when unavailable

## Testing
- Added `TestFormatExecResponseWithRowsAffected`
- Added `TestFormatExecResponseWithoutRowsAffected`
- Local `go test` could not run in this environment because `go` is not installed (`zsh: command not found: go`)

Fixes #2044
