### PR TITLE
feat(ui): adapt Web UI to native MCP endpoints

### DIFF
--- a/internal/server/static/js/loadTools.js
+++ b/internal/server/static/js/loadTools.js
@@ -27,12 +27,31 @@ let toolDetailsAbortController = null;
 export async function loadTools(secondNavContent, toolDisplayArea, toolsetName) {
     secondNavContent.innerHTML = '<p>Fetching tools...</p>';
     try {
-        const response = await fetch(`/api/toolset/${toolsetName}`);
+        const rpcPayload = {
+            jsonrpc: "2.0",
+            id: crypto.randomUUID(),
+            method: "tools/list",
+            params: {}
+        };
+
+        const response = await fetch('/mcp', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(rpcPayload)
+        });
+
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
         }
         const apiResponse = await response.json();
-        renderToolList(apiResponse, secondNavContent, toolDisplayArea);
+        
+        if (apiResponse.error) {
+            throw new Error(`MCP error ${apiResponse.error.code}: ${apiResponse.error.message}`);
+        }
+
+        renderToolList(apiResponse.result, secondNavContent, toolDisplayArea);
     } catch (error) {
         console.error('Failed to load tools:', error);
         secondNavContent.innerHTML = `<p class="error">Failed to load tools: <pre><code>${escapeHtml(String(error))}</code></pre></p>`;
@@ -48,14 +67,14 @@ export async function loadTools(secondNavContent, toolDisplayArea, toolsetName) 
 function renderToolList(apiResponse, secondNavContent, toolDisplayArea) {
     secondNavContent.innerHTML = '';
 
-    if (!apiResponse || typeof apiResponse.tools !== 'object' || apiResponse.tools === null) {
-        console.error('Error: Expected an object with a "tools" property, but received:', apiResponse);
-        secondNavContent.textContent = 'Error: Invalid response format from toolset API.';
+    if (!apiResponse || !Array.isArray(apiResponse.tools)) {
+        console.error('Error: Expected a "tools" array, but received:', apiResponse);
+        secondNavContent.textContent = 'Error: Invalid response format from tools API.';
         return;
     }
 
-    const toolsObject = apiResponse.tools;
-    const toolNames = Object.keys(toolsObject);
+    const toolsArray = apiResponse.tools;
+    const toolNames = toolsArray.map(t => t.name);
 
     if (toolNames.length === 0) {
         secondNavContent.textContent = 'No tools found.';
@@ -113,56 +132,92 @@ async function fetchToolDetails(toolName, toolDisplayArea) {
     toolDisplayArea.innerHTML = '<p>Loading tool details...</p>';
 
     try {
-        const response = await fetch(`/api/tool/${encodeURIComponent(toolName)}`, { signal });
-        if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const apiResponse = await response.json();
+        const rpcPayload = {
+            jsonrpc: "2.0",
+            id: crypto.randomUUID(),
+            method: "tools/list",
+            params: {}
+        };
 
-        if (!apiResponse.tools || !apiResponse.tools[toolName]) {
+        const response = await fetch('/mcp', { 
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(rpcPayload),
+            signal 
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const apiResponse = await response.json();
+        if (apiResponse.error) {
+            throw new Error(`MCP error ${apiResponse.error.code}: ${apiResponse.error.message}`);
+        }
+
+        const toolsArray = apiResponse.result?.tools || [];
+        const toolObject = toolsArray.find(t => t.name === toolName);
+
+        if (!toolObject) {
             throw new Error(`Tool "${toolName}" data not found in API response.`);
         }
-        const toolObject = apiResponse.tools[toolName];
         console.debug("Received tool object: ", toolObject)
 
+        // Parse MCP JSON Schema parameters back into internal UI format
+        let parameters = [];
+        if (toolObject.inputSchema && toolObject.inputSchema.properties) {
+             const props = toolObject.inputSchema.properties;
+             const requiredCols = toolObject.inputSchema.required || [];
+             parameters = Object.keys(props).map(paramName => {
+                 const paramSchema = props[paramName];
+                 let inputType = 'text'; 
+                 const apiType = paramSchema.type ? paramSchema.type.toLowerCase() : 'string';
+                 let valueType = 'string'; 
+                 let label = paramSchema.description || paramName;
+
+                 if (apiType === 'integer' || apiType === 'number') {
+                     inputType = 'number';
+                     valueType = 'number';
+                 } else if (apiType === 'boolean') {
+                     inputType = 'checkbox';
+                     valueType = 'boolean';
+                 } else if (apiType === 'array') {
+                     inputType = 'textarea'; 
+                     const itemType = paramSchema.items && paramSchema.items.type ? paramSchema.items.type.toLowerCase() : 'string';
+                     valueType = `array<${itemType}>`;
+                     label += ' (Array)';
+                 }
+
+                 let authServices = undefined;
+                 if (toolObject._meta && toolObject._meta['toolbox/authParam'] && toolObject._meta['toolbox/authParam'][paramName]) {
+                     authServices = toolObject._meta['toolbox/authParam'][paramName];
+                 }
+
+                 return {
+                     name: paramName,
+                     type: inputType,    
+                     valueType: valueType, 
+                     label: label,
+                     required: requiredCols.includes(paramName),
+                     authServices: authServices
+                 };
+             });
+        }
+
+        let authRequired = undefined;
+        if (toolObject._meta && toolObject._meta['toolbox/authInvoke']) {
+             authRequired = toolObject._meta['toolbox/authInvoke'];
+        }
+
         const toolInterfaceData = {
-            id: toolName,
-            name: toolName,
-            description: toolObject.description || "No description provided.",
-            authRequired: toolObject.authRequired || [],
-            parameters: (toolObject.parameters || []).map(param => {
-                let inputType = 'text'; 
-                const apiType = param.type ? param.type.toLowerCase() : 'string';
-                let valueType = 'string'; 
-                let label = param.description || param.name;
-
-                if (apiType === 'integer' || apiType === 'float') {
-                    inputType = 'number';
-                    valueType = 'number';
-                } else if (apiType === 'boolean') {
-                    inputType = 'checkbox';
-                    valueType = 'boolean';
-                } else if (apiType === 'array') {
-                    inputType = 'textarea'; 
-                    const itemType = param.items && param.items.type ? param.items.type.toLowerCase() : 'string';
-                    valueType = `array<${itemType}>`;
-                    label += ' (Array)';
-                }
-
-                return {
-                    name: param.name,
-                    type: inputType,    
-                    valueType: valueType, 
-                    label: label,
-                    authServices: param.authSources,
-                    required: param.required || false,
-                    // defaultValue: param.default, can't do this yet bc tool manifest doesn't have default
-                };
-            })
+             id: toolObject.name,
+             name: toolObject.name,
+             description: toolObject.description || "No description provided.",
+             parameters: parameters,
+             authRequired: authRequired
         };
 
         console.debug("Transformed toolInterfaceData:", toolInterfaceData);
-
         renderToolInterface(toolInterfaceData, toolDisplayArea);
     } catch (error) {
         if (error.name === 'AbortError') {

--- a/internal/server/static/js/runTool.js
+++ b/internal/server/static/js/runTool.js
@@ -15,7 +15,7 @@
 import { isParamIncluded } from "./toolDisplay.js";
 
 /**
- * Runs a specific tool using the /api/tools/toolName/invoke endpoint
+ * Runs a specific tool using the MCP /mcp JSON-RPC endpoint
  * @param {string} toolId The unique identifier for the tool.
  * @param {!HTMLFormElement} form The form element containing parameter inputs.
  * @param {!HTMLTextAreaElement} responseArea The textarea to display results or errors.
@@ -45,7 +45,7 @@ export async function handleRunTool(toolId, form, responseArea, parameters, pret
             if (VALUE_TYPE === 'boolean') {
                 typedParams[NAME] = RAW_VALUE !== null;
                 console.debug(`Parameter ${NAME} (boolean) set to: ${typedParams[NAME]}`);
-                continue; 
+                continue;
             }
 
             // process remaining types
@@ -74,22 +74,41 @@ export async function handleRunTool(toolId, form, responseArea, parameters, pret
         } catch (error) {
             console.error('Error processing parameter:', NAME, error);
             responseArea.value = `Error for ${NAME}: ${error.message}`;
-            return; 
+            return;
         }
     }
 
     console.debug('Running tool:', toolId, 'with typed params:', typedParams);
     try {
-        const response = await fetch(`/api/tool/${toolId}/invoke`, {
+        const rpcPayload = {
+            jsonrpc: "2.0",
+            id: crypto.randomUUID(),
+            method: "tools/call",
+            params: {
+                name: toolId,
+                arguments: typedParams
+            }
+        };
+
+        const response = await fetch(`/mcp`, {
             method: 'POST',
             headers: headers,
-            body: JSON.stringify(typedParams)
+            body: JSON.stringify(rpcPayload)
         });
+
         if (!response.ok) {
             const errorBody = await response.text();
             throw new Error(`HTTP error ${response.status}: ${errorBody}`);
         }
-        const results = await response.json();
+
+        const rpcResponse = await response.json();
+
+        if (rpcResponse.error) {
+            throw new Error(`MCP error ${rpcResponse.error.code}: ${rpcResponse.error.message}`);
+        }
+
+        const results = rpcResponse.result;
+
         updateLastResults(results);
         displayResults(results, responseArea, prettifyCheckbox.checked);
     } catch (error) {
@@ -145,7 +164,17 @@ export function displayResults(results, responseArea, prettify) {
         return;
     }
     try {
-        const resultJson = JSON.parse(results.result);
+        let content = results;
+
+        if (results.content && results.content.length > 0) {
+            if (results.content.length === 1 && results.content[0].text) {
+                content = results.content[0].text;
+            } else {
+                content = JSON.stringify(results.content.map(c => JSON.parse(c.text)));
+            }
+        }
+
+        const resultJson = JSON.parse(content);
         if (prettify) {
             responseArea.value = JSON.stringify(resultJson, null, 2);
         } else {
@@ -153,10 +182,12 @@ export function displayResults(results, responseArea, prettify) {
         }
     } catch (error) {
         console.error("Error parsing or stringifying results:", error);
-        if (typeof results.result === 'string') {
-            responseArea.value = results.result;
+        if (results.content && results.content.length > 0) {
+            responseArea.value = results.content.map(c => c.text).join('\n\n');
+        } else if (typeof results === 'string') {
+            responseArea.value = results;
         } else {
-            responseArea.value = "Error displaying results. Invalid format.";
+            responseArea.value = JSON.stringify(results, null, 2);
         }
     }
 }

--- a/internal/server/static/js/toolDisplay.js
+++ b/internal/server/static/js/toolDisplay.js
@@ -193,7 +193,7 @@ function createHeaderEditorModal(toolId, currentHeaders, toolParameters, authReq
     modalContent.appendChild(modalHeader);
     modalContent.appendChild(headersTextarea);
 
-    if (authProfileNames.size > 0 || authRequired.length > 0) {
+    if (authProfileNames.size > 0 || (authRequired && authRequired.length > 0)) {
         const authHelperSection = document.createElement('div');
         authHelperSection.className = 'auth-helper-section';
         const authList = document.createElement('div');


### PR DESCRIPTION
## Overview
This PR adapts the frontend MCP Toolbox UI directly against the dynamically populated MCP specifications.

## Changes
* Overhauled underlying frontend engine files (`runTool.js`, `loadTools.js`).
* Updated the parser to read direct standard MCP interface Result structures and format content blocks using unified Markdown conversions onto the DOM.
* Stripped down proxy array mappers that were explicitly tailored for unwrapping old non-schema REST implementations.

> [!NOTE]
> This PR is Part 4 of 5 to migrate legacy endpoints to standard MCP endpoints.
(Base PR: https://github.com/googleapis/genai-toolbox/pull/2713)