### PR TITLE
Fix: Prevent integer to float conversion for tool parameters invoked via agent skills

### DIFF
--- a/cmd/internal/invoke/command.go
+++ b/cmd/internal/invoke/command.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/googleapis/genai-toolbox/cmd/internal"
 	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 	"github.com/spf13/cobra"
 )
@@ -87,7 +89,7 @@ func runInvoke(cmd *cobra.Command, args []string, opts *internal.ToolboxOptions)
 
 	params := make(map[string]any)
 	if paramsInput != "" {
-		if err := json.Unmarshal([]byte(paramsInput), &params); err != nil {
+		if err := util.DecodeJSON(strings.NewReader(paramsInput), &params); err != nil {
 			errMsg := fmt.Errorf("params must be a valid JSON string: %w", err)
 			opts.Logger.ErrorContext(ctx, errMsg.Error())
 			return errMsg


### PR DESCRIPTION
## Description
This PR addresses a bug where tools fail to execute due to a type mismatch error when integer parameters are provided. Crucially, this issue only occurs when the tool is invoked through agent skills; it does not happen when the tools are executed directly. When an agent skill routes a payload via the Gemini CLI, JSON integers are incorrectly unmarshalled as floats before being passed down to the underlying tool.

**Steps to Reproduce**:

Activate an agent skill (e.g., cloud-sql-postgres-data from the cloud-sql-postgresql extensions) via the Gemini CLI.

Invoke a tool that requires an integer parameter (like list_indexes) using a natural language prompt, such as:

"List all the indexes in the database, max limit of rows is 2"

The Gemini CLI agent internally constructs and executes the following command:


```node /usr/local/google/home/pavanrampalli/.gemini/extensions/cloud-sql-postgresql/skills/cloud-sql-postgres-data/scripts/list_indexes.js '{"limit": 2}'```
The execution fails because the tool expects an integer for the limit parameter, but the agent's request parser has converted and passed it as a float.

**Root Cause**:
Upon investigation of the agent skill invocation path, the standard json.Unmarshal function defaults to parsing all JSON numbers as float64. When this parsed request is handed off to a tool that strictly enforces an integer type, it triggers a validation error.

**Proposed Solution**:
Replaced the standard json.Unmarshal with util.DecodeJSON specifically within the request unmarshalling logic for agent skills. This ensures that numeric types are decoded accurately and integers are preserved without being implicitly converted to floats before reaching the tools.
> Should include a concise description of the changes (bug or feature), it's
> impact, along with a summary of the solution

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/genai-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/genai-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
