### PR TITLE
tests: update --enable-api to be part of args input

### DIFF
--- a/tests/alloydb/alloydb_integration_test.go
+++ b/tests/alloydb/alloydb_integration_test.go
@@ -151,7 +151,7 @@ func TestAlloyDBToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getAlloyDBToolsConfig()
 
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
@@ -1099,7 +1099,7 @@ func TestAlloyDBCreateCluster(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getAlloyDBToolsConfig()
 	cmd, cleanupCmd, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
@@ -1209,7 +1209,7 @@ func TestAlloyDBCreateInstance(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getAlloyDBToolsConfig()
 	cmd, cleanupCmd, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
@@ -1335,7 +1335,7 @@ func TestAlloyDBCreateUser(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getAlloyDBToolsConfig()
 	cmd, cleanupCmd, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/alloydb/alloydb_wait_for_operation_test.go
+++ b/tests/alloydb/alloydb_wait_for_operation_test.go
@@ -134,7 +134,7 @@ func TestWaitToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	toolsFile := getWaitToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)

--- a/tests/alloydbainl/alloydb_ai_nl_integration_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_integration_test.go
@@ -78,7 +78,7 @@ func TestAlloyDBAINLToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Write config into a file and pass it to command
 	toolsFile := getAINLToolsConfig(sourceConfig)

--- a/tests/alloydbomni/alloydb_omni_integration_test.go
+++ b/tests/alloydbomni/alloydb_omni_integration_test.go
@@ -118,7 +118,7 @@ func TestAlloyDBOmni(t *testing.T) {
 	// Generate a unique ID
 	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
 
-	args := []string{"--prebuilt", "alloydb-omni"}
+	args := []string{"--prebuilt", "alloydb-omni", "--enable-api"}
 
 	pool, err := initPostgresConnectionPool(AlloyDBHost, AlloyDBPort, AlloyDBUser, AlloyDBPass, AlloyDBDatabase)
 	if err != nil {

--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -122,7 +122,7 @@ func TestAlloyDBPgToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initAlloyDBPgConnectionPool(AlloyDBPostgresProject, AlloyDBPostgresRegion, AlloyDBPostgresCluster, AlloyDBPostgresInstance, "public", AlloyDBPostgresUser, AlloyDBPostgresPass, AlloyDBPostgresDatabase)
 	if err != nil {
@@ -222,7 +222,7 @@ func TestAlloyDBPgPrebuiltStatementTools(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	args := []string{"--prebuilt", "alloydb-postgres"}
+	args := []string{"--prebuilt", "alloydb-postgres", "--enable-api"}
 
 	cmd, cleanup, err := tests.StartCmd(ctx, map[string]any{}, args...)
 	if err != nil {

--- a/tests/auth/auth_integration_test.go
+++ b/tests/auth/auth_integration_test.go
@@ -82,7 +82,8 @@ func TestMcpAuth(t *testing.T) {
 		},
 		"tools": map[string]any{},
 	}
-	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -81,7 +81,7 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	client, err := initBigQueryConnection(BigqueryProject)
 	if err != nil {
@@ -336,7 +336,8 @@ func TestBigQueryToolWithDatasetRestriction(t *testing.T) {
 	}
 
 	// Start server
-	cmd, cleanup, err := tests.StartCmd(ctx, config)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, config, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}
@@ -411,7 +412,8 @@ func TestBigQueryWriteModeAllowed(t *testing.T) {
 		},
 	}
 
-	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}
@@ -455,7 +457,8 @@ func TestBigQueryWriteModeBlocked(t *testing.T) {
 		},
 	}
 
-	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}
@@ -518,7 +521,8 @@ func TestBigQueryWriteModeProtected(t *testing.T) {
 		},
 	}
 
-	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}

--- a/tests/bigtable/bigtable_integration_test.go
+++ b/tests/bigtable/bigtable_integration_test.go
@@ -68,7 +68,7 @@ func TestBigtableToolEndpoints(t *testing.T) {
 	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
 	t.Logf("Starting Bigtable test with uniqueID: %s", uniqueID)
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Initialize AdminClient to create or delete tables
 	adminClient, err := bigtable.NewAdminClient(context.Background(), sourceConfig["project"].(string), sourceConfig["instance"].(string))

--- a/tests/cassandra/cassandra_integration_test.go
+++ b/tests/cassandra/cassandra_integration_test.go
@@ -180,7 +180,7 @@ func TestCassandra(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 	paramTableName := "param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 	tableNameAuth := "auth_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
 	tableNameTemplateParam := "template_param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")

--- a/tests/clickhouse/clickhouse_integration_test.go
+++ b/tests/clickhouse/clickhouse_integration_test.go
@@ -106,7 +106,7 @@ func TestClickHouse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initClickHouseConnectionPool(ClickHouseHost, ClickHousePort, ClickHouseUser, ClickHousePass, ClickHouseDatabase, ClickHouseProtocol)
 	if err != nil {
@@ -268,7 +268,7 @@ func TestClickHouseBasicConnection(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initClickHouseConnectionPool(ClickHouseHost, ClickHousePort, ClickHouseUser, ClickHousePass, ClickHouseDatabase, ClickHouseProtocol)
 	if err != nil {
@@ -418,7 +418,7 @@ func TestClickHouseSQLTool(t *testing.T) {
 		},
 	}
 
-	var args []string
+	args := []string{"--enable-api"}
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
@@ -529,7 +529,7 @@ func TestClickHouseExecuteSQLTool(t *testing.T) {
 		},
 	}
 
-	var args []string
+	args := []string{"--enable-api"}
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
@@ -666,7 +666,7 @@ func TestClickHouseEdgeCases(t *testing.T) {
 		},
 	}
 
-	var args []string
+	args := []string{"--enable-api"}
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
@@ -918,7 +918,7 @@ func TestClickHouseListDatabasesTool(t *testing.T) {
 		},
 	}
 
-	var args []string
+	args := []string{"--enable-api"}
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
@@ -1047,7 +1047,7 @@ func TestClickHouseListTablesTool(t *testing.T) {
 		},
 	}
 
-	var args []string
+	args := []string{"--enable-api"}
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)

--- a/tests/cloudgda/cloud_gda_integration_test.go
+++ b/tests/cloudgda/cloud_gda_integration_test.go
@@ -126,7 +126,7 @@ func TestCloudGdaToolEndpoints(t *testing.T) {
 		return origFunc(ctx, opts...)
 	}
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCloudGdaToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudhealthcare/cloud_healthcare_integration_test.go
+++ b/tests/cloudhealthcare/cloud_healthcare_integration_test.go
@@ -163,7 +163,7 @@ func TestHealthcareToolEndpoints(t *testing.T) {
 	toolsFile := getToolsConfig(sourceConfig)
 	toolsFile = addClientAuthSourceConfig(t, toolsFile)
 
-	var args []string
+	args := []string{"--enable-api"}
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
@@ -248,7 +248,8 @@ func TestHealthcareToolWithStoreRestriction(t *testing.T) {
 	}
 
 	// Start server
-	cmd, cleanup, err := tests.StartCmd(ctx, config)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, config, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}

--- a/tests/cloudloggingadmin/cloud_logging_admin_integration_test.go
+++ b/tests/cloudloggingadmin/cloud_logging_admin_integration_test.go
@@ -87,7 +87,7 @@ func TestLogAdminToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	_, err := initLogAdminConnection(LogAdminProject)
 	if err != nil {

--- a/tests/cloudsql/cloud_sql_clone_instance_test.go
+++ b/tests/cloudsql/cloud_sql_clone_instance_test.go
@@ -132,7 +132,7 @@ func TestCloneInstanceToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCloneInstanceToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsql/cloud_sql_create_backup_test.go
+++ b/tests/cloudsql/cloud_sql_create_backup_test.go
@@ -121,7 +121,7 @@ func TestCreateBackupToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCreateBackupToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsql/cloud_sql_create_database_test.go
+++ b/tests/cloudsql/cloud_sql_create_database_test.go
@@ -124,7 +124,7 @@ func TestCreateDatabaseToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCreateDatabaseToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsql/cloud_sql_create_users_test.go
+++ b/tests/cloudsql/cloud_sql_create_users_test.go
@@ -130,7 +130,7 @@ func TestCreateUsersToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCreateUsersToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsql/cloud_sql_get_instances_test.go
+++ b/tests/cloudsql/cloud_sql_get_instances_test.go
@@ -122,7 +122,7 @@ func TestGetInstancesToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	toolsFile := getToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)

--- a/tests/cloudsql/cloud_sql_list_databases_test.go
+++ b/tests/cloudsql/cloud_sql_list_databases_test.go
@@ -107,7 +107,7 @@ func TestListDatabasesToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getListDatabasesToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsql/cloud_sql_restore_backup_test.go
+++ b/tests/cloudsql/cloud_sql_restore_backup_test.go
@@ -138,7 +138,7 @@ func TestRestoreBackupToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getRestoreBackupToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsql/cloudsql_list_instances_test.go
+++ b/tests/cloudsql/cloudsql_list_instances_test.go
@@ -81,7 +81,7 @@ func TestListInstance(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	toolsFile := getListInstanceToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)

--- a/tests/cloudsql/cloudsql_wait_for_operation_test.go
+++ b/tests/cloudsql/cloudsql_wait_for_operation_test.go
@@ -173,7 +173,7 @@ func TestCloudSQLWaitToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	toolsFile := getCloudSQLWaitToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)

--- a/tests/cloudsqlmssql/cloud_sql_mssql_create_instance_integration_test.go
+++ b/tests/cloudsqlmssql/cloud_sql_mssql_create_instance_integration_test.go
@@ -161,7 +161,7 @@ func TestCreateInstanceToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCreateInstanceToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
+++ b/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
@@ -111,7 +111,7 @@ func TestCloudSQLMSSQLToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	db, err := initCloudSQLMSSQLConnection(CloudSQLMSSQLProject, CloudSQLMSSQLRegion, CloudSQLMSSQLInstance, "public", CloudSQLMSSQLUser, CloudSQLMSSQLPass, CloudSQLMSSQLDatabase)
 	if err != nil {

--- a/tests/cloudsqlmysql/cloud_sql_mysql_create_instance_integration_test.go
+++ b/tests/cloudsqlmysql/cloud_sql_mysql_create_instance_integration_test.go
@@ -162,7 +162,7 @@ func TestCreateInstanceToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCreateInstanceToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
+++ b/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
@@ -103,7 +103,7 @@ func TestCloudSQLMySQLToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initCloudSQLMySQLConnectionPool(CloudSQLMySQLProject, CloudSQLMySQLRegion, CloudSQLMySQLInstance, "public", CloudSQLMySQLUser, CloudSQLMySQLPass, CloudSQLMySQLDatabase)
 	if err != nil {
@@ -269,7 +269,8 @@ func TestCloudSQLMySQLIAMConnection(t *testing.T) {
 			}
 
 			// Start the Toolbox Command
-			cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+			args := []string{"--enable-api"}
+			cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 			if err != nil {
 				t.Fatalf("command initialization returned an error: %s", err)
 			}

--- a/tests/cloudsqlpg/cloud_sql_pg_create_instances_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_create_instances_test.go
@@ -163,7 +163,7 @@ func TestCreateInstanceToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getCreateInstanceToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -107,7 +107,7 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initCloudSQLPgConnectionPool(CloudSQLPostgresProject, CloudSQLPostgresRegion, CloudSQLPostgresInstance, "public", CloudSQLPostgresUser, CloudSQLPostgresPass, CloudSQLPostgresDatabase)
 	if err != nil {

--- a/tests/cloudsqlpg/cloud_sql_pg_upgrade_precheck_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_upgrade_precheck_test.go
@@ -224,7 +224,7 @@ func TestPreCheckToolEndpoints(t *testing.T) {
 		http.DefaultClient.Transport = originalTransport
 	})
 
-	var args []string
+	args := []string{"--enable-api"}
 	toolsFile := getPreCheckToolsConfig()
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {

--- a/tests/cockroachdb/cockroachdb_integration_test.go
+++ b/tests/cockroachdb/cockroachdb_integration_test.go
@@ -90,7 +90,7 @@ func TestCockroachDB(t *testing.T) {
 	connString := fmt.Sprintf("postgres://root@%s:%s/defaultdb?sslmode=disable", host, port.Port())
 
 	sourceConfig := getCockroachDBVars(host, port.Port())
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initCockroachDBConnectionPool(connString)
 	if err != nil {

--- a/tests/couchbase/couchbase_integration_test.go
+++ b/tests/couchbase/couchbase_integration_test.go
@@ -119,7 +119,8 @@ func TestCouchbaseToolEndpoints(t *testing.T) {
 	toolsFile := tests.GetToolsConfig(sourceConfig, couchbaseToolType, paramToolStmt, idParamToolStmt, nameParamToolStmt, arrayToolStmt, authToolStmt)
 	toolsFile = tests.AddTemplateParamConfig(t, toolsFile, couchbaseToolType, tmplSelectCombined, tmplSelectFilterCombined, tmplSelectAll)
 
-	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization failed: %s", err)
 	}

--- a/tests/dataform/dataform_integration_test.go
+++ b/tests/dataform/dataform_integration_test.go
@@ -78,7 +78,8 @@ func TestDataformCompileTool(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd, cleanupServer, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanupServer, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}

--- a/tests/dataplex/dataplex_integration_test.go
+++ b/tests/dataplex/dataplex_integration_test.go
@@ -145,7 +145,7 @@ func TestDataplexToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 	bigqueryClient, err := initBigQueryConnection(ctx, DataplexProject)
 	if err != nil {
 		t.Fatalf("unable to create Cloud SQL connection pool: %s", err)

--- a/tests/dataproc/dataproc_integration_test.go
+++ b/tests/dataproc/dataproc_integration_test.go
@@ -129,7 +129,8 @@ func TestDataprocClustersToolEndpoints(t *testing.T) {
 		},
 	}
 
-	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}

--- a/tests/dgraph/dgraph_integration_test.go
+++ b/tests/dgraph/dgraph_integration_test.go
@@ -52,7 +52,7 @@ func TestDgraphToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Write config into a file and pass it to command
 	toolsFile := map[string]any{

--- a/tests/elasticsearch/elasticsearch_integration_test.go
+++ b/tests/elasticsearch/elasticsearch_integration_test.go
@@ -64,7 +64,7 @@ func TestElasticsearchToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	sourceConfig := getElasticsearchVars(t)
 

--- a/tests/firebird/firebird_integration_test.go
+++ b/tests/firebird/firebird_integration_test.go
@@ -86,7 +86,7 @@ func TestFirebirdToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	db, err := initFirebirdConnection(FirebirdHost, FirebirdPort, FirebirdUser, FirebirdPass, FirebirdDatabase)
 	if err != nil {

--- a/tests/firestore/firestore_integration_test.go
+++ b/tests/firestore/firestore_integration_test.go
@@ -80,7 +80,7 @@ func TestFirestoreToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	client, err := initFirestoreConnection(FirestoreProject, FirestoreDatabase)
 	if err != nil {

--- a/tests/http/http_integration_test.go
+++ b/tests/http/http_integration_test.go
@@ -342,7 +342,7 @@ func TestHttpToolEndpoints(t *testing.T) {
 	}))
 	defer jwksServer.Close()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	toolsFile := getHTTPToolsConfig(sourceConfig, HttpToolType, jwksServer.URL)
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)

--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -84,7 +84,7 @@ func TestLooker(t *testing.T) {
 	}
 	ctx = util.WithLogger(ctx, testLogger)
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Write config into a file and pass it to command
 

--- a/tests/mariadb/mariadb_integration_test.go
+++ b/tests/mariadb/mariadb_integration_test.go
@@ -86,7 +86,7 @@ func TestMySQLToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initMariaDB(MariaDBHost, MariaDBPort, MariaDBUser, MariaDBPass, MariaDBDatabase)
 	if err != nil {

--- a/tests/mindsdb/mindsdb_integration_test.go
+++ b/tests/mindsdb/mindsdb_integration_test.go
@@ -90,7 +90,7 @@ func TestMindsDBToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Create unique table names with UUID
 	tableNameParam := "param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")

--- a/tests/mongodb/mongodb_integration_test.go
+++ b/tests/mongodb/mongodb_integration_test.go
@@ -71,7 +71,7 @@ func TestMongoDBToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	database, err := initMongoDbDatabase(ctx, MongoDbUri, MongoDbDatabase)
 	if err != nil {

--- a/tests/mssql/mssql_integration_test.go
+++ b/tests/mssql/mssql_integration_test.go
@@ -90,7 +90,7 @@ func TestMSSQLToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initMSSQLConnection(MSSQLHost, MSSQLPort, MSSQLUser, MSSQLPass, MSSQLDatabase)
 	if err != nil {

--- a/tests/mysql/mysql_integration_test.go
+++ b/tests/mysql/mysql_integration_test.go
@@ -80,7 +80,7 @@ func TestMySQLToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initMySQLConnectionPool(MySQLHost, MySQLPort, MySQLUser, MySQLPass, MySQLDatabase)
 	if err != nil {

--- a/tests/neo4j/neo4j_integration_test.go
+++ b/tests/neo4j/neo4j_integration_test.go
@@ -71,7 +71,7 @@ func TestNeo4jToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Write config into a file and pass it to the command.
 	// This configuration defines the data source and the tools to be tested.

--- a/tests/oceanbase/oceanbase_integration_test.go
+++ b/tests/oceanbase/oceanbase_integration_test.go
@@ -82,7 +82,7 @@ func TestOceanBaseToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initOceanBaseConnectionPool(OceanBaseHost, OceanBasePort, OceanBaseUser, OceanBasePass, OceanBaseDatabase)
 	if err != nil {

--- a/tests/oracle/oracle_integration_test.go
+++ b/tests/oracle/oracle_integration_test.go
@@ -76,7 +76,7 @@ func TestOracleSimpleToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	db, err := initOracleConnection(ctx, OracleUser, OraclePass, OracleConnStr)
 	if err != nil {

--- a/tests/postgres/postgres_integration_test.go
+++ b/tests/postgres/postgres_integration_test.go
@@ -86,7 +86,7 @@ func TestPostgres(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initPostgresConnectionPool(PostgresHost, PostgresPort, PostgresUser, PostgresPass, PostgresDatabase)
 	if err != nil {

--- a/tests/prompts/custom/prompts_integration_test.go
+++ b/tests/prompts/custom/prompts_integration_test.go
@@ -79,7 +79,8 @@ func TestMCPPromptsIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd, cleanup, err := tests.StartCmd(ctx, getPromptsConfig())
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, getPromptsConfig(), args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %v", err)
 	}

--- a/tests/redis/redis_test.go
+++ b/tests/redis/redis_test.go
@@ -69,7 +69,7 @@ func TestRedisToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	client, err := initRedisClient(ctx, RedisAddress, RedisPass)
 	if err != nil {

--- a/tests/server.go
+++ b/tests/server.go
@@ -68,7 +68,7 @@ func StartCmd(ctx context.Context, toolsFile map[string]any, args ...string) (*C
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to write config: %s", err)
 	}
-	args = append(args, "--config", path, "--enable-api")
+	args = append(args, "--config", path)
 
 	ctx, cancel := context.WithCancel(ctx)
 	// Open a pipe for tracking the output from the cmd

--- a/tests/serverlessspark/serverless_spark_integration_test.go
+++ b/tests/serverlessspark/serverless_spark_integration_test.go
@@ -191,7 +191,8 @@ func TestServerlessSparkToolEndpoints(t *testing.T) {
 		},
 	}
 
-	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}

--- a/tests/singlestore/singlestore_integration_test.go
+++ b/tests/singlestore/singlestore_integration_test.go
@@ -184,7 +184,7 @@ func TestSingleStoreToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initSingleStoreConnectionPool(SingleStoreHost, SingleStorePort, SingleStoreUser, SingleStorePass, SingleStoreDatabase)
 	if err != nil {

--- a/tests/snowflake/snowflake_integration_test.go
+++ b/tests/snowflake/snowflake_integration_test.go
@@ -101,7 +101,7 @@ func TestSnowflake(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	db, err := initSnowflakeConnectionPool(ctx, SnowflakeAccount, SnowflakeUser, SnowflakePassword, SnowflakeDatabase, SnowflakeSchema, SnowflakeWarehouse, SnowflakeRole)
 	if err != nil {

--- a/tests/source.go
+++ b/tests/source.go
@@ -34,7 +34,7 @@ func RunSourceConnectionTest(t *testing.T, sourceConfig map[string]any, toolType
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Write config into a file and pass it to command
 	toolsFile := map[string]any{

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -86,7 +86,7 @@ func TestSpannerToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// Create Spanner client
 	dataClient, adminClient, err := initSpannerClients(ctx, SpannerProject, SpannerInstance, SpannerDatabase)

--- a/tests/sqlite/sqlite_integration_test.go
+++ b/tests/sqlite/sqlite_integration_test.go
@@ -121,7 +121,7 @@ func TestSQLiteToolEndpoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	// create table name with UUID
 	tableNameParam := "param_table_" + strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -201,7 +201,8 @@ func TestSQLiteExecuteSqlTool(t *testing.T) {
 		},
 	}
 
-	cmd, cleanup, err := tests.StartCmd(ctx, toolConfig)
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolConfig, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
 	}

--- a/tests/tidb/tidb_integration_test.go
+++ b/tests/tidb/tidb_integration_test.go
@@ -112,7 +112,7 @@ func TestTiDBToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initTiDBConnectionPool(TiDBHost, TiDBPort, TiDBUser, TiDBPass, TiDBDatabase, false)
 	if err != nil {

--- a/tests/trino/trino_integration_test.go
+++ b/tests/trino/trino_integration_test.go
@@ -213,7 +213,7 @@ func TestTrinoToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initTrinoConnectionPool(TrinoHost, TrinoPort, TrinoUser, TrinoPass, TrinoCatalog, TrinoSchema)
 	if err != nil {

--- a/tests/valkey/valkey_test.go
+++ b/tests/valkey/valkey_test.go
@@ -72,7 +72,7 @@ func TestValkeyToolEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	client, err := initValkeyClient(ctx, []string{ValkeyAddress})
 	if err != nil {

--- a/tests/yugabytedb/yugabytedb_integration_test.go
+++ b/tests/yugabytedb/yugabytedb_integration_test.go
@@ -111,7 +111,7 @@ func TestYugabyteDB(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	var args []string
+	args := []string{"--enable-api"}
 
 	pool, err := initYBConnectionPool(YBDB_HOST, YBDB_PORT, YBDB_USER, YBDB_PASS, YBDB_DATABASE, YBDB_LB)
 	if err != nil {


### PR DESCRIPTION
Update the `--enable-api` flag in integration test to be part of args input rather than hard coded in `StartCmd()` function.