### PR TITLE
chore(sources/cloudsqlmssql)!: remove support for ipAddress

### DIFF
--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
@@ -50,16 +50,15 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	// Cloud SQL MSSQL configs
-	Name      string         `yaml:"name" validate:"required"`
-	Type      string         `yaml:"type" validate:"required"`
-	Project   string         `yaml:"project" validate:"required"`
-	Region    string         `yaml:"region" validate:"required"`
-	Instance  string         `yaml:"instance" validate:"required"`
-	IPAddress string         `yaml:"ipAddress"` // Deprecated: kept for backwards compatibility
-	IPType    sources.IPType `yaml:"ipType" validate:"required"`
-	User      string         `yaml:"user" validate:"required"`
-	Password  string         `yaml:"password" validate:"required"`
-	Database  string         `yaml:"database" validate:"required"`
+	Name     string         `yaml:"name" validate:"required"`
+	Type     string         `yaml:"type" validate:"required"`
+	Project  string         `yaml:"project" validate:"required"`
+	Region   string         `yaml:"region" validate:"required"`
+	Instance string         `yaml:"instance" validate:"required"`
+	IPType   sources.IPType `yaml:"ipType" validate:"required"`
+	User     string         `yaml:"user" validate:"required"`
+	Password string         `yaml:"password" validate:"required"`
+	Database string         `yaml:"database" validate:"required"`
 }
 
 func (r Config) SourceConfigType() string {

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql_test.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql_test.go
@@ -86,35 +86,6 @@ func TestParseFromYamlCloudSQLMssql(t *testing.T) {
 				},
 			},
 		},
-		{
-			desc: "with deprecated ipAddress",
-			in: `
-			kind: sources
-			name: my-instance
-			type: cloud-sql-mssql
-			project: my-project
-			region: my-region
-			instance: my-instance
-			ipAddress: random
-			database: my_db
-			user: my_user
-			password: my_pass
-			`,
-			want: map[string]sources.SourceConfig{
-				"my-instance": cloudsqlmssql.Config{
-					Name:      "my-instance",
-					Type:      cloudsqlmssql.SourceType,
-					Project:   "my-project",
-					Region:    "my-region",
-					Instance:  "my-instance",
-					IPAddress: "random",
-					IPType:    "public",
-					Database:  "my_db",
-					User:      "my_user",
-					Password:  "my_pass",
-				},
-			},
-		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
The ipAddress field had not been used for awhile. It was previously kept for backwards compatibility. We will be removing it from the config. 