### PR TITLE
chore: release hugo update

### DIFF
--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -52,6 +52,10 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 # The order of versions in this file is mirrored into the dropdown
 
 [[params.versions]]
+  version = "v0.30.0"
+  url = "https://googleapis.github.io/genai-toolbox/v0.30.0/"
+
+[[params.versions]]
   version = "v0.29.0"
   url = "https://googleapis.github.io/genai-toolbox/v0.29.0/"
 


### PR DESCRIPTION
update hugo.toml for 0.30.0 release