### PR TITLE
feat: add PUT endpoint for admin api

### DIFF
--- a/cmd/internal/invoke/command.go
+++ b/cmd/internal/invoke/command.go
@@ -71,7 +71,7 @@ func runInvoke(cmd *cobra.Command, args []string, opts *internal.ToolboxOptions)
 		return errMsg
 	}
 
-	resourceMgr := resources.NewResourceManager(sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap)
+	resourceMgr := resources.NewResourceManager(opts.Cfg.Version, sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap)
 
 	// Execute Tool
 	toolName := args[0]

--- a/cmd/internal/skills/command.go
+++ b/cmd/internal/skills/command.go
@@ -229,7 +229,7 @@ func (c *skillsCmd) collectTools(ctx context.Context, opts *internal.ToolboxOpti
 		return nil, fmt.Errorf("failed to initialize resources: %w", err)
 	}
 
-	resourceMgr := resources.NewResourceManager(sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap)
+	resourceMgr := resources.NewResourceManager(opts.Cfg.Version, sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap)
 
 	skillsToTools := make(map[string]map[string]tools.Tool)
 

--- a/cmd/internal/skills/generator_test.go
+++ b/cmd/internal/skills/generator_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 	"go.opentelemetry.io/otel/trace"
@@ -175,7 +175,7 @@ func TestFormatParameters(t *testing.T) {
 
 func TestGenerateSkillMarkdown(t *testing.T) {
 	toolsMap := map[string]tools.Tool{
-		"tool1": server.MockTool{
+		"tool1": testutils.MockTool{
 			Description: "First tool",
 			Params: []parameters.Parameter{
 				parameters.NewStringParameter("p1", "d1"),

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/snowflakedb/gosnowflake v1.19.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/cockroachdb v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/couchbase v0.41.0
@@ -239,7 +240,6 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/internal/prompts/promptsets.go
+++ b/internal/prompts/promptsets.go
@@ -36,33 +36,41 @@ func (p Promptset) ToConfig() PromptsetConfig {
 	return p.PromptsetConfig
 }
 
+func (ps *Promptset) Initialize(serverVersion string, promptsMap map[string]Prompt) error {
+	ps.Prompts = make([]*Prompt, 0, len(ps.PromptNames))
+	ps.McpManifest = make([]McpManifest, 0, len(ps.PromptNames))
+	ps.Manifest = PromptsetManifest{
+		ServerVersion:   serverVersion,
+		PromptsManifest: make(map[string]Manifest, len(ps.PromptNames)),
+	}
+	for _, promptName := range ps.PromptNames {
+		prompt, ok := promptsMap[promptName]
+		if !ok {
+			return fmt.Errorf("prompt does not exist: %s", promptName)
+		}
+		p := prompt
+		ps.Prompts = append(ps.Prompts, &p)
+		ps.Manifest.PromptsManifest[promptName] = prompt.Manifest()
+		ps.McpManifest = append(ps.McpManifest, prompt.McpManifest())
+	}
+	return nil
+}
+
 type PromptsetManifest struct {
 	ServerVersion   string              `json:"serverVersion"`
 	PromptsManifest map[string]Manifest `json:"prompts"`
 }
 
-func (t PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]Prompt) (Promptset, error) {
+func (p PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]Prompt) (Promptset, error) {
 	// Check each declared prompt name exists
-	var promptset Promptset
-	promptset.Name = t.Name
+	promptset := &Promptset{PromptsetConfig: p}
+	promptset.Name = p.Name
 	if !tools.IsValidName(promptset.Name) {
-		return promptset, fmt.Errorf("invalid promptset name: %s", promptset.Name)
+		return *promptset, fmt.Errorf("invalid promptset name: %s", promptset.Name)
 	}
-	promptset.Prompts = make([]*Prompt, 0, len(t.PromptNames))
-	promptset.McpManifest = make([]McpManifest, 0, len(t.PromptNames))
-	promptset.Manifest = PromptsetManifest{
-		ServerVersion:   serverVersion,
-		PromptsManifest: make(map[string]Manifest, len(t.PromptNames)),
+	err := promptset.Initialize(serverVersion, promptsMap)
+	if err != nil {
+		return *promptset, err
 	}
-	for _, promptName := range t.PromptNames {
-		prompt, ok := promptsMap[promptName]
-		if !ok {
-			return promptset, fmt.Errorf("prompt does not exist: %s", promptName)
-		}
-		promptset.Prompts = append(promptset.Prompts, &prompt)
-		promptset.Manifest.PromptsManifest[promptName] = prompt.Manifest()
-		promptset.McpManifest = append(promptset.McpManifest, prompt.McpManifest())
-	}
-
-	return promptset, nil
+	return *promptset, nil
 }

--- a/internal/prompts/promptsets_test.go
+++ b/internal/prompts/promptsets_test.go
@@ -93,7 +93,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			},
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "default",
+					Name:        "default",
+					PromptNames: []string{"prompt1", "prompt2"},
 				},
 				Prompts: []*prompts.Prompt{
 					prompt1Ptr,
@@ -121,7 +122,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			},
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "single",
+					Name:        "single",
+					PromptNames: []string{"prompt1"},
 				},
 				Prompts: []*prompts.Prompt{
 					prompt1Ptr,
@@ -144,7 +146,7 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 				Name:        "invalid name", // Contains a space
 				PromptNames: []string{"prompt1"},
 			},
-			want:    prompts.Promptset{PromptsetConfig: prompts.PromptsetConfig{Name: "invalid name"}}, // Expect partial struct
+			want:    prompts.Promptset{PromptsetConfig: prompts.PromptsetConfig{Name: "invalid name", PromptNames: []string{"prompt1"}}}, // Expect partial struct
 			wantErr: "invalid promptset name",
 		},
 		{
@@ -156,7 +158,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			// Expect partial struct with fields populated up to the error
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "missing_prompt",
+					Name:        "missing_prompt",
+					PromptNames: []string{"prompt1", "prompt_does_not_exist"},
 				},
 				Prompts: []*prompts.Prompt{
 					prompt1Ptr,
@@ -181,7 +184,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			},
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "empty",
+					Name:        "empty",
+					PromptNames: []string{},
 				},
 				Prompts: []*prompts.Prompt{},
 				Manifest: prompts.PromptsetManifest{

--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -15,9 +15,16 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 // adminRouter creates a router that represents the routes under /admin
@@ -28,5 +35,92 @@ func adminRouter(s *Server) (chi.Router, error) {
 	r.Use(middleware.StripSlashes)
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
+	r.Put("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { createOrUpdatePrimitives(s, w, r) })
+
 	return r, nil
+}
+
+// createOrUpdatePrimitives handles the creation or updating of primitives
+// changing name will result in creation of a new primitive instead of replacing
+// existing primitive
+// Invalid primitive kind will result in http.StatusBadRequest
+// Other errors will result in http.StatusInternalServerError
+func createOrUpdatePrimitives(s *Server, w http.ResponseWriter, r *http.Request) {
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+	ctx := r.Context()
+	ctx = util.WithInstrumentation(ctx, s.instrumentation)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		err = fmt.Errorf("unable to read request body: %w", err)
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
+		return
+	}
+	var req struct {
+		Config map[string]any `json:"config"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("unable to unmarshal request body: %w", err)
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
+		return
+	}
+
+	// Attempt to create or update the primitive based on its kind and name
+	var updateErr error
+	switch strings.ToLower(kind) {
+	case "source":
+		c, err := UnmarshalYAMLSourceConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal source config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateSource(ctx, name, c)
+	case "authservice":
+		c, err := UnmarshalYAMLAuthServiceConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal auth service config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateAuthService(ctx, name, c)
+	case "embeddingmodel":
+		c, err := UnmarshalYAMLEmbeddingModelConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal embedding model config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateEmbeddingModel(ctx, name, c)
+	case "tool":
+		c, err := UnmarshalYAMLToolConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal tool config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateTool(ctx, name, c)
+	case "toolset":
+		c, err := UnmarshalYAMLToolsetConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal toolset config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateToolset(ctx, name, c, s.version)
+	case "prompt":
+		c, err := UnmarshalYAMLPromptConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal prompt config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdatePrompt(ctx, name, c)
+	default:
+		err = fmt.Errorf("invalid primitive kind provided")
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
+		return
+	}
+	if updateErr != nil {
+		s.logger.DebugContext(ctx, updateErr.Error())
+		_ = render.Render(w, r, newErrResponse(updateErr, http.StatusInternalServerError))
+		return
+	}
 }

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/googleapis/genai-toolbox/internal/auth"
+	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/genai-toolbox/internal/prompts"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+)
+
+func init() {
+	sources.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (sources.SourceConfig, error) {
+		var c testutils.MockSourceConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	auth.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (auth.AuthServiceConfig, error) {
+		var c testutils.MockAuthServiceConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	embeddingmodels.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (embeddingmodels.EmbeddingModelConfig, error) {
+		var c testutils.MockEmbeddingModelConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	tools.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+		var c testutils.MockToolConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	prompts.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (prompts.PromptConfig, error) {
+		var c testutils.MockPromptConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+}
+
+func TestUpdateEndpoint(t *testing.T) {
+	r, shutdown := setUpServer(t, "admin", map[string]sources.Source{}, map[string]auth.AuthService{}, map[string]embeddingmodels.EmbeddingModel{}, map[string]tools.Tool{}, map[string]tools.Toolset{}, map[string]prompts.Prompt{}, map[string]prompts.Promptset{})
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	tests := []struct {
+		name               string
+		kind               string
+		resourceName       string
+		requestBody        string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Update Source - Success",
+			kind:               "source",
+			resourceName:       "test-source",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Auth Service - Success",
+			kind:               "authService",
+			resourceName:       "test-auth-service",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Embedding Model - Success",
+			kind:               "embeddingModel",
+			resourceName:       "test-embedding-model",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Tool - Success",
+			kind:               "tool",
+			resourceName:       "test-tool",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Toolset - Success",
+			kind:               "toolset",
+			resourceName:       "test-toolset",
+			requestBody:        `{"config": {"name": "test-toolset","tools":["test-tool"]}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Prompt - Success",
+			kind:               "prompt",
+			resourceName:       "test-prompt",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update unknown primitives - Error",
+			kind:               "foo",
+			resourceName:       "test-foo",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body, err := runRequest(ts, http.MethodPut, fmt.Sprintf("/%s/%s", tt.kind, tt.resourceName), bytes.NewBuffer([]byte(tt.requestBody)), nil)
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+			if resp.StatusCode != tt.expectedStatusCode {
+				t.Fatalf("response status code is not %d, got %d, %s", tt.expectedStatusCode, resp.StatusCode, string(body))
+			}
+		})
+	}
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 )
 
 func TestToolsetEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2}
+	mockTools := []testutils.MockTool{tool1, tool2}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
-	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
+	r, shutdown := setUpServer(t, "api", nil, nil, nil, toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -124,9 +125,9 @@ func TestToolsetEndpoint(t *testing.T) {
 }
 
 func TestToolGetEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2}
+	mockTools := []testutils.MockTool{tool1, tool2}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
-	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
+	r, shutdown := setUpServer(t, "api", nil, nil, nil, toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -212,9 +213,9 @@ func TestToolGetEndpoint(t *testing.T) {
 }
 
 func TestToolInvokeEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool4, tool5}
+	mockTools := []testutils.MockTool{tool1, tool2, tool4, tool5}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
-	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
+	r, shutdown := setUpServer(t, "api", nil, nil, nil, toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -26,8 +26,13 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/prompts"
+
+	"github.com/googleapis/genai-toolbox/internal/auth"
+	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
+	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 )
@@ -36,16 +41,16 @@ import (
 const fakeVersionString = "0.0.0"
 
 var (
-	_ tools.Tool     = MockTool{}
-	_ prompts.Prompt = MockPrompt{}
+	_ tools.Tool     = testutils.MockTool{}
+	_ prompts.Prompt = testutils.MockPrompt{}
 )
 
-var tool1 = MockTool{
+var tool1 = testutils.MockTool{
 	Name:   "no_params",
 	Params: []parameters.Parameter{},
 }
 
-var tool2 = MockTool{
+var tool2 = testutils.MockTool{
 	Name: "some_params",
 	Params: parameters.Parameters{
 		parameters.NewIntParameter("param1", "This is the first parameter."),
@@ -53,7 +58,7 @@ var tool2 = MockTool{
 	},
 }
 
-var tool3 = MockTool{
+var tool3 = testutils.MockTool{
 	Name:        "array_param",
 	Description: "some description",
 	Params: parameters.Parameters{
@@ -61,24 +66,24 @@ var tool3 = MockTool{
 	},
 }
 
-var tool4 = MockTool{
+var tool4 = testutils.MockTool{
 	Name:         "unauthorized_tool",
 	Params:       []parameters.Parameter{},
-	unauthorized: true,
+	Unauthorized: true,
 }
 
-var tool5 = MockTool{
-	Name:                         "require_client_auth_tool",
-	Params:                       []parameters.Parameter{},
-	requiresClientAuthrorization: true,
+var tool5 = testutils.MockTool{
+	Name:                "require_client_auth_tool",
+	Params:              []parameters.Parameter{},
+	ClientAuthorization: true,
 }
 
-var prompt1 = MockPrompt{
+var prompt1 = testutils.MockPrompt{
 	Name: "prompt1",
 	Args: prompts.Arguments{},
 }
 
-var prompt2 = MockPrompt{
+var prompt2 = testutils.MockPrompt{
 	Name: "prompt2",
 	Args: prompts.Arguments{
 		{Parameter: parameters.NewStringParameter("arg1", "This is the first argument.")},
@@ -86,11 +91,11 @@ var prompt2 = MockPrompt{
 }
 
 // setUpResources setups resources to test against
-func setUpResources(t *testing.T, mockTools []MockTool, mockPrompts []MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
+func setUpResources(t *testing.T, mockTools []testutils.MockTool, mockPrompts []testutils.MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
 	toolsMap := make(map[string]tools.Tool)
 	var allTools []string
 	for _, tool := range mockTools {
-		tool.manifest = tool.Manifest()
+		tool.ToolManifest = tool.Manifest()
 		toolsMap[tool.Name] = tool
 		allTools = append(allTools, tool.Name)
 	}
@@ -130,7 +135,7 @@ func setUpResources(t *testing.T, mockTools []MockTool, mockPrompts []MockPrompt
 }
 
 // setUpServer create a new server with tools, toolsets, prompts, and promptsets.
-func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, toolsets map[string]tools.Toolset, prompts map[string]prompts.Prompt, promptsets map[string]prompts.Promptset) (chi.Router, func()) {
+func setUpServer(t *testing.T, router string, sources map[string]sources.Source, authServices map[string]auth.AuthService, embeddingModels map[string]embeddingmodels.EmbeddingModel, tools map[string]tools.Tool, toolsets map[string]tools.Toolset, prompts map[string]prompts.Prompt, promptsets map[string]prompts.Promptset) (chi.Router, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
@@ -150,7 +155,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 
 	sseManager := newSseManager(ctx)
 
-	resourceManager := resources.NewResourceManager(nil, nil, nil, tools, toolsets, prompts, promptsets)
+	resourceManager := resources.NewResourceManager("test-version", sources, authServices, embeddingModels, tools, toolsets, prompts, promptsets)
 
 	server := Server{
 		version:         fakeVersionString,

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 )
 
 const jsonrpcVersion = "2.0"
@@ -76,10 +77,10 @@ var prompt2Args = []any{
 }
 
 func TestMcpEndpointWithoutInitialized(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
-	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -421,10 +422,10 @@ func runInitializeLifecycle(t *testing.T, ts *httptest.Server, protocolVersion s
 }
 
 func TestMcpEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
-	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -908,7 +909,7 @@ func TestMcpEndpoint(t *testing.T) {
 }
 
 func TestInvalidProtocolVersionHeader(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -934,7 +935,7 @@ func TestInvalidProtocolVersionHeader(t *testing.T) {
 }
 
 func TestDeleteEndpoint(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -949,7 +950,7 @@ func TestDeleteEndpoint(t *testing.T) {
 }
 
 func TestGetEndpoint(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -972,7 +973,7 @@ func TestGetEndpoint(t *testing.T) {
 }
 
 func TestSseEndpoint(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -1092,8 +1093,8 @@ func TestStdioSession(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockTools := []MockTool{tool1, tool2, tool3}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
 
 	pr, pw, err := os.Pipe()
@@ -1124,7 +1125,7 @@ func TestStdioSession(t *testing.T) {
 
 	sseManager := newSseManager(ctx)
 
-	resourceManager := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	resourceManager := resources.NewResourceManager("test-version", nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
 
 	server := &Server{
 		version:         fakeVersionString,

--- a/internal/server/resources/resources.go
+++ b/internal/server/resources/resources.go
@@ -15,6 +15,9 @@
 package resources
 
 import (
+	"context"
+	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/googleapis/genai-toolbox/internal/auth"
@@ -22,11 +25,27 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/prompts"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/googleapis/genai-toolbox/internal/util"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ResourceKind string
+
+const (
+	KindSource         ResourceKind = "source"
+	KindAuthService    ResourceKind = "authservice"
+	KindEmbeddingModel ResourceKind = "embeddingmodel"
+	KindTool           ResourceKind = "tool"
+	KindToolset        ResourceKind = "toolset"
+	KindPrompt         ResourceKind = "prompt"
+	KindPromptset      ResourceKind = "promptset"
 )
 
 // ResourceManager contains available resources for the server. Should be initialized with NewResourceManager().
 type ResourceManager struct {
 	mu              sync.RWMutex
+	serverVersion   string
 	sources         map[string]sources.Source
 	authServices    map[string]auth.AuthService
 	embeddingModels map[string]embeddingmodels.EmbeddingModel
@@ -37,6 +56,7 @@ type ResourceManager struct {
 }
 
 func NewResourceManager(
+	serverVersion string,
 	sourcesMap map[string]sources.Source,
 	authServicesMap map[string]auth.AuthService,
 	embeddingModelsMap map[string]embeddingmodels.EmbeddingModel,
@@ -46,6 +66,7 @@ func NewResourceManager(
 ) *ResourceManager {
 	resourceMgr := &ResourceManager{
 		mu:              sync.RWMutex{},
+		serverVersion:   serverVersion,
 		sources:         sourcesMap,
 		authServices:    authServicesMap,
 		embeddingModels: embeddingModelsMap,
@@ -56,6 +77,18 @@ func NewResourceManager(
 	}
 
 	return resourceMgr
+}
+
+func (r *ResourceManager) SetResources(sourcesMap map[string]sources.Source, authServicesMap map[string]auth.AuthService, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel, toolsMap map[string]tools.Tool, toolsetsMap map[string]tools.Toolset, promptsMap map[string]prompts.Prompt, promptsetsMap map[string]prompts.Promptset) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sources = sourcesMap
+	r.authServices = authServicesMap
+	r.embeddingModels = embeddingModelsMap
+	r.tools = toolsMap
+	r.toolsets = toolsetsMap
+	r.prompts = promptsMap
+	r.promptsets = promptsetsMap
 }
 
 func (r *ResourceManager) GetSource(sourceName string) (sources.Source, bool) {
@@ -107,18 +140,6 @@ func (r *ResourceManager) GetPromptset(promptsetName string) (prompts.Promptset,
 	return promptset, ok
 }
 
-func (r *ResourceManager) SetResources(sourcesMap map[string]sources.Source, authServicesMap map[string]auth.AuthService, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel, toolsMap map[string]tools.Tool, toolsetsMap map[string]tools.Toolset, promptsMap map[string]prompts.Prompt, promptsetsMap map[string]prompts.Promptset) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.sources = sourcesMap
-	r.authServices = authServicesMap
-	r.embeddingModels = embeddingModelsMap
-	r.tools = toolsMap
-	r.toolsets = toolsetsMap
-	r.prompts = promptsMap
-	r.promptsets = promptsetsMap
-}
-
 func (r *ResourceManager) GetAuthServiceMap() map[string]auth.AuthService {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -157,4 +178,231 @@ func (r *ResourceManager) GetPromptsMap() map[string]prompts.Prompt {
 		copiedMap[k] = v
 	}
 	return copiedMap
+}
+
+// UpdateSource creates or update source.
+func (r *ResourceManager) UpdateSource(ctx context.Context, name string, config sources.SourceConfig) error {
+	primitive, exist := r.GetSource(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	childCtx, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/source/init",
+		trace.WithAttributes(attribute.String("source_type", config.SourceConfigType())),
+		trace.WithAttributes(attribute.String("source_name", name)),
+	)
+	defer span.End()
+	s, err := config.Initialize(childCtx, instrumentation.Tracer)
+	if err != nil {
+		return fmt.Errorf("unable to initialize source %q: %w", name, err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sources[name] = s
+	return nil
+}
+
+// UpdateAuthService creates or update auth service.
+func (r *ResourceManager) UpdateAuthService(ctx context.Context, name string, config auth.AuthServiceConfig) error {
+	primitive, exist := r.GetAuthService(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/auth/init",
+		trace.WithAttributes(attribute.String("auth_type", config.AuthServiceConfigType())),
+		trace.WithAttributes(attribute.String("auth_name", name)),
+	)
+	defer span.End()
+	as, err := config.Initialize()
+	if err != nil {
+		return fmt.Errorf("unable to initialize auth service %q: %w", name, err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.authServices[name] = as
+	return nil
+}
+
+// UpdateEmbeddingModel creates or update embedding model.
+func (r *ResourceManager) UpdateEmbeddingModel(ctx context.Context, name string, config embeddingmodels.EmbeddingModelConfig) error {
+	primitive, exist := r.GetEmbeddingModel(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/embeddingmodel/init",
+		trace.WithAttributes(attribute.String("model_type", config.EmbeddingModelConfigType())),
+		trace.WithAttributes(attribute.String("model_name", name)),
+	)
+	defer span.End()
+	em, err := config.Initialize(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to initialize embedding model %q: %w", name, err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.embeddingModels[name] = em
+	return nil
+}
+
+// UpdateTool creates or update tool.
+func (r *ResourceManager) UpdateTool(ctx context.Context, name string, config tools.ToolConfig) error {
+	primitive, exist := r.GetTool(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/tool/init",
+		trace.WithAttributes(attribute.String("tool_type", config.ToolConfigType())),
+		trace.WithAttributes(attribute.String("tool_name", name)),
+	)
+	defer span.End()
+	t, err := config.Initialize(r.sources)
+	if err != nil {
+		return fmt.Errorf("unable to initialize tool %q: %w", name, err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// update the default toolset - this will update list manifests
+	defaultToolset := r.toolsets[""]
+	// only need to append toolName if tool does not currently exist
+	if !exist {
+		defaultToolset.ToolNames = append(defaultToolset.ToolNames, name)
+	}
+	r.tools[name] = t
+	err = defaultToolset.Initialize(r.serverVersion, r.tools)
+	if err != nil {
+		delete(r.tools, name)
+		return fmt.Errorf("error updating toolset: %w", err)
+	}
+	r.toolsets[""] = defaultToolset
+	return nil
+}
+
+// UpdateToolset creates or update toolset.
+func (r *ResourceManager) UpdateToolset(ctx context.Context, name string, config tools.ToolsetConfig, version string) error {
+	primitive, exist := r.GetToolset(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/toolset/init",
+		trace.WithAttributes(attribute.String("toolset.name", name)),
+	)
+	defer span.End()
+	ts, err := config.Initialize(version, r.tools)
+	if err != nil {
+		return fmt.Errorf("unable to initialize toolset %q: %w", name, err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.toolsets[name] = ts
+	return nil
+}
+
+// UpdatePrompt creates or update prompt.
+func (r *ResourceManager) UpdatePrompt(ctx context.Context, name string, config prompts.PromptConfig) error {
+	primitive, exist := r.GetPrompt(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/prompt/init",
+		trace.WithAttributes(attribute.String("prompt_type", config.PromptConfigType())),
+		trace.WithAttributes(attribute.String("prompt_name", name)),
+	)
+	defer span.End()
+	p, err := config.Initialize()
+	if err != nil {
+		return fmt.Errorf("unable to initialize prompt %q: %w", name, err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// update the default promptset - this will update list manifests
+	defaultPromptset := r.promptsets[""]
+	// only need to append promptNames if prompt does not currently exist
+	if !exist {
+		defaultPromptset.PromptNames = append(defaultPromptset.PromptNames, name)
+	}
+	r.prompts[name] = p
+	err = defaultPromptset.Initialize(r.serverVersion, r.prompts)
+	if err != nil {
+		delete(r.prompts, name)
+		return fmt.Errorf("error updating promptset: %w", err)
+	}
+	r.promptsets[""] = defaultPromptset
+	return nil
 }

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -15,6 +15,8 @@
 package resources_test
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,7 +26,11 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
+	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/googleapis/genai-toolbox/internal/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateServer(t *testing.T) {
@@ -56,7 +62,7 @@ func TestUpdateServer(t *testing.T) {
 			Prompts: []*prompts.Prompt{},
 		},
 	}
-	resMgr := resources.NewResourceManager(newSources, newAuth, newEmbeddingModels, newTools, newToolsets, newPrompts, newPromptsets)
+	resMgr := resources.NewResourceManager("test-version", newSources, newAuth, newEmbeddingModels, newTools, newToolsets, newPrompts, newPromptsets)
 
 	gotSource, _ := resMgr.GetSource("example-source")
 	if diff := cmp.Diff(gotSource, newSources["example-source"]); diff != "" {
@@ -101,5 +107,152 @@ func TestUpdateServer(t *testing.T) {
 	gotSource, _ = resMgr.GetSource("example-source2")
 	if diff := cmp.Diff(gotSource, updateSource["example-source2"]); diff != "" {
 		t.Errorf("error updating server, sources (-want +got):\n%s", diff)
+	}
+}
+
+func TestCreateAndUpdatePrimitives(t *testing.T) {
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation("test-version")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	ctx := context.Background()
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+	resMgr := resources.NewResourceManager(
+		"test-version",
+		map[string]sources.Source{},
+		map[string]auth.AuthService{},
+		map[string]embeddingmodels.EmbeddingModel{},
+		map[string]tools.Tool{},
+		map[string]tools.Toolset{},
+		map[string]prompts.Prompt{},
+		map[string]prompts.Promptset{},
+	)
+
+	// create primitives
+	sourceConfig := &testutils.MockSourceConfig{}
+	err = resMgr.UpdateSource(ctx, "test-source", sourceConfig)
+	assert.NoError(t, err)
+	_, ok := resMgr.GetSource("test-source")
+	if !ok {
+		t.Fatalf("missing source")
+	}
+
+	asConfig := &testutils.MockAuthServiceConfig{}
+	err = resMgr.UpdateAuthService(ctx, "test-auth-service", asConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetAuthService("test-auth-service")
+	if !ok {
+		t.Fatalf("missing auth service")
+	}
+
+	emConfig := &testutils.MockEmbeddingModelConfig{}
+	err = resMgr.UpdateEmbeddingModel(ctx, "test-embedding-model", emConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetEmbeddingModel("test-embedding-model")
+	if !ok {
+		t.Fatalf("missing embedding model")
+	}
+
+	toolConfig := &testutils.MockToolConfig{}
+	err = resMgr.UpdateTool(ctx, "test-tool", toolConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetTool("test-tool")
+	if !ok {
+		t.Fatalf("missing tool")
+	}
+
+	tsConfig := tools.ToolsetConfig{
+		Name:      "test-toolset",
+		ToolNames: []string{},
+	}
+	err = resMgr.UpdateToolset(ctx, "test-toolset", tsConfig, "test-version")
+	assert.NoError(t, err)
+	_, ok = resMgr.GetToolset("test-toolset")
+	if !ok {
+		t.Fatalf("missing toolset")
+	}
+
+	pConfig := &testutils.MockPromptConfig{}
+	err = resMgr.UpdatePrompt(ctx, "test-prompt", pConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetPrompt("test-prompt")
+	if !ok {
+		t.Fatalf("missing prompt")
+	}
+
+	// Update primitives
+	sourceConfig = &testutils.MockSourceConfig{Foo: "foo"}
+	err = resMgr.UpdateSource(ctx, "test-source", sourceConfig)
+	assert.NoError(t, err)
+	source, ok := resMgr.GetSource("test-source")
+	if !ok {
+		t.Fatalf("missing source")
+	}
+	sc := source.ToConfig()
+	if !reflect.DeepEqual(sc, sourceConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", sc, sourceConfig)
+	}
+
+	asConfig = &testutils.MockAuthServiceConfig{}
+	err = resMgr.UpdateAuthService(ctx, "test-auth-service", asConfig)
+	assert.NoError(t, err)
+	as, ok := resMgr.GetAuthService("test-auth-service")
+	if !ok {
+		t.Fatalf("missing auth service")
+	}
+	asc := as.ToConfig()
+	if !reflect.DeepEqual(asc, asConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", asc, asConfig)
+	}
+
+	emConfig = &testutils.MockEmbeddingModelConfig{}
+	err = resMgr.UpdateEmbeddingModel(ctx, "test-embedding-model", emConfig)
+	assert.NoError(t, err)
+	em, ok := resMgr.GetEmbeddingModel("test-embedding-model")
+	if !ok {
+		t.Fatalf("missing embedding model")
+	}
+	emc := em.ToConfig()
+	if !reflect.DeepEqual(emc, emConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", emc, emConfig)
+	}
+
+	toolConfig = &testutils.MockToolConfig{}
+	err = resMgr.UpdateTool(ctx, "test-tool", toolConfig)
+	assert.NoError(t, err)
+	tool, ok := resMgr.GetTool("test-tool")
+	if !ok {
+		t.Fatalf("missing tool")
+	}
+	tc := tool.ToConfig()
+	if !reflect.DeepEqual(tc, toolConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", tc, toolConfig)
+	}
+
+	tsConfig = tools.ToolsetConfig{
+		Name:      "test-toolset",
+		ToolNames: []string{"test-tool"},
+	}
+	err = resMgr.UpdateToolset(ctx, "test-toolset", tsConfig, "test-version")
+	assert.NoError(t, err)
+	ts, ok := resMgr.GetToolset("test-toolset")
+	if !ok {
+		t.Fatalf("missing toolset")
+	}
+	tsc := ts.ToConfig()
+	if !reflect.DeepEqual(tsc, tsConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", tsc, tsConfig)
+	}
+
+	pConfig = &testutils.MockPromptConfig{}
+	err = resMgr.UpdatePrompt(ctx, "test-prompt", pConfig)
+	assert.NoError(t, err)
+	p, ok := resMgr.GetPrompt("test-prompt")
+	if !ok {
+		t.Fatalf("missing prompt")
+	}
+	pc := p.ToConfig()
+	if !reflect.DeepEqual(pc, pConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", pc, pConfig)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -374,7 +374,7 @@ func NewServer(ctx context.Context, cfg ServerConfig, enableAdmin bool) (*Server
 
 	sseManager := newSseManager(ctx)
 
-	resourceManager := resources.NewResourceManager(sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap)
+	resourceManager := resources.NewResourceManager(cfg.Version, sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap)
 
 	s := &Server{
 		version:         cfg.Version,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -327,7 +327,7 @@ func TestPRMEndpoint(t *testing.T) {
 	}
 
 	// Initialize and start the server
-	s, err := server.NewServer(ctx, cfg)
+	s, err := server.NewServer(ctx, cfg, false)
 	if err != nil {
 		t.Fatalf("unable to initialize server: %v", err)
 	}
@@ -429,7 +429,7 @@ func TestPRMOverride(t *testing.T) {
 	}
 
 	// Initialize and Start the Server
-	s, err := server.NewServer(ctx, cfg)
+	s, err := server.NewServer(ctx, cfg, false)
 	if err != nil {
 		t.Fatalf("unable to initialize server: %v", err)
 	}

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -12,27 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package testutils
 
 import (
 	"context"
 	"fmt"
+	"net/http"
 
+	"github.com/googleapis/genai-toolbox/internal/auth"
 	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/genai-toolbox/internal/prompts"
+	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
+	"go.opentelemetry.io/otel/trace"
 )
+
+type MockSource struct {
+	MockSourceConfig
+	Name string
+}
+
+func (s MockSource) SourceType() string {
+	return "mock"
+}
+
+func (s MockSource) ToConfig() sources.SourceConfig {
+	return &s.MockSourceConfig
+}
+
+type MockAuthService struct {
+	MockAuthServiceConfig
+	Name string
+}
+
+func (a MockAuthService) AuthServiceType() string {
+	return "mock"
+}
+
+func (a MockAuthService) GetName() string {
+	return a.Name
+}
+
+func (a MockAuthService) GetClaimsFromHeader(ctx context.Context, h http.Header) (map[string]any, error) {
+	return nil, nil
+}
+
+func (a MockAuthService) ToConfig() auth.AuthServiceConfig {
+	return &a.MockAuthServiceConfig
+}
+
+type MockEmbeddingModel struct {
+	MockEmbeddingModelConfig
+	Name string
+}
+
+func (e MockEmbeddingModel) EmbeddingModelType() string {
+	return "mock"
+}
+
+func (e MockEmbeddingModel) ToConfig() embeddingmodels.EmbeddingModelConfig {
+	return &e.MockEmbeddingModelConfig
+}
+
+func (e MockEmbeddingModel) EmbedParameters(ctx context.Context, t []string) ([][]float32, error) {
+	return nil, nil
+}
 
 // MockTool is used to mock tools in tests
 type MockTool struct {
-	Name                         string
-	Description                  string
-	Params                       []parameters.Parameter
-	manifest                     tools.Manifest
-	unauthorized                 bool
-	requiresClientAuthrorization bool
+	MockToolConfig
+	Name                string
+	Description         string
+	Params              []parameters.Parameter
+	ToolManifest        tools.Manifest
+	Unauthorized        bool
+	ClientAuthorization bool
 }
 
 func (t MockTool) Invoke(context.Context, tools.SourceProvider, parameters.ParamValues, tools.AccessToken) (any, util.ToolboxError) {
@@ -41,7 +97,7 @@ func (t MockTool) Invoke(context.Context, tools.SourceProvider, parameters.Param
 }
 
 func (t MockTool) ToConfig() tools.ToolConfig {
-	return nil
+	return &t.MockToolConfig
 }
 
 // claims is a map of user info decoded from an auth token
@@ -63,12 +119,12 @@ func (t MockTool) Manifest() tools.Manifest {
 
 func (t MockTool) Authorized(verifiedAuthServices []string) bool {
 	// defaulted to true
-	return !t.unauthorized
+	return !t.Unauthorized
 }
 
 func (t MockTool) RequiresClientAuthorization(tools.SourceProvider) (bool, error) {
 	// defaulted to false
-	return t.requiresClientAuthrorization, nil
+	return t.ClientAuthorization, nil
 }
 
 func (t MockTool) GetParameters() parameters.Parameters {
@@ -118,6 +174,7 @@ func (t MockTool) GetAuthTokenHeaderName(tools.SourceProvider) (string, error) {
 
 // MockPrompt is used to mock prompts in tests
 type MockPrompt struct {
+	MockPromptConfig
 	Name        string
 	Description string
 	Args        prompts.Arguments
@@ -156,5 +213,79 @@ func (p MockPrompt) McpManifest() prompts.McpManifest {
 }
 
 func (p MockPrompt) ToConfig() prompts.PromptConfig {
-	return nil
+	return &p.MockPromptConfig
+}
+
+type MockSourceConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockSourceConfig) SourceConfigType() string {
+	return "mock"
+}
+
+func (m *MockSourceConfig) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
+	return MockSource{MockSourceConfig: *m}, nil
+}
+
+type MockAuthServiceConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockAuthServiceConfig) AuthServiceConfigType() string {
+	return "mock"
+}
+
+func (m *MockAuthServiceConfig) Initialize() (auth.AuthService, error) {
+	return MockAuthService{MockAuthServiceConfig: *m}, nil
+}
+
+type MockEmbeddingModelConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockEmbeddingModelConfig) EmbeddingModelConfigType() string {
+	return "mock"
+}
+
+func (m *MockEmbeddingModelConfig) Initialize(ctx context.Context) (embeddingmodels.EmbeddingModel, error) {
+	return MockEmbeddingModel{MockEmbeddingModelConfig: *m}, nil
+}
+
+type MockToolConfig struct {
+	Foo          string   `yaml:"foo"`
+	Type         string   `yaml:"type"`
+	AuthRequired []string `yaml:"authRequired"`
+}
+
+func (m *MockToolConfig) ToolConfigType() string {
+	return "mock"
+}
+
+func (m *MockToolConfig) Initialize(map[string]sources.Source) (tools.Tool, error) {
+	return MockTool{MockToolConfig: *m}, nil
+}
+
+type MockToolsetConfig struct {
+	tools.ToolsetConfig
+}
+
+func (m *MockToolsetConfig) Initialize(serverVersion string, toolsMap map[string]tools.Tool) (tools.Toolset, error) {
+	return tools.Toolset{ToolsetConfig: m.ToolsetConfig}, nil
+}
+
+type MockPromptConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockPromptConfig) PromptConfigType() string {
+	return "mock"
+}
+
+func (m *MockPromptConfig) Initialize() (prompts.Prompt, error) {
+	return MockPrompt{MockPromptConfig: *m}, nil
 }

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
@@ -39,7 +38,10 @@ func FormatYaml(in string) []byte {
 // ContextWithNewLogger create a new context with new logger
 func ContextWithNewLogger() (context.Context, error) {
 	ctx := context.Background()
-	logger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	defer pr.Close()
+	logger, err := log.NewStdLogger(pw, pw, "info")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create logger: %s", err)
 	}

--- a/internal/tools/cloudgda/cloudgda_test.go
+++ b/internal/tools/cloudgda/cloudgda_test.go
@@ -269,7 +269,7 @@ func TestInvoke(t *testing.T) {
 		{Name: "query", Value: query},
 	}
 
-	resourceMgr := resources.NewResourceManager(srcs, nil, nil, nil, nil, nil, nil)
+	resourceMgr := resources.NewResourceManager("test-version", srcs, nil, nil, nil, nil, nil, nil)
 
 	ctx := testutils.ContextWithUserAgent(context.Background(), "test-user-agent")
 

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -35,6 +35,25 @@ func (t Toolset) ToConfig() ToolsetConfig {
 	return t.ToolsetConfig
 }
 
+func (ts *Toolset) Initialize(serverVersion string, toolsMap map[string]Tool) error {
+	ts.Tools = make([]*Tool, 0, len(ts.ToolNames))
+	ts.Manifest = ToolsetManifest{
+		ServerVersion: serverVersion,
+		ToolsManifest: make(map[string]Manifest),
+	}
+	for _, toolName := range ts.ToolNames {
+		tool, ok := toolsMap[toolName]
+		if !ok {
+			return fmt.Errorf("tool does not exist: %s", toolName)
+		}
+		t := tool
+		ts.Tools = append(ts.Tools, &t)
+		ts.Manifest.ToolsManifest[toolName] = tool.Manifest()
+		ts.McpManifest = append(ts.McpManifest, tool.McpManifest())
+	}
+	return nil
+}
+
 type ToolsetManifest struct {
 	ServerVersion string              `json:"serverVersion"`
 	ToolsManifest map[string]Manifest `json:"tools"`
@@ -43,27 +62,16 @@ type ToolsetManifest struct {
 func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool) (Toolset, error) {
 	// finish toolset setup
 	// Check each declared tool name exists
-	var toolset Toolset
+	toolset := &Toolset{ToolsetConfig: t}
 	toolset.Name = t.Name
 	if !IsValidName(toolset.Name) {
-		return toolset, fmt.Errorf("invalid toolset name: %s", toolset.Name)
+		return *toolset, fmt.Errorf("invalid toolset name: %s", toolset.Name)
 	}
-	toolset.Tools = make([]*Tool, 0, len(t.ToolNames))
-	toolset.Manifest = ToolsetManifest{
-		ServerVersion: serverVersion,
-		ToolsManifest: make(map[string]Manifest),
+	err := toolset.Initialize(serverVersion, toolsMap)
+	if err != nil {
+		return *toolset, err
 	}
-	for _, toolName := range t.ToolNames {
-		tool, ok := toolsMap[toolName]
-		if !ok {
-			return toolset, fmt.Errorf("tool does not exist: %s", toolName)
-		}
-		toolset.Tools = append(toolset.Tools, &tool)
-		toolset.Manifest.ToolsManifest[toolName] = tool.Manifest()
-		toolset.McpManifest = append(toolset.McpManifest, tool.McpManifest())
-	}
-
-	return toolset, nil
+	return *toolset, nil
 }
 
 var validName = regexp.MustCompile(`^[a-zA-Z0-9_-]*$`)


### PR DESCRIPTION
Support put endpoint for `/admin` api. 

This endpoint will create (if primitive not yet existed) or update primitive.
_Note: Updating name does not work. This endpoint will create a new primitive._


This PR also does the following: 
* move `internal/server/mock.go` to `internal/testutils/mock.go` so that it can be shared by other tests.
* create new mocks for each primitive configs.
* move the `Promptset` and `Toolset` initialize into a separate function. This will allow us to run Promptset and Toolset initialize (to update manifest) after updating the tools or prompts list