### PR TITLE
fix(mcp): enforce toolset membership for tool calls

### DIFF
--- a/internal/prompts/promptsets.go
+++ b/internal/prompts/promptsets.go
@@ -16,6 +16,7 @@ package prompts
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 )
@@ -36,6 +37,10 @@ func (p Promptset) ToConfig() PromptsetConfig {
 	return p.PromptsetConfig
 }
 
+func (p Promptset) HasPrompt(promptName string) bool {
+	return slices.Contains(p.PromptNames, promptName)
+}
+
 type PromptsetManifest struct {
 	ServerVersion   string              `json:"serverVersion"`
 	PromptsManifest map[string]Manifest `json:"prompts"`
@@ -44,7 +49,7 @@ type PromptsetManifest struct {
 func (t PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]Prompt) (Promptset, error) {
 	// Check each declared prompt name exists
 	var promptset Promptset
-	promptset.Name = t.Name
+	promptset.PromptsetConfig = t
 	if !tools.IsValidName(promptset.Name) {
 		return promptset, fmt.Errorf("invalid promptset name: %s", promptset.Name)
 	}

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -42,11 +42,11 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case TOOLS_LIST:
 		return toolsListHandler(id, toolset, body)
 	case TOOLS_CALL:
-		return toolsCallHandler(ctx, id, resourceMgr, body, header)
+		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
 		return promptsListHandler(ctx, id, promptset, body)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, resourceMgr, body)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
@@ -87,7 +87,7 @@ func toolsListHandler(id jsonrpc.RequestId, toolset tools.Toolset, body []byte) 
 }
 
 // toolsCallHandler generate a response for tools call.
-func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.Toolset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	authServices := resourceMgr.GetAuthServiceMap()
 
 	// retrieve logger from context
@@ -105,6 +105,11 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *re
 	toolName := req.Params.Name
 	toolArgument := req.Params.Arguments
 	logger.DebugContext(ctx, fmt.Sprintf("tool name: %s", toolName))
+
+	if !toolset.HasTool(toolName) {
+		err = fmt.Errorf("tool with name %q does not exist in toolset %q", toolName, toolset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)
@@ -339,7 +344,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, promptset pro
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -355,6 +360,11 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *r
 
 	promptName := req.Params.Name
 	logger.DebugContext(ctx, fmt.Sprintf("prompt name: %s", promptName))
+
+	if !promptset.HasPrompt(promptName) {
+		err := fmt.Errorf("prompt with name %q does not exist in promptset %q", promptName, promptset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -42,11 +42,11 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case TOOLS_LIST:
 		return toolsListHandler(id, toolset, body)
 	case TOOLS_CALL:
-		return toolsCallHandler(ctx, id, resourceMgr, body, header)
+		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
 		return promptsListHandler(ctx, id, promptset, body)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, resourceMgr, body)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
@@ -87,7 +87,7 @@ func toolsListHandler(id jsonrpc.RequestId, toolset tools.Toolset, body []byte) 
 }
 
 // toolsCallHandler generate a response for tools call.
-func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.Toolset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	authServices := resourceMgr.GetAuthServiceMap()
 
 	// retrieve logger from context
@@ -105,6 +105,11 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *re
 	toolName := req.Params.Name
 	toolArgument := req.Params.Arguments
 	logger.DebugContext(ctx, fmt.Sprintf("tool name: %s", toolName))
+
+	if !toolset.HasTool(toolName) {
+		err = fmt.Errorf("tool with name %q does not exist in toolset %q", toolName, toolset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)
@@ -338,7 +343,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, promptset pro
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -354,6 +359,11 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *r
 
 	promptName := req.Params.Name
 	logger.DebugContext(ctx, fmt.Sprintf("prompt name: %s", promptName))
+
+	if !promptset.HasPrompt(promptName) {
+		err := fmt.Errorf("prompt with name %q does not exist in promptset %q", promptName, promptset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -42,11 +42,11 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case TOOLS_LIST:
 		return toolsListHandler(id, toolset, body)
 	case TOOLS_CALL:
-		return toolsCallHandler(ctx, id, resourceMgr, body, header)
+		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
 		return promptsListHandler(ctx, id, promptset, body)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, resourceMgr, body)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
@@ -80,7 +80,7 @@ func toolsListHandler(id jsonrpc.RequestId, toolset tools.Toolset, body []byte) 
 }
 
 // toolsCallHandler generate a response for tools call.
-func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.Toolset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	authServices := resourceMgr.GetAuthServiceMap()
 
 	// retrieve logger from context
@@ -98,6 +98,11 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *re
 	toolName := req.Params.Name
 	toolArgument := req.Params.Arguments
 	logger.DebugContext(ctx, fmt.Sprintf("tool name: %s", toolName))
+
+	if !toolset.HasTool(toolName) {
+		err = fmt.Errorf("tool with name %q does not exist in toolset %q", toolName, toolset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)
@@ -332,7 +337,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, promptset pro
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -348,6 +353,11 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *r
 
 	promptName := req.Params.Name
 	logger.DebugContext(ctx, fmt.Sprintf("prompt name: %s", promptName))
+
+	if !promptset.HasPrompt(promptName) {
+		err := fmt.Errorf("prompt with name %q does not exist in promptset %q", promptName, promptset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -42,11 +42,11 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case TOOLS_LIST:
 		return toolsListHandler(id, toolset, body)
 	case TOOLS_CALL:
-		return toolsCallHandler(ctx, id, resourceMgr, body, header)
+		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
 		return promptsListHandler(ctx, id, promptset, body)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, resourceMgr, body)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
@@ -80,7 +80,7 @@ func toolsListHandler(id jsonrpc.RequestId, toolset tools.Toolset, body []byte) 
 }
 
 // toolsCallHandler generate a response for tools call.
-func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.Toolset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	authServices := resourceMgr.GetAuthServiceMap()
 
 	// retrieve logger from context
@@ -98,6 +98,11 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *re
 	toolName := req.Params.Name
 	toolArgument := req.Params.Arguments
 	logger.DebugContext(ctx, fmt.Sprintf("tool name: %s", toolName))
+
+	if !toolset.HasTool(toolName) {
+		err = fmt.Errorf("tool with name %q does not exist in toolset %q", toolName, toolset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)
@@ -332,7 +337,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, promptset pro
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -348,6 +353,11 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *r
 
 	promptName := req.Params.Name
 	logger.DebugContext(ctx, fmt.Sprintf("prompt name: %s", promptName))
+
+	if !promptset.HasPrompt(promptName) {
+		err := fmt.Errorf("prompt with name %q does not exist in promptset %q", promptName, promptset.Name)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
 
 	// Update span name and set gen_ai attributes
 	span := trace.SpanFromContext(ctx)

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -303,7 +303,7 @@ func TestMcpEndpointWithoutInitialized(t *testing.T) {
 				"id":      "prompts-get-non-existent",
 				"error": map[string]any{
 					"code":    -32602.0,
-					"message": `prompt with name "non_existent_prompt" does not exist`,
+					"message": `prompt with name "non_existent_prompt" does not exist in promptset ""`,
 				},
 			},
 		},
@@ -674,6 +674,30 @@ func TestMcpEndpoint(t *testing.T) {
 									"inputSchema": basicInputSchema,
 								},
 							},
+						},
+					},
+				},
+				{
+					name:  "tools/call on tool1_only denied",
+					url:   "/tool1_only",
+					isErr: true,
+					body: jsonrpc.JSONRPCRequest{
+						Jsonrpc: jsonrpcVersion,
+						Id:      "tools-call-tool1-only",
+						Request: jsonrpc.Request{
+							Method: "tools/call",
+						},
+						Params: map[string]any{
+							"name": "some_params",
+						},
+					},
+					wantStatusCode: http.StatusOK,
+					want: map[string]any{
+						"jsonrpc": "2.0",
+						"id":      "tools-call-tool1-only",
+						"error": map[string]any{
+							"code":    -32602.0,
+							"message": `tool with name "some_params" does not exist in toolset "tool1_only"`,
 						},
 					},
 				},

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -17,6 +17,7 @@ package tools
 import (
 	"fmt"
 	"regexp"
+	"slices"
 )
 
 type ToolsetConfig struct {
@@ -35,6 +36,10 @@ func (t Toolset) ToConfig() ToolsetConfig {
 	return t.ToolsetConfig
 }
 
+func (t Toolset) HasTool(toolName string) bool {
+	return slices.Contains(t.ToolNames, toolName)
+}
+
 type ToolsetManifest struct {
 	ServerVersion string              `json:"serverVersion"`
 	ToolsManifest map[string]Manifest `json:"tools"`
@@ -44,7 +49,7 @@ func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool
 	// finish toolset setup
 	// Check each declared tool name exists
 	var toolset Toolset
-	toolset.Name = t.Name
+	toolset.ToolsetConfig = t
 	if !IsValidName(toolset.Name) {
 		return toolset, fmt.Errorf("invalid toolset name: %s", toolset.Name)
 	}


### PR DESCRIPTION
- enforce toolset membership checks for MCP tools/call and prompts/get in all supported protocol versions
- add helper logic to validate membership using toolset/promptset entries
- add a regression test for toolset-scoped tools/call
- Fixes #2755 
-  Testing- go test ./internal/server -run TestMcpEndpoint