### PR TITLE
chore: adjust looker integration test for possible race state in Looker

### DIFF
--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -1958,20 +1958,21 @@ func TestLooker(t *testing.T) {
 	wantResult = "master"
 	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(`{"operation": "list", "project_id": "the_look"}`), wantResult)
 
-	wantResult = "test_branch"
-	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(`{"operation": "create", "project_id": "the_look", "branch": "test_branch"}`), wantResult)
+	wantResult = fmt.Sprintf("test_branch_%s", randstr)
+	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(fmt.Sprintf(`{"operation": "create", "project_id": "the_look", "branch": "test_branch_%s"}`, randstr)), wantResult)
 
+	time.Sleep(5 * time.Second)
 	wantResult = "d2d4eafdf8932837b2a12b773282c165a43fb0c0"
-	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(`{"operation": "switch", "project_id": "the_look", "branch": "test_branch", "ref": "d2d4eafdf8932837b2a12b773282c165a43fb0c0"}`), wantResult)
+	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(fmt.Sprintf(`{"operation": "switch", "project_id": "the_look", "branch": "test_branch_%s", "ref": "d2d4eafdf8932837b2a12b773282c165a43fb0c0"}`, randstr)), wantResult)
 
-	wantResult = "test_branch"
+	wantResult = fmt.Sprintf("test_branch_%s", randstr)
 	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(`{"operation": "get", "project_id": "the_look"}`), wantResult)
 
 	wantResult = "dev-mike-deangelo-twqb"
 	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(`{"operation": "switch", "project_id": "the_look", "branch": "dev-mike-deangelo-twqb"}`), wantResult)
 
 	wantResult = "Deleted"
-	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(`{"operation": "delete", "project_id": "the_look", "branch": "test_branch"}`), wantResult)
+	tests.RunToolInvokeParametersTest(t, "project_git_branch", []byte(fmt.Sprintf(`{"operation": "delete", "project_id": "the_look", "branch": "test_branch_%s"}`, randstr)), wantResult)
 
 	wantResult = "[]"
 	tests.RunToolInvokeParametersTest(t, "get_lookml_tests", []byte(`{"project_id": "the_look"}`), wantResult)


### PR DESCRIPTION
## Description

Add sleep in integration test to work around possible race state in Looker.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes # issue reported by @Yuan325 
