### PR TITLE
fix(mcp): end stdio spans per message

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -200,7 +200,6 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 		msgCtx, span := s.server.instrumentation.Tracer.Start(msgCtx, "toolbox/server/mcp/stdio",
 			trace.WithSpanKind(trace.SpanKindServer),
 		)
-		defer span.End()
 
 		v, res, err := processMcpMessage(msgCtx, []byte(line), s.server, s.protocol, "", "", nil, "")
 		if err != nil {
@@ -216,9 +215,11 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 		// no responses for notifications
 		if res != nil {
 			if err = s.write(msgCtx, res); err != nil {
+				span.End()
 				return err
 			}
 		}
+		span.End()
 	}
 }
 

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -20,17 +20,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"go.opentelemetry.io/otel"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 const jsonrpcVersion = "2.0"
@@ -1166,5 +1171,79 @@ func TestStdioSession(t *testing.T) {
 	want := fmt.Sprintf(`"%s"`, write) + "\n"
 	if read != want {
 		t.Fatalf("unexpected read: got %s, want %s", read, want)
+	}
+}
+
+func TestStdioSessionReadInputStreamEndsSpansPerMessage(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(spanRecorder))
+	defer func() {
+		if err := tracerProvider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("failed to shutdown tracer provider: %v", err)
+		}
+	}()
+
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	defer otel.SetTracerProvider(previousTracerProvider)
+
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(fakeVersionString)
+	if err != nil {
+		t.Fatalf("unable to create telemetry instrumentation: %v", err)
+	}
+
+	testLogger, err := log.NewStdLogger(io.Discard, io.Discard, "error")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %v", err)
+	}
+
+	server := &Server{
+		logger:          testLogger,
+		instrumentation: instrumentation,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pr, pw := io.Pipe()
+	defer pr.Close()
+
+	stdioSession := NewStdioSession(server, pr, io.Discard)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- stdioSession.readInputStream(ctx)
+	}()
+
+	if _, err := pw.Write([]byte("not-json-1\nnot-json-2\n")); err != nil {
+		t.Fatalf("unable to write test input: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if len(spanRecorder.Ended()) >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected at least 2 ended spans while session is running, got %d", len(spanRecorder.Ended()))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("readInputStream returned too early: %v", err)
+	default:
+	}
+
+	cancel()
+	_ = pw.Close()
+
+	select {
+	case err := <-errCh:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("unexpected readInputStream error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readInputStream did not exit after cancellation")
 	}
 }


### PR DESCRIPTION
## Summary
- replace `defer span.End()` inside the message loop with explicit per-iteration `span.End()`
- ensure spans are ended before returning on write errors
- add regression test that verifies spans are ended while the input loop is still running

## Why
Issue #2549 reports `defer span.End()` in `readInputStream` inside a `for` loop. In long-lived stdio sessions, deferred calls accumulate until function exit, causing memory growth and delayed span finalization.

## Fix
Call `span.End()` at the end of each loop iteration and before early return paths, so each message span is finalized immediately.

## Testing
- Added `TestStdioSessionReadInputStreamEndsSpansPerMessage` in `internal/server/mcp_test.go`
- Local `go test` could not run in this environment because `go` is not installed (`zsh: command not found: go`)

Fixes #2549