### PR TITLE
chore: label new and reopened issues with p2

### DIFF
--- a/.github/workflows/label_new_issues.yaml
+++ b/.github/workflows/label_new_issues.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Label all new/reopened issues with P2
 on:
   issues:


### PR DESCRIPTION
## Description

Currently new issues don't have a priority label. This means that the issue mirror for
buganizer automatically treats them as P0 and they go out of SLO very quickly. This
automation will set them to p2 in GitHub, so they will become P2 in buganizer.

The code has been used for several years in https://github.com/looker-open-source/sdk-codegen/blob/main/.github/workflows/p3-issue-label.yml

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #
