### PR TITLE
fix(tests): resolve LlamaIndex dependency conflict in JS quickstart

### DIFF
--- a/docs/en/getting-started/quickstart/js/llamaindex/package-lock.json
+++ b/docs/en/getting-started/quickstart/js/llamaindex/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@llamaindex/core": "0.6.22",
-        "@llamaindex/google": "^0.4.0",
-        "@llamaindex/workflow": "^1.1.22",
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/google": "0.3.20",
+        "@llamaindex/workflow": "1.1.22",
         "@toolbox-sdk/core": "^0.2.0",
-        "llamaindex": "^0.12.0"
+        "llamaindex": "0.12.0"
       }
     },
     "node_modules/@aws-crypto/sha256-js": {
@@ -155,34 +155,15 @@
       }
     },
     "node_modules/@llamaindex/core": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.22.tgz",
-      "integrity": "sha512-/BXyemkvpxMaUhOkbwJ2PTvzKjSWkL8+6QLpz/n+pk8xBwMMe1GVBgli/J57gCyi8GbrlBafBj6GaPOgWub2Eg==",
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.20.tgz",
+      "integrity": "sha512-3Sq8eoNyHjF9yFdzHJKjHxVioQPKcp7YLp6PiwkWryev30H3EFIloAr5CvgppRHGmwlhbTwHsGp+SSfpWIdg/g==",
       "dependencies": {
-        "@finom/zod-to-json-schema": "3.24.11",
         "@llamaindex/env": "0.1.30",
         "@types/node": "^24.0.13",
         "magic-bytes.js": "^1.10.0",
-        "zod": "^4.1.5"
-      }
-    },
-    "node_modules/@llamaindex/core/node_modules/@finom/zod-to-json-schema": {
-      "version": "3.24.11",
-      "resolved": "https://registry.npmjs.org/@finom/zod-to-json-schema/-/zod-to-json-schema-3.24.11.tgz",
-      "integrity": "sha512-fL656yBPiWebtfGItvtXLWrFNGlF1NcDFS0WdMQXMs9LluVg0CfT5E2oXYp0pidl0vVG53XkW55ysijNkU5/hA==",
-      "deprecated": "Use https://www.npmjs.com/package/zod-v3-to-json-schema instead. See issue comment for details: https://github.com/StefanTerdell/zod-to-json-schema/issues/178#issuecomment-3533122539",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^4.0.14"
-      }
-    },
-    "node_modules/@llamaindex/core/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.6"
       }
     },
     "node_modules/@llamaindex/env": {
@@ -208,14 +189,14 @@
       }
     },
     "node_modules/@llamaindex/google": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@llamaindex/google/-/google-0.4.0.tgz",
-      "integrity": "sha512-VHf21a+RfrEXaE1rdFquQu72fl5jsfvgly/SiKODXTw5FK/WVhoeflXiM/sBptHrREf4mMi/Cx4MdkkOTI2ovg==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@llamaindex/google/-/google-0.3.20.tgz",
+      "integrity": "sha512-N5om9kKfn898f+8xqEEBd37DCLrhLNZeATLyg9lUyRlRrXQe7b1vwVmXuALzL+SH03ivhd23tk7/MOCfs88BXQ==",
       "dependencies": {
         "@google/genai": "^1.7.0"
       },
       "peerDependencies": {
-        "@llamaindex/core": "0.6.22",
+        "@llamaindex/core": "0.6.20",
         "@llamaindex/env": "0.1.30"
       }
     },
@@ -957,6 +938,28 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/llamaindex/node_modules/@finom/zod-to-json-schema": {
+      "version": "3.24.11",
+      "resolved": "https://registry.npmjs.org/@finom/zod-to-json-schema/-/zod-to-json-schema-3.24.11.tgz",
+      "integrity": "sha512-fL656yBPiWebtfGItvtXLWrFNGlF1NcDFS0WdMQXMs9LluVg0CfT5E2oXYp0pidl0vVG53XkW55ysijNkU5/hA==",
+      "deprecated": "Use https://www.npmjs.com/package/zod-v3-to-json-schema instead. See issue comment for details: https://github.com/StefanTerdell/zod-to-json-schema/issues/178#issuecomment-3533122539",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^4.0.14"
+      }
+    },
+    "node_modules/llamaindex/node_modules/@llamaindex/core": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.22.tgz",
+      "integrity": "sha512-/BXyemkvpxMaUhOkbwJ2PTvzKjSWkL8+6QLpz/n+pk8xBwMMe1GVBgli/J57gCyi8GbrlBafBj6GaPOgWub2Eg==",
+      "dependencies": {
+        "@finom/zod-to-json-schema": "3.24.11",
+        "@llamaindex/env": "0.1.30",
+        "@types/node": "^24.0.13",
+        "magic-bytes.js": "^1.10.0",
+        "zod": "^4.1.5"
+      }
+    },
     "node_modules/llamaindex/node_modules/@llamaindex/node-parser": {
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/@llamaindex/node-parser/-/node-parser-2.0.22.tgz",
@@ -981,6 +984,15 @@
       "peerDependencies": {
         "@llamaindex/core": "0.6.22",
         "@llamaindex/env": "0.1.30"
+      }
+    },
+    "node_modules/llamaindex/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/lodash": {
@@ -1235,7 +1247,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1244,7 +1255,6 @@
       "version": "3.24.6",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
       "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.24.1"
       }

--- a/docs/en/getting-started/quickstart/js/llamaindex/package.json
+++ b/docs/en/getting-started/quickstart/js/llamaindex/package.json
@@ -11,10 +11,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@llamaindex/google": "^0.4.0",
-    "@llamaindex/workflow": "^1.1.22",
+    "@llamaindex/core": "0.6.20",
+    "@llamaindex/google": "0.3.20",
+    "@llamaindex/workflow": "1.1.22",
     "@toolbox-sdk/core": "^0.2.0",
-    "llamaindex": "^0.12.0",
-    "@llamaindex/core": "0.6.22"
+    "llamaindex": "0.12.0"
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a failing quickstart-test-js presubmit (#2214) by explicitly aligning the LlamaIndex ecosystem dependencies. The previous configuration caused an ERESOLVE error because `@llamaindex/google` required a specific version of `@llamaindex/core` that was conflicting with the top-level resolution.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
