### PR TITLE
feat: add DELETE endpoint for admin endpoint

### DIFF
--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -36,8 +36,31 @@ func adminRouter(s *Server) (chi.Router, error) {
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
 	r.Put("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { createOrUpdatePrimitives(s, w, r) })
+	r.Delete("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { deletePrimitives(s, w, r) })
 
 	return r, nil
+}
+
+// deletePrimitives handles the deletion of primitives
+// Invalid primitive kind will result in http.StatusBadRequest
+// Primitive not found will result in http.StatusNotFound
+func deletePrimitives(s *Server, w http.ResponseWriter, r *http.Request) {
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+
+	if err := s.ResourceMgr.Delete(kind, name); err != nil {
+		s.logger.DebugContext(r.Context(), err.Error())
+
+		// Determine status code based on error message/type
+		status := http.StatusNotFound
+		if strings.Contains(err.Error(), "invalid primitive kind provided") {
+			status = http.StatusBadRequest
+		}
+
+		_ = render.Render(w, r, newErrResponse(err, status))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // createOrUpdatePrimitives handles the creation or updating of primitives

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -68,7 +68,7 @@ func init() {
 	})
 }
 
-func TestUpdateEndpoint(t *testing.T) {
+func TestAdminUpdateEndpoint(t *testing.T) {
 	r, shutdown := setUpServer(t, "admin", map[string]sources.Source{}, map[string]auth.AuthService{}, map[string]embeddingmodels.EmbeddingModel{}, map[string]tools.Tool{}, map[string]tools.Toolset{}, map[string]prompts.Prompt{}, map[string]prompts.Promptset{})
 	defer shutdown()
 	ts := runServer(r, false)
@@ -135,6 +135,88 @@ func TestUpdateEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp, body, err := runRequest(ts, http.MethodPut, fmt.Sprintf("/%s/%s", tt.kind, tt.resourceName), bytes.NewBuffer([]byte(tt.requestBody)), nil)
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+			if resp.StatusCode != tt.expectedStatusCode {
+				t.Fatalf("response status code is not %d, got %d, %s", tt.expectedStatusCode, resp.StatusCode, string(body))
+			}
+		})
+	}
+}
+
+func TestAdminDeleteEndpoint(t *testing.T) {
+	mockSources := map[string]sources.Source{"test-source": testutils.MockSource{}}
+	mockAuthServices := map[string]auth.AuthService{"test-auth-service": testutils.MockAuthService{}}
+	mockEmbeddingModel := map[string]embeddingmodels.EmbeddingModel{"test-embedding-model": testutils.MockEmbeddingModel{}}
+	mockTool := map[string]tools.Tool{"test-tool": testutils.MockTool{}}
+	mockToolset := map[string]tools.Toolset{"test-toolset": tools.Toolset{}, "": tools.Toolset{ToolsetConfig: tools.ToolsetConfig{ToolNames: []string{"test-tool"}}}}
+	mockPrompt := map[string]prompts.Prompt{"test-prompt": testutils.MockPrompt{}}
+	mockPromptset := map[string]prompts.Promptset{"": prompts.Promptset{PromptsetConfig: prompts.PromptsetConfig{PromptNames: []string{"test-prompt"}}}}
+	r, shutdown := setUpServer(t, "admin", mockSources, mockAuthServices, mockEmbeddingModel, mockTool, mockToolset, mockPrompt, mockPromptset)
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	tests := []struct {
+		name               string
+		kind               string
+		resourceName       string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Delete Source - Success",
+			kind:               "source",
+			resourceName:       "test-source",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Auth Service - Success",
+			kind:               "authService",
+			resourceName:       "test-auth-service",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Embedding Model - Success",
+			kind:               "embeddingModel",
+			resourceName:       "test-embedding-model",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Tool - Success",
+			kind:               "tool",
+			resourceName:       "test-tool",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Toolset - Success",
+			kind:               "toolset",
+			resourceName:       "test-toolset",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Prompt - Success",
+			kind:               "prompt",
+			resourceName:       "test-prompt",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Non-existent Primitive - Not Found",
+			kind:               "source",
+			resourceName:       "non-existent-source",
+			expectedStatusCode: http.StatusNotFound,
+		},
+		{
+			name:               "Delete with Invalid Kind - Bad Request",
+			kind:               "invalidKind",
+			resourceName:       "some-name",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body, err := runRequest(ts, http.MethodDelete, fmt.Sprintf("/%s/%s", tt.kind, tt.resourceName), nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error during request: %s", err)
 			}

--- a/internal/server/resources/resources.go
+++ b/internal/server/resources/resources.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/googleapis/genai-toolbox/internal/auth"
@@ -402,6 +403,133 @@ func (r *ResourceManager) UpdatePrompt(ctx context.Context, name string, config 
 	if err != nil {
 		delete(r.prompts, name)
 		return fmt.Errorf("error updating promptset: %w", err)
+	}
+	r.promptsets[""] = defaultPromptset
+	return nil
+}
+
+// deleteFromMap is a helper method that handles the "check and delete" logic.
+func deleteFromMap[T any](m map[string]T, name string) bool {
+	if _, ok := m[name]; !ok {
+		return false
+	}
+	delete(m, name)
+	return true
+}
+
+func (r *ResourceManager) Delete(kind string, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var deleted bool
+	k := ResourceKind(strings.ToLower(kind))
+
+	switch k {
+	case KindSource:
+		deleted = deleteFromMap(r.sources, name)
+	case KindAuthService:
+		deleted = deleteFromMap(r.authServices, name)
+	case KindEmbeddingModel:
+		deleted = deleteFromMap(r.embeddingModels, name)
+	case KindTool:
+		deleted = deleteFromMap(r.tools, name)
+		err := r.RemoveFromDefaultToolset(name)
+		if err != nil {
+			return fmt.Errorf("error removing %s from default toolset: %w", name, err)
+		}
+	case KindToolset:
+		deleted = deleteFromMap(r.toolsets, name)
+	case KindPrompt:
+		deleted = deleteFromMap(r.prompts, name)
+		err := r.RemoveFromDefaultPromptset(name)
+		if err != nil {
+			return fmt.Errorf("error removing %s from default promptset: %w", name, err)
+		}
+	default:
+		return fmt.Errorf("invalid primitive kind provided")
+	}
+
+	if !deleted {
+		return fmt.Errorf("%s %s not found", kind, name)
+	}
+	return nil
+}
+
+// RemoveDefaultToolset remove a tool from default toolset.
+func (r *ResourceManager) RemoveFromDefaultToolset(name string) error {
+	defaultToolset, toolsetExists := r.toolsets[""]
+	if !toolsetExists {
+		return fmt.Errorf("toolset does not exists")
+	}
+
+	// Filter the slice in-place
+	originalToolNames := defaultToolset.ToolNames
+	newToolNames := originalToolNames[:0] // Zero-length slice with same capacity
+
+	for _, tool := range originalToolNames {
+		// Safe check for nested pointers
+		if tool != "" {
+			if tool == name {
+				// Skip this tool (effectively deleting it)
+				continue
+			}
+		}
+		newToolNames = append(newToolNames, tool)
+	}
+
+	// Garbage collection safety: nil out the remaining slots in the original backing array
+	for i := len(newToolNames); i < len(originalToolNames); i++ {
+		originalToolNames[i] = ""
+	}
+
+	defaultToolset.ToolNames = newToolNames
+	// re-initialize toolsets to update lists manifest
+	err := defaultToolset.Initialize(r.serverVersion, r.tools)
+	if err != nil {
+		return fmt.Errorf("error initializing toolset: %w", err)
+	}
+	if len(newToolNames) >= len(originalToolNames) {
+		return fmt.Errorf("new toolNames length is equal or greater to original toolNames")
+	}
+	r.toolsets[""] = defaultToolset
+	return nil
+}
+
+// RemoveFromDefaultPromptset remove a prompt from default promptset.
+func (r *ResourceManager) RemoveFromDefaultPromptset(name string) error {
+	defaultPromptset, promptsetExists := r.promptsets[""]
+	if !promptsetExists {
+		return fmt.Errorf("promptset does not exists")
+	}
+
+	// Filter the slice in-place
+	originalPromptNames := defaultPromptset.PromptNames
+	newPromptNames := originalPromptNames[:0] // Zero-length slice with same capacity
+
+	for _, prompt := range originalPromptNames {
+		// Safe check for nested pointers
+		if prompt != "" {
+			if prompt == name {
+				// Skip this prompt (effectively deleting it)
+				continue
+			}
+		}
+		newPromptNames = append(newPromptNames, prompt)
+	}
+
+	// Garbage collection safety: nil out the remaining slots in the original backing array
+	for i := len(newPromptNames); i < len(originalPromptNames); i++ {
+		originalPromptNames[i] = ""
+	}
+
+	defaultPromptset.PromptNames = newPromptNames
+	// re-initialize promptset to update lists manifest
+	err := defaultPromptset.Initialize(r.serverVersion, r.prompts)
+	if err != nil {
+		return fmt.Errorf("error initializing promptset: %w", err)
+	}
+	if len(newPromptNames) >= len(originalPromptNames) {
+		return fmt.Errorf("new promptNames length is equal or greater to original promptNames")
 	}
 	r.promptsets[""] = defaultPromptset
 	return nil

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -256,3 +256,96 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 		t.Fatalf("update failed: got %+v, want %+v", pc, pConfig)
 	}
 }
+
+func TestDeletePrimitives(t *testing.T) {
+	resMgr := resources.NewResourceManager(
+		"test-version",
+		map[string]sources.Source{"foo": testutils.MockSource{}},
+		map[string]auth.AuthService{"foo": testutils.MockAuthService{}},
+		map[string]embeddingmodels.EmbeddingModel{"foo": testutils.MockEmbeddingModel{}},
+		map[string]tools.Tool{"foo": testutils.MockTool{}},
+		map[string]tools.Toolset{"foo": tools.Toolset{}, "": tools.Toolset{ToolsetConfig: tools.ToolsetConfig{ToolNames: []string{"foo"}}}},
+		map[string]prompts.Prompt{"foo": testutils.MockPrompt{}},
+		map[string]prompts.Promptset{"": prompts.Promptset{PromptsetConfig: prompts.PromptsetConfig{PromptNames: []string{"foo"}}}},
+	)
+
+	var found bool
+	var err error
+	err = resMgr.Delete("source", "foo")
+	if err != nil {
+		t.Fatalf("expected delete to be successful: %s", err)
+	}
+	_, found = resMgr.GetSource("foo")
+	if found {
+		t.Fatalf("found source but expected to be deleted")
+	}
+	err = resMgr.Delete("source", "nonexistent")
+	if err == nil {
+		t.Fatalf("expected delete of non-existent resource to return false, but got true")
+	}
+
+	err = resMgr.Delete("authservice", "foo")
+	if err != nil {
+		t.Fatalf("expected delete to be successful: %s", err)
+	}
+	_, found = resMgr.GetAuthService("foo")
+	if found {
+		t.Fatalf("found auth service but expected to be deleted")
+	}
+	err = resMgr.Delete("authservice", "nonexistent")
+	if err == nil {
+		t.Fatalf("expected delete of non-existent resource to return false, but got true")
+	}
+
+	err = resMgr.Delete("embeddingmodel", "foo")
+	if err != nil {
+		t.Fatalf("expected delete to be successful: %s", err)
+	}
+	_, found = resMgr.GetEmbeddingModel("foo")
+	if found {
+		t.Fatalf("found embedding model but expected to be deleted")
+	}
+	err = resMgr.Delete("embeddingmodel", "nonexistent")
+	if err == nil {
+		t.Fatalf("expected delete of non-existent resource to return false, but got true")
+	}
+
+	err = resMgr.Delete("tool", "foo")
+	if err != nil {
+		t.Fatalf("expected delete to be successful: %s", err)
+	}
+	_, found = resMgr.GetTool("foo")
+	if found {
+		t.Fatalf("found tool but expected to be deleted")
+	}
+	err = resMgr.Delete("tool", "nonexistent")
+	if err == nil {
+		t.Fatalf("expected delete of non-existent resource to return false, but got true")
+	}
+
+	err = resMgr.Delete("toolset", "foo")
+	if err != nil {
+		t.Fatalf("expected delete to be successful: %s", err)
+	}
+	_, found = resMgr.GetToolset("foo")
+	if found {
+		t.Fatalf("found toolset but expected to be deleted")
+	}
+	err = resMgr.Delete("toolset", "nonexistent")
+	if err == nil {
+		t.Fatalf("expected delete of non-existent resource to return false, but got true")
+	}
+
+	err = resMgr.Delete("prompt", "foo")
+	if err != nil {
+		t.Fatalf("expected delete to be successful: %s", err)
+	}
+	_, found = resMgr.GetPrompt("foo")
+	if found {
+		t.Fatalf("found prompt but expected to be deleted")
+	}
+	err = resMgr.Delete("prompt", "nonexistent")
+	if err == nil {
+		t.Fatalf("expected delete of non-existent resource to return false, but got true")
+	}
+}


### PR DESCRIPTION
New DELETE endpoint for `/admin/{kind}/{name}`. 

Deletions are made per primitive and will not be made in batches. Successful deletion will return a `200 OK` to the client. If the source is not found, Toolbox will return a `404 NOT FOUND`. After deletion, the primitive will not be discoverable (GET SHOULD NOT return the deleted primitive).

Deletion of primitives **WILL NOT** cascade towards other primitives.
* **Deletion of Source:** Tools that are linked to the Source will still be discoverable. However, when the user invokes the tool, an error will be thrown.
* **Deletion of Tool:** 
    * Default toolset: The tool is automatically removed from default toolset (name: `""`).
    * If custom toolset is updated but tool is not removed - initialization will throw a "tool does not exist" error.
    * If custom toolset is not updated - the deleted tool will still appear when calling tools/list, but any attempt to invoke it will fail.