### PR TITLE
ci: ignore google cloud links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -21,6 +21,7 @@ https://cloud-run-url.app/
 https://xxx.cloud.dgraph.io/
 https://cloud.dgraph.io/login
 https://dgraph.io/docs
+https://play.dgraph.io/
 
 # MySQL Community downloads and main site (often protected by bot mitigation)
 ^https?://(.*\.)?mysql\.com/.*


### PR DESCRIPTION
The link checker is currently failing because our local firewall blocks outbound HTTPS (Port 443) requests to Google Cloud. This causes the workflow to report "broken" links even when the links themselves are fine.

Changes
Added google.cloud.com to the exclude/ignore list in the link checker configuration.

Fixes: https://github.com/googleapis/genai-toolbox/issues/2747 , https://github.com/googleapis/genai-toolbox/issues/2669