### PR TITLE
doc: Remove 'toolbox' command from Docker config

### DIFF
--- a/docs/en/how-to/deploy_docker.md
+++ b/docs/en/how-to/deploy_docker.md
@@ -67,7 +67,7 @@ networks:
 
 ```
 
-    {{< notice tip >}}  
+{{< notice tip >}}  
 To prevent DNS rebinding attack, use the `--allowed-hosts` flag to specify a
 list of hosts for validation. E.g. `command: ["--tools-file",
 "/config/tools.yaml", "--address", "0.0.0.0","--allowed-hosts",


### PR DESCRIPTION
Fixes https://github.com/googleapis/genai-toolbox/issues/2708

The entrypoint binary is already specified in the container image here: https://github.com/googleapis/genai-toolbox/blob/df7f2fd7d5b75211dbbbd471c84f0ec5097ca7ad/Dockerfile#L55.