### PR TITLE
feat: add GET endpoint by primitive kind and name

### DIFF
--- a/cmd/internal/skills/generator_test.go
+++ b/cmd/internal/skills/generator_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 	"go.opentelemetry.io/otel/trace"
@@ -175,7 +175,7 @@ func TestFormatParameters(t *testing.T) {
 
 func TestGenerateSkillMarkdown(t *testing.T) {
 	toolsMap := map[string]tools.Tool{
-		"tool1": server.MockTool{
+		"tool1": testutils.MockTool{
 			Description: "First tool",
 			Params: []parameters.Parameter{
 				parameters.NewStringParameter("p1", "d1"),

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/snowflakedb/gosnowflake v1.19.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/cockroachdb v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/couchbase v0.41.0
@@ -239,7 +240,6 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/internal/embeddingmodels/gemini/gemini_test.go
+++ b/internal/embeddingmodels/gemini/gemini_test.go
@@ -95,11 +95,7 @@ func TestFailParseFromYamlGemini(t *testing.T) {
             type: gemini
             `,
 			// Removed the specific model name from the prefix to match your output
-<<<<<<< HEAD
 			err: "error unmarshaling embeddingModel: unable to parse embeddingModel \"bad-model\" as \"gemini\": Key: 'Config.Model' Error:Field validation for 'Model' failed on the 'required' tag",
-=======
-			err: "error unmarshaling embeddingModels: unable to parse embeddingModel \"bad-model\" as \"gemini\": Key: 'Config.Model' Error:Field validation for 'Model' failed on the 'required' tag",
->>>>>>> 12fe22c7cee (chore: update auth and embeddingmodels to use the register model (#2794))
 		},
 		{
 			desc: "unknown field",
@@ -111,11 +107,7 @@ func TestFailParseFromYamlGemini(t *testing.T) {
             invalid_param: true
             `,
 			// Updated to match the specific line-starting format of your error output
-<<<<<<< HEAD
 			err: "error unmarshaling embeddingModel: unable to parse embeddingModel \"bad-field\" as \"gemini\": [1:1] unknown field \"invalid_param\"\n>  1 | invalid_param: true\n       ^\n   2 | model: text-embedding-004\n   3 | name: bad-field\n   4 | type: gemini",
-=======
-			err: "error unmarshaling embeddingModels: unable to parse embeddingModel \"bad-field\" as \"gemini\": [1:1] unknown field \"invalid_param\"\n>  1 | invalid_param: true\n       ^\n   2 | model: text-embedding-004\n   3 | name: bad-field\n   4 | type: gemini",
->>>>>>> 12fe22c7cee (chore: update auth and embeddingmodels to use the register model (#2794))
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/embeddingmodels/gemini/gemini_test.go
+++ b/internal/embeddingmodels/gemini/gemini_test.go
@@ -95,7 +95,11 @@ func TestFailParseFromYamlGemini(t *testing.T) {
             type: gemini
             `,
 			// Removed the specific model name from the prefix to match your output
+<<<<<<< HEAD
 			err: "error unmarshaling embeddingModel: unable to parse embeddingModel \"bad-model\" as \"gemini\": Key: 'Config.Model' Error:Field validation for 'Model' failed on the 'required' tag",
+=======
+			err: "error unmarshaling embeddingModels: unable to parse embeddingModel \"bad-model\" as \"gemini\": Key: 'Config.Model' Error:Field validation for 'Model' failed on the 'required' tag",
+>>>>>>> 12fe22c7cee (chore: update auth and embeddingmodels to use the register model (#2794))
 		},
 		{
 			desc: "unknown field",
@@ -107,7 +111,11 @@ func TestFailParseFromYamlGemini(t *testing.T) {
             invalid_param: true
             `,
 			// Updated to match the specific line-starting format of your error output
+<<<<<<< HEAD
 			err: "error unmarshaling embeddingModel: unable to parse embeddingModel \"bad-field\" as \"gemini\": [1:1] unknown field \"invalid_param\"\n>  1 | invalid_param: true\n       ^\n   2 | model: text-embedding-004\n   3 | name: bad-field\n   4 | type: gemini",
+=======
+			err: "error unmarshaling embeddingModels: unable to parse embeddingModel \"bad-field\" as \"gemini\": [1:1] unknown field \"invalid_param\"\n>  1 | invalid_param: true\n       ^\n   2 | model: text-embedding-004\n   3 | name: bad-field\n   4 | type: gemini",
+>>>>>>> 12fe22c7cee (chore: update auth and embeddingmodels to use the register model (#2794))
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -15,9 +15,16 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 // adminRouter creates a router that represents the routes under /admin
@@ -28,5 +35,92 @@ func adminRouter(s *Server) (chi.Router, error) {
 	r.Use(middleware.StripSlashes)
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
+	r.Put("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { createOrUpdatePrimitives(s, w, r) })
+
 	return r, nil
+}
+
+// createOrUpdatePrimitives handles the creation or updating of primitives
+// changing name will result in creation of a new primitive instead of replacing
+// existing primitive
+// Invalid primitive kind will result in http.StatusBadRequest
+// Other errors will result in http.StatusInternalServerError
+func createOrUpdatePrimitives(s *Server, w http.ResponseWriter, r *http.Request) {
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+	ctx := r.Context()
+	ctx = util.WithInstrumentation(ctx, s.instrumentation)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		err = fmt.Errorf("unable to read request body: %w", err)
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusInternalServerError))
+		return
+	}
+	var req struct {
+		Config map[string]any `json:"config"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("unable to unmarshal request body: %w", err)
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusInternalServerError))
+		return
+	}
+
+	// check if primitive exists with the same name and type
+	var updateErr error
+	switch strings.ToLower(kind) {
+	case "source":
+		c, err := UnmarshalYAMLSourceConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal source config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateSource(ctx, name, c)
+	case "authservice":
+		c, err := UnmarshalYAMLAuthServiceConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal auth service config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateAuthService(ctx, name, c)
+	case "embeddingmodels":
+		c, err := UnmarshalYAMLEmbeddingModelConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal embedding model config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateEmbeddingModel(ctx, name, c)
+	case "tool":
+		c, err := UnmarshalYAMLToolConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal tool config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateTool(ctx, name, c)
+	case "toolset":
+		c, err := UnmarshalYAMLToolsetConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal toolset config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdateToolset(ctx, name, c, s.version)
+	case "prompt":
+		c, err := UnmarshalYAMLPromptConfig(ctx, name, req.Config)
+		if err != nil {
+			updateErr = fmt.Errorf("unable to unmarshal prompt config: %w", err)
+			break
+		}
+		updateErr = s.ResourceMgr.UpdatePrompt(ctx, name, c)
+	default:
+		err = fmt.Errorf("invalid primitive kind provided")
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
+		return
+	}
+	if updateErr != nil {
+		s.logger.DebugContext(ctx, updateErr.Error())
+		_ = render.Render(w, r, newErrResponse(updateErr, http.StatusInternalServerError))
+		return
+	}
 }

--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -67,7 +67,7 @@ func createOrUpdatePrimitives(s *Server, w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// check if primitive exists with the same name and type
+	// Attempt to create or update the primitive based on its kind and name
 	var updateErr error
 	switch strings.ToLower(kind) {
 	case "source":
@@ -84,7 +84,7 @@ func createOrUpdatePrimitives(s *Server, w http.ResponseWriter, r *http.Request)
 			break
 		}
 		updateErr = s.ResourceMgr.UpdateAuthService(ctx, name, c)
-	case "embeddingmodels":
+	case "embeddingmodel":
 		c, err := UnmarshalYAMLEmbeddingModelConfig(ctx, name, req.Config)
 		if err != nil {
 			updateErr = fmt.Errorf("unable to unmarshal embedding model config: %w", err)

--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -36,8 +36,49 @@ func adminRouter(s *Server) (chi.Router, error) {
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
 	r.Put("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { createOrUpdatePrimitives(s, w, r) })
+	r.Delete("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { deletePrimitives(s, w, r) })
 
 	return r, nil
+}
+
+// deletePrimitives handles the deletion of primitives
+// Invalid primitive kind will result in http.StatusBadRequest
+// Primitive not found will result in http.StatusNotFound
+func deletePrimitives(s *Server, w http.ResponseWriter, r *http.Request) {
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+	ctx := r.Context()
+	ctx = util.WithInstrumentation(ctx, s.instrumentation)
+
+	var deleted bool
+	switch strings.ToLower(kind) {
+	case "source":
+		deleted = s.ResourceMgr.DeleteSource(name)
+	case "authservice":
+		deleted = s.ResourceMgr.DeleteAuthService(name)
+	case "embeddingmodel":
+		deleted = s.ResourceMgr.DeleteEmbeddingModel(name)
+	case "tool":
+		deleted = s.ResourceMgr.DeleteTool(name)
+	case "toolset":
+		deleted = s.ResourceMgr.DeleteToolset(name)
+	case "prompt":
+		deleted = s.ResourceMgr.DeletePrompt(name)
+	default:
+		err := fmt.Errorf("invalid primitive kind provided")
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
+		return
+	}
+
+	if !deleted {
+		err := fmt.Errorf("%s %s not found", kind, name)
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 // createOrUpdatePrimitives handles the creation or updating of primitives

--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -37,6 +37,7 @@ func adminRouter(s *Server) (chi.Router, error) {
 
 	r.Put("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { createOrUpdatePrimitives(s, w, r) })
 	r.Delete("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { deletePrimitives(s, w, r) })
+	r.Get("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { getPrimitiveByName(s, w, r) })
 
 	return r, nil
 }
@@ -162,6 +163,80 @@ func createOrUpdatePrimitives(s *Server, w http.ResponseWriter, r *http.Request)
 	if updateErr != nil {
 		s.logger.DebugContext(ctx, updateErr.Error())
 		_ = render.Render(w, r, newErrResponse(updateErr, http.StatusInternalServerError))
+		return
+	}
+}
+
+func getPrimitiveByName(s *Server, w http.ResponseWriter, r *http.Request) {
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+	ctx := r.Context()
+
+	switch strings.ToLower(kind) {
+	case "source":
+		source, ok := s.ResourceMgr.GetSource(name)
+		if !ok {
+			err := fmt.Errorf("%s with name %q does not exist", kind, name)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+		m := source.ToConfig()
+		render.JSON(w, r, m)
+	case "authservice":
+		as, ok := s.ResourceMgr.GetAuthService(name)
+		if !ok {
+			err := fmt.Errorf("%s with name %q does not exist", kind, name)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+		m := as.ToConfig()
+		render.JSON(w, r, m)
+	case "embeddingmodel":
+		em, ok := s.ResourceMgr.GetEmbeddingModel(name)
+		if !ok {
+			err := fmt.Errorf("%s with name %q does not exist", kind, name)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+		m := em.ToConfig()
+		render.JSON(w, r, m)
+	case "tool":
+		tool, ok := s.ResourceMgr.GetTool(name)
+		if !ok {
+			err := fmt.Errorf("%s with name %q does not exist", kind, name)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+		m := tool.ToConfig()
+		render.JSON(w, r, m)
+	case "toolset":
+		ts, ok := s.ResourceMgr.GetToolset(name)
+		if !ok {
+			err := fmt.Errorf("%s with name %q does not exist", kind, name)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+		m := ts.ToConfig()
+		render.JSON(w, r, m)
+	case "prompt":
+		prompt, ok := s.ResourceMgr.GetPrompt(name)
+		if !ok {
+			err := fmt.Errorf("%s with name %q does not exist", kind, name)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+		m := prompt.ToConfig()
+		render.JSON(w, r, m)
+	default:
+		err := fmt.Errorf("invalid primitive kind provided")
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
 		return
 	}
 }

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/googleapis/genai-toolbox/internal/auth"
+	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/genai-toolbox/internal/prompts"
+	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/tools"
+)
+
+func init() {
+	sources.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (sources.SourceConfig, error) {
+		var c testutils.MockSourceConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	auth.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (auth.AuthServiceConfig, error) {
+		var c testutils.MockAuthServiceConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	embeddingmodels.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (embeddingmodels.EmbeddingModelConfig, error) {
+		var c testutils.MockEmbeddingModelConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	tools.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+		var c testutils.MockToolConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+	prompts.Register("mock", func(ctx context.Context, name string, decoder *yaml.Decoder) (prompts.PromptConfig, error) {
+		var c testutils.MockPromptConfig
+		if err := decoder.DecodeContext(ctx, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	})
+}
+
+func TestUpdateEndpoint(t *testing.T) {
+	r, shutdown := setUpServer(t, "admin", map[string]sources.Source{}, map[string]auth.AuthService{}, map[string]embeddingmodels.EmbeddingModel{}, map[string]tools.Tool{}, map[string]tools.Toolset{}, map[string]prompts.Prompt{}, map[string]prompts.Promptset{})
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	tests := []struct {
+		name               string
+		kind               string
+		resourceName       string
+		requestBody        string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Update Source - Success",
+			kind:               "source",
+			resourceName:       "test-source",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Auth Service - Success",
+			kind:               "authService",
+			resourceName:       "test-auth-service",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Embedding Model - Success",
+			kind:               "embeddingModels",
+			resourceName:       "test-embedding-model",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Tool - Success",
+			kind:               "tool",
+			resourceName:       "test-tool",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Toolset - Success",
+			kind:               "toolset",
+			resourceName:       "test-toolset",
+			requestBody:        `{"config": {"name": "test-toolset","tools":["test-tool"]}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update Prompt - Success",
+			kind:               "prompt",
+			resourceName:       "test-prompt",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Update unknown primitives - Error",
+			kind:               "foo",
+			resourceName:       "test-foo",
+			requestBody:        `{"config": {"type": "mock"}}`,
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body, err := runRequest(ts, http.MethodPut, fmt.Sprintf("/%s/%s", tt.kind, tt.resourceName), bytes.NewBuffer([]byte(tt.requestBody)), nil)
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+			if resp.StatusCode != tt.expectedStatusCode {
+				t.Fatalf("response status code is not %d, got %d, %s", tt.expectedStatusCode, resp.StatusCode, string(body))
+			}
+		})
+	}
+}

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -97,7 +97,7 @@ func TestUpdateEndpoint(t *testing.T) {
 		},
 		{
 			name:               "Update Embedding Model - Success",
-			kind:               "embeddingModels",
+			kind:               "embeddingModel",
 			resourceName:       "test-embedding-model",
 			requestBody:        `{"config": {"type": "mock"}}`,
 			expectedStatusCode: http.StatusOK,

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -128,7 +128,7 @@ func TestUpdateEndpoint(t *testing.T) {
 			kind:               "foo",
 			resourceName:       "test-foo",
 			requestBody:        `{"config": {"type": "mock"}}`,
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 		},
 	}
 

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -17,8 +17,10 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -221,6 +223,120 @@ func TestAdminDeleteEndpoint(t *testing.T) {
 			}
 			if resp.StatusCode != tt.expectedStatusCode {
 				t.Fatalf("response status code is not %d, got %d, %s", tt.expectedStatusCode, resp.StatusCode, string(body))
+			}
+		})
+	}
+}
+
+func TestAdminGetEndpoint(t *testing.T) {
+	mockSource := testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{Foo: "foo", Password: "password"}}
+	mockSourceConfigMasked := testutils.MockSourceConfig{Foo: "foo", Password: "***"}
+	mockAuthService := testutils.MockAuthService{MockAuthServiceConfig: testutils.MockAuthServiceConfig{Foo: "foo"}}
+	mockEmbeddingModel := testutils.MockEmbeddingModel{MockEmbeddingModelConfig: testutils.MockEmbeddingModelConfig{Foo: "foo"}}
+	mockTool := testutils.MockTool{MockToolConfig: testutils.MockToolConfig{Foo: "foo"}}
+	mockToolset := tools.Toolset{ToolsetConfig: tools.ToolsetConfig{ToolNames: []string{"test-tool"}}}
+	mockPrompt := testutils.MockPrompt{MockPromptConfig: testutils.MockPromptConfig{Foo: "foo"}}
+
+	mockSources := map[string]sources.Source{"test-source": mockSource}
+	mockAuthServices := map[string]auth.AuthService{"test-auth-service": mockAuthService}
+	mockEmbeddingModels := map[string]embeddingmodels.EmbeddingModel{"test-embedding-model": mockEmbeddingModel}
+	mockTools := map[string]tools.Tool{"test-tool": mockTool}
+	mockToolsets := map[string]tools.Toolset{"test-toolset": mockToolset}
+	mockPrompts := map[string]prompts.Prompt{"test-prompt": mockPrompt}
+
+	r, shutdown := setUpServer(t, "admin", mockSources, mockAuthServices, mockEmbeddingModels, mockTools, mockToolsets, mockPrompts, map[string]prompts.Promptset{})
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	tests := []struct {
+		name               string
+		kind               string
+		resourceName       string
+		want               any
+		expectedStatusCode int
+	}{
+		{
+			name:               "Get Source - Success",
+			kind:               "source",
+			resourceName:       "test-source",
+			want:               mockSourceConfigMasked,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Auth Service - Success",
+			kind:               "authService",
+			resourceName:       "test-auth-service",
+			want:               mockAuthService.ToConfig(),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Embedding Model - Success",
+			kind:               "embeddingModel",
+			resourceName:       "test-embedding-model",
+			want:               mockEmbeddingModel.ToConfig(),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Tool - Success",
+			kind:               "tool",
+			resourceName:       "test-tool",
+			want:               mockTool.ToConfig(),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Toolset - Success",
+			kind:               "toolset",
+			resourceName:       "test-toolset",
+			want:               mockToolset.ToConfig(),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Prompt - Success",
+			kind:               "prompt",
+			resourceName:       "test-prompt",
+			want:               mockPrompt.ToConfig(),
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Non-existent Primitive - Not Found",
+			kind:               "source",
+			resourceName:       "non-existent-source",
+			expectedStatusCode: http.StatusNotFound,
+		},
+		{
+			name:               "Get with Invalid Kind - Bad Request",
+			kind:               "invalidKind",
+			resourceName:       "some-name",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body, err := runRequest(ts, http.MethodGet, fmt.Sprintf("/%s/%s", tt.kind, tt.resourceName), nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+			if resp.StatusCode != tt.expectedStatusCode {
+				t.Fatalf("response status code is not %d, got %d, %s", tt.expectedStatusCode, resp.StatusCode, string(body))
+			}
+			if tt.expectedStatusCode == http.StatusOK {
+				var got any
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("error unmarshaling response body")
+				}
+				var want any
+				wantBytes, err := json.Marshal(tt.want)
+				if err != nil {
+					t.Fatalf("error marshaling want struct")
+				}
+				if err = json.Unmarshal(wantBytes, &want); err != nil {
+					t.Fatalf("error unmarshaling want bytes")
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("unexpected output: got %+v, want %+v", got, want)
+				}
 			}
 		})
 	}

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -68,7 +68,7 @@ func init() {
 	})
 }
 
-func TestUpdateEndpoint(t *testing.T) {
+func TestAdminUpdateEndpoint(t *testing.T) {
 	r, shutdown := setUpServer(t, "admin", map[string]sources.Source{}, map[string]auth.AuthService{}, map[string]embeddingmodels.EmbeddingModel{}, map[string]tools.Tool{}, map[string]tools.Toolset{}, map[string]prompts.Prompt{}, map[string]prompts.Promptset{})
 	defer shutdown()
 	ts := runServer(r, false)
@@ -135,6 +135,87 @@ func TestUpdateEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp, body, err := runRequest(ts, http.MethodPut, fmt.Sprintf("/%s/%s", tt.kind, tt.resourceName), bytes.NewBuffer([]byte(tt.requestBody)), nil)
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+			if resp.StatusCode != tt.expectedStatusCode {
+				t.Fatalf("response status code is not %d, got %d, %s", tt.expectedStatusCode, resp.StatusCode, string(body))
+			}
+		})
+	}
+}
+
+func TestAdminDeleteEndpoint(t *testing.T) {
+	mockSources := map[string]sources.Source{"test-source": testutils.MockSource{}}
+	mockAuthServices := map[string]auth.AuthService{"test-auth-service": testutils.MockAuthService{}}
+	mockEmbeddingModel := map[string]embeddingmodels.EmbeddingModel{"test-embedding-model": testutils.MockEmbeddingModel{}}
+	mockTool := map[string]tools.Tool{"test-tool": testutils.MockTool{}}
+	mockToolset := map[string]tools.Toolset{"test-toolset": tools.Toolset{}}
+	mockPrompt := map[string]prompts.Prompt{"test-prompt": testutils.MockPrompt{}}
+	r, shutdown := setUpServer(t, "admin", mockSources, mockAuthServices, mockEmbeddingModel, mockTool, mockToolset, mockPrompt, map[string]prompts.Promptset{})
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	tests := []struct {
+		name               string
+		kind               string
+		resourceName       string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Delete Source - Success",
+			kind:               "source",
+			resourceName:       "test-source",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Auth Service - Success",
+			kind:               "authService",
+			resourceName:       "test-auth-service",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Embedding Model - Success",
+			kind:               "embeddingModel",
+			resourceName:       "test-embedding-model",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Tool - Success",
+			kind:               "tool",
+			resourceName:       "test-tool",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Toolset - Success",
+			kind:               "toolset",
+			resourceName:       "test-toolset",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Prompt - Success",
+			kind:               "prompt",
+			resourceName:       "test-prompt",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Delete Non-existent Primitive - Not Found",
+			kind:               "source",
+			resourceName:       "non-existent-source",
+			expectedStatusCode: http.StatusNotFound,
+		},
+		{
+			name:               "Delete with Invalid Kind - Bad Request",
+			kind:               "invalidKind",
+			resourceName:       "some-name",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body, err := runRequest(ts, http.MethodDelete, fmt.Sprintf("/%s/%s", tt.kind, tt.resourceName), nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error during request: %s", err)
 			}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 )
 
 func TestToolsetEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2}
+	mockTools := []testutils.MockTool{tool1, tool2}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
-	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
+	r, shutdown := setUpServer(t, "api", nil, nil, nil, toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -124,9 +125,9 @@ func TestToolsetEndpoint(t *testing.T) {
 }
 
 func TestToolGetEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2}
+	mockTools := []testutils.MockTool{tool1, tool2}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
-	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
+	r, shutdown := setUpServer(t, "api", nil, nil, nil, toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -212,9 +213,9 @@ func TestToolGetEndpoint(t *testing.T) {
 }
 
 func TestToolInvokeEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool4, tool5}
+	mockTools := []testutils.MockTool{tool1, tool2, tool4, tool5}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
-	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
+	r, shutdown := setUpServer(t, "api", nil, nil, nil, toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -26,8 +26,13 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/googleapis/genai-toolbox/internal/prompts"
+
+	"github.com/googleapis/genai-toolbox/internal/auth"
+	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
+	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 )
@@ -36,16 +41,16 @@ import (
 const fakeVersionString = "0.0.0"
 
 var (
-	_ tools.Tool     = MockTool{}
-	_ prompts.Prompt = MockPrompt{}
+	_ tools.Tool     = testutils.MockTool{}
+	_ prompts.Prompt = testutils.MockPrompt{}
 )
 
-var tool1 = MockTool{
+var tool1 = testutils.MockTool{
 	Name:   "no_params",
 	Params: []parameters.Parameter{},
 }
 
-var tool2 = MockTool{
+var tool2 = testutils.MockTool{
 	Name: "some_params",
 	Params: parameters.Parameters{
 		parameters.NewIntParameter("param1", "This is the first parameter."),
@@ -53,7 +58,7 @@ var tool2 = MockTool{
 	},
 }
 
-var tool3 = MockTool{
+var tool3 = testutils.MockTool{
 	Name:        "array_param",
 	Description: "some description",
 	Params: parameters.Parameters{
@@ -61,24 +66,24 @@ var tool3 = MockTool{
 	},
 }
 
-var tool4 = MockTool{
+var tool4 = testutils.MockTool{
 	Name:         "unauthorized_tool",
 	Params:       []parameters.Parameter{},
-	unauthorized: true,
+	Unauthorized: true,
 }
 
-var tool5 = MockTool{
+var tool5 = testutils.MockTool{
 	Name:                         "require_client_auth_tool",
 	Params:                       []parameters.Parameter{},
-	requiresClientAuthrorization: true,
+	RequiresClientAuthrorization: true,
 }
 
-var prompt1 = MockPrompt{
+var prompt1 = testutils.MockPrompt{
 	Name: "prompt1",
 	Args: prompts.Arguments{},
 }
 
-var prompt2 = MockPrompt{
+var prompt2 = testutils.MockPrompt{
 	Name: "prompt2",
 	Args: prompts.Arguments{
 		{Parameter: parameters.NewStringParameter("arg1", "This is the first argument.")},
@@ -86,11 +91,11 @@ var prompt2 = MockPrompt{
 }
 
 // setUpResources setups resources to test against
-func setUpResources(t *testing.T, mockTools []MockTool, mockPrompts []MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
+func setUpResources(t *testing.T, mockTools []testutils.MockTool, mockPrompts []testutils.MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
 	toolsMap := make(map[string]tools.Tool)
 	var allTools []string
 	for _, tool := range mockTools {
-		tool.manifest = tool.Manifest()
+		tool.ToolManifest = tool.Manifest()
 		toolsMap[tool.Name] = tool
 		allTools = append(allTools, tool.Name)
 	}
@@ -130,7 +135,7 @@ func setUpResources(t *testing.T, mockTools []MockTool, mockPrompts []MockPrompt
 }
 
 // setUpServer create a new server with tools, toolsets, prompts, and promptsets.
-func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, toolsets map[string]tools.Toolset, prompts map[string]prompts.Prompt, promptsets map[string]prompts.Promptset) (chi.Router, func()) {
+func setUpServer(t *testing.T, router string, sources map[string]sources.Source, authServices map[string]auth.AuthService, embeddingModels map[string]embeddingmodels.EmbeddingModel, tools map[string]tools.Tool, toolsets map[string]tools.Toolset, prompts map[string]prompts.Prompt, promptsets map[string]prompts.Promptset) (chi.Router, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
@@ -150,7 +155,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 
 	sseManager := newSseManager(ctx)
 
-	resourceManager := resources.NewResourceManager(nil, nil, nil, tools, toolsets, prompts, promptsets)
+	resourceManager := resources.NewResourceManager(sources, authServices, embeddingModels, tools, toolsets, prompts, promptsets)
 
 	server := Server{
 		version:         fakeVersionString,

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
 	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 )
 
 const jsonrpcVersion = "2.0"
@@ -76,10 +77,10 @@ var prompt2Args = []any{
 }
 
 func TestMcpEndpointWithoutInitialized(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
-	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -421,10 +422,10 @@ func runInitializeLifecycle(t *testing.T, ts *httptest.Server, protocolVersion s
 }
 
 func TestMcpEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
-	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -908,7 +909,7 @@ func TestMcpEndpoint(t *testing.T) {
 }
 
 func TestInvalidProtocolVersionHeader(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -934,7 +935,7 @@ func TestInvalidProtocolVersionHeader(t *testing.T) {
 }
 
 func TestDeleteEndpoint(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -949,7 +950,7 @@ func TestDeleteEndpoint(t *testing.T) {
 }
 
 func TestGetEndpoint(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -972,7 +973,7 @@ func TestGetEndpoint(t *testing.T) {
 }
 
 func TestSseEndpoint(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil, nil, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -1092,8 +1093,8 @@ func TestStdioSession(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockTools := []MockTool{tool1, tool2, tool3}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
 
 	pr, pw, err := os.Pipe()

--- a/internal/server/resources/resources.go
+++ b/internal/server/resources/resources.go
@@ -15,6 +15,9 @@
 package resources
 
 import (
+	"context"
+	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/googleapis/genai-toolbox/internal/auth"
@@ -22,6 +25,9 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/prompts"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/googleapis/genai-toolbox/internal/util"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ResourceManager contains available resources for the server. Should be initialized with NewResourceManager().
@@ -56,6 +62,18 @@ func NewResourceManager(
 	}
 
 	return resourceMgr
+}
+
+func (r *ResourceManager) SetResources(sourcesMap map[string]sources.Source, authServicesMap map[string]auth.AuthService, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel, toolsMap map[string]tools.Tool, toolsetsMap map[string]tools.Toolset, promptsMap map[string]prompts.Prompt, promptsetsMap map[string]prompts.Promptset) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sources = sourcesMap
+	r.authServices = authServicesMap
+	r.embeddingModels = embeddingModelsMap
+	r.tools = toolsMap
+	r.toolsets = toolsetsMap
+	r.prompts = promptsMap
+	r.promptsets = promptsetsMap
 }
 
 func (r *ResourceManager) GetSource(sourceName string) (sources.Source, bool) {
@@ -107,18 +125,6 @@ func (r *ResourceManager) GetPromptset(promptsetName string) (prompts.Promptset,
 	return promptset, ok
 }
 
-func (r *ResourceManager) SetResources(sourcesMap map[string]sources.Source, authServicesMap map[string]auth.AuthService, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel, toolsMap map[string]tools.Tool, toolsetsMap map[string]tools.Toolset, promptsMap map[string]prompts.Prompt, promptsetsMap map[string]prompts.Promptset) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.sources = sourcesMap
-	r.authServices = authServicesMap
-	r.embeddingModels = embeddingModelsMap
-	r.tools = toolsMap
-	r.toolsets = toolsetsMap
-	r.prompts = promptsMap
-	r.promptsets = promptsetsMap
-}
-
 func (r *ResourceManager) GetAuthServiceMap() map[string]auth.AuthService {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -157,4 +163,215 @@ func (r *ResourceManager) GetPromptsMap() map[string]prompts.Prompt {
 		copiedMap[k] = v
 	}
 	return copiedMap
+}
+
+// UpdateSource creates or update source.
+func (r *ResourceManager) UpdateSource(ctx context.Context, name string, config sources.SourceConfig) error {
+	primitive, exist := r.GetSource(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	childCtx, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/source/init",
+		trace.WithAttributes(attribute.String("source_type", config.SourceConfigType())),
+		trace.WithAttributes(attribute.String("source_name", name)),
+	)
+	defer span.End()
+	s, err := config.Initialize(childCtx, instrumentation.Tracer)
+	if err != nil {
+		return fmt.Errorf("unable to initialize source %q: %w", name, err)
+	}
+	r.sources[name] = s
+	return nil
+}
+
+// UpdateAuthService creates or update auth service.
+func (r *ResourceManager) UpdateAuthService(ctx context.Context, name string, config auth.AuthServiceConfig) error {
+	primitive, exist := r.GetAuthService(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/auth/init",
+		trace.WithAttributes(attribute.String("auth_type", config.AuthServiceConfigType())),
+		trace.WithAttributes(attribute.String("auth_name", name)),
+	)
+	defer span.End()
+	as, err := config.Initialize()
+	if err != nil {
+		return fmt.Errorf("unable to initialize auth service %q: %w", name, err)
+	}
+	r.authServices[name] = as
+	return nil
+}
+
+// UpdateEmbeddingModel creates or update embedding model.
+func (r *ResourceManager) UpdateEmbeddingModel(ctx context.Context, name string, config embeddingmodels.EmbeddingModelConfig) error {
+	primitive, exist := r.GetEmbeddingModel(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/embeddingmodel/init",
+		trace.WithAttributes(attribute.String("model_type", config.EmbeddingModelConfigType())),
+		trace.WithAttributes(attribute.String("model_name", name)),
+	)
+	defer span.End()
+	em, err := config.Initialize(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to initialize embedding model %q: %w", name, err)
+	}
+	r.embeddingModels[name] = em
+	return nil
+}
+
+func removeFirstFromToolset(ts tools.Toolset, target string) tools.Toolset {
+	for i, tool := range ts.Tools {
+		if tool != nil && (*tool) != nil && (*tool).McpManifest().Name == target {
+
+			copy(ts.Tools[i:], ts.Tools[i+1:])
+
+			// Set the very last element to nil to prevent a memory leak
+			ts.Tools[len(ts.Tools)-1] = nil
+			ts.Tools = ts.Tools[:len(ts.Tools)-1]
+			return ts
+		}
+	}
+
+	return ts
+}
+
+// UpdateTool creates or update tool.
+func (r *ResourceManager) UpdateTool(ctx context.Context, name string, config tools.ToolConfig) error {
+	primitive, exist := r.GetTool(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	defaultToolset := r.toolsets[""]
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+		defaultToolset = removeFirstFromToolset(defaultToolset, name)
+	}
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/tool/init",
+		trace.WithAttributes(attribute.String("tool_type", config.ToolConfigType())),
+		trace.WithAttributes(attribute.String("tool_name", name)),
+	)
+	defer span.End()
+	t, err := config.Initialize(r.sources)
+	if err != nil {
+		return fmt.Errorf("unable to initialize tool %q: %w", name, err)
+	}
+	r.tools[name] = t
+	// add new tool to default toolset
+	defaultToolset.Tools = append(defaultToolset.Tools, &t)
+	r.toolsets[""] = defaultToolset
+	return nil
+}
+
+// UpdateToolset creates or update toolset.
+func (r *ResourceManager) UpdateToolset(ctx context.Context, name string, config tools.ToolsetConfig, version string) error {
+	primitive, exist := r.GetToolset(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/toolset/init",
+		trace.WithAttributes(attribute.String("toolset.name", name)),
+	)
+	defer span.End()
+	ts, err := config.Initialize(version, r.tools)
+	if err != nil {
+		return fmt.Errorf("unable to initialize toolset %q: %w", name, err)
+	}
+
+	r.toolsets[name] = ts
+	return nil
+}
+
+// UpdatePrompt creates or update prompt.
+func (r *ResourceManager) UpdatePrompt(ctx context.Context, name string, config prompts.PromptConfig) error {
+	primitive, exist := r.GetPrompt(name)
+	instrumentation, err := util.InstrumentationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		curConfig := primitive.ToConfig()
+		// if config remains the same, return
+		// if diff, re-initialize the primitive
+		if reflect.DeepEqual(config, curConfig) {
+			return nil
+		}
+	}
+
+	_, span := instrumentation.Tracer.Start(
+		ctx,
+		"toolbox/server/prompt/init",
+		trace.WithAttributes(attribute.String("prompt_type", config.PromptConfigType())),
+		trace.WithAttributes(attribute.String("prompt_name", name)),
+	)
+	defer span.End()
+	p, err := config.Initialize()
+	if err != nil {
+		return fmt.Errorf("unable to initialize prompt %q: %w", name, err)
+	}
+	r.prompts[name] = p
+	return nil
 }

--- a/internal/server/resources/resources.go
+++ b/internal/server/resources/resources.go
@@ -260,6 +260,7 @@ func (r *ResourceManager) UpdateEmbeddingModel(ctx context.Context, name string,
 	return nil
 }
 
+// removeFirstFromToolset removes a target tool from toolset
 func removeFirstFromToolset(ts tools.Toolset, target string) tools.Toolset {
 	for i, tool := range ts.Tools {
 		if tool != nil && (*tool) != nil && (*tool).McpManifest().Name == target {
@@ -374,4 +375,83 @@ func (r *ResourceManager) UpdatePrompt(ctx context.Context, name string, config 
 	}
 	r.prompts[name] = p
 	return nil
+}
+
+// DeleteSource deletes a source.
+func (r *ResourceManager) DeleteSource(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.sources[name]
+	if !ok {
+		return false
+	}
+	delete(r.sources, name)
+	return true
+}
+
+// DeleteAuthService deletes an auth service.
+func (r *ResourceManager) DeleteAuthService(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.authServices[name]
+	if !ok {
+		return false
+	}
+	delete(r.authServices, name)
+	return true
+}
+
+// DeleteEmbeddingModel deletes an embedding model.
+func (r *ResourceManager) DeleteEmbeddingModel(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.embeddingModels[name]
+	if !ok {
+		return false
+	}
+	delete(r.embeddingModels, name)
+	return true
+}
+
+// DeleteTool deletes a tool.
+func (r *ResourceManager) DeleteTool(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.tools[name]
+	if !ok {
+		return false
+	}
+	delete(r.tools, name)
+
+	// Also remove the tool from the default toolset
+	// This function do not remove tool from other toolset. User have to update
+	// toolset explicitly
+	if defaultToolset, toolsetExists := r.toolsets[""]; toolsetExists {
+		r.toolsets[""] = removeFirstFromToolset(defaultToolset, name)
+	}
+	return true
+}
+
+// DeleteToolset deletes a toolset.
+func (r *ResourceManager) DeleteToolset(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.toolsets[name]
+	if !ok {
+		return false
+	}
+	delete(r.toolsets, name)
+	return true
+}
+
+// DeletePrompt deletes a prompt.
+func (r *ResourceManager) DeletePrompt(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.prompts[name]
+	if !ok {
+		return false
+	}
+	delete(r.prompts, name)
+	return true
 }

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -189,7 +189,7 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 	}
 	sc := source.ToConfig()
 	if !reflect.DeepEqual(sc, sourceConfig) {
-		t.Fatalf("update failed: got %s, want %s", sc, sourceConfig)
+		t.Fatalf("update failed: got %+v, want %+v", sc, sourceConfig)
 	}
 
 	asConfig = &testutils.MockAuthServiceConfig{}
@@ -200,7 +200,7 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 		t.Fatalf("missing auth service")
 	}
 	if !reflect.DeepEqual(as, asConfig) {
-		t.Fatalf("update failed: got %s, want %s", as, asConfig)
+		t.Fatalf("update failed: got %+v, want %+v", as, asConfig)
 	}
 
 	emConfig = &testutils.MockEmbeddingModelConfig{}
@@ -211,7 +211,7 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 		t.Fatalf("missing embedding model")
 	}
 	if !reflect.DeepEqual(em, emConfig) {
-		t.Fatalf("update failed: got %s, want %s", em, emConfig)
+		t.Fatalf("update failed: got %+v, want %+v", em, emConfig)
 	}
 
 	toolConfig = &testutils.MockToolConfig{}
@@ -222,7 +222,7 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 		t.Fatalf("missing tool")
 	}
 	if !reflect.DeepEqual(tool, toolConfig) {
-		t.Fatalf("update failed: got %s, want %s", tool, toolConfig)
+		t.Fatalf("update failed: got %+v, want %+v", tool, toolConfig)
 	}
 
 	tsConfig = tools.ToolsetConfig{
@@ -236,7 +236,7 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 		t.Fatalf("missing toolset")
 	}
 	if !reflect.DeepEqual(ts, tsConfig) {
-		t.Fatalf("update failed: got %v, want %v", ts, tsConfig)
+		t.Fatalf("update failed: got %+v, want %+v", ts, tsConfig)
 	}
 
 	pConfig = &testutils.MockPromptConfig{}
@@ -247,6 +247,6 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 		t.Fatalf("missing prompt")
 	}
 	if !reflect.DeepEqual(p, pConfig) {
-		t.Fatalf("update failed: got %s, want %s", p, pConfig)
+		t.Fatalf("update failed: got %+v, want %+v", p, pConfig)
 	}
 }

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -199,8 +199,9 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing auth service")
 	}
-	if !reflect.DeepEqual(as, asConfig) {
-		t.Fatalf("update failed: got %+v, want %+v", as, asConfig)
+	asc := as.ToConfig()
+	if !reflect.DeepEqual(asc, asConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", asc, asConfig)
 	}
 
 	emConfig = &testutils.MockEmbeddingModelConfig{}
@@ -210,8 +211,9 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing embedding model")
 	}
-	if !reflect.DeepEqual(em, emConfig) {
-		t.Fatalf("update failed: got %+v, want %+v", em, emConfig)
+	emc := em.ToConfig()
+	if !reflect.DeepEqual(emc, emConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", emc, emConfig)
 	}
 
 	toolConfig = &testutils.MockToolConfig{}
@@ -221,8 +223,9 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing tool")
 	}
-	if !reflect.DeepEqual(tool, toolConfig) {
-		t.Fatalf("update failed: got %+v, want %+v", tool, toolConfig)
+	tc := tool.ToConfig()
+	if !reflect.DeepEqual(tc, toolConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", tc, toolConfig)
 	}
 
 	tsConfig = tools.ToolsetConfig{
@@ -235,8 +238,9 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing toolset")
 	}
-	if !reflect.DeepEqual(ts, tsConfig) {
-		t.Fatalf("update failed: got %+v, want %+v", ts, tsConfig)
+	tsc := ts.ToConfig()
+	if !reflect.DeepEqual(tsc, tsConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", tsc, tsConfig)
 	}
 
 	pConfig = &testutils.MockPromptConfig{}
@@ -246,7 +250,8 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing prompt")
 	}
-	if !reflect.DeepEqual(p, pConfig) {
-		t.Fatalf("update failed: got %+v, want %+v", p, pConfig)
+	pc := p.ToConfig()
+	if !reflect.DeepEqual(pc, pConfig) {
+		t.Fatalf("update failed: got %+v, want %+v", pc, pConfig)
 	}
 }

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -15,6 +15,8 @@
 package resources_test
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,7 +26,11 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/server/resources"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
+	"github.com/googleapis/genai-toolbox/internal/telemetry"
+	"github.com/googleapis/genai-toolbox/internal/testutils"
 	"github.com/googleapis/genai-toolbox/internal/tools"
+	"github.com/googleapis/genai-toolbox/internal/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateServer(t *testing.T) {
@@ -101,5 +107,146 @@ func TestUpdateServer(t *testing.T) {
 	gotSource, _ = resMgr.GetSource("example-source2")
 	if diff := cmp.Diff(gotSource, updateSource["example-source2"]); diff != "" {
 		t.Errorf("error updating server, sources (-want +got):\n%s", diff)
+	}
+}
+
+func TestCreateAndUpdatePrimitives(t *testing.T) {
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation("test-version")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	ctx := context.Background()
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+	resMgr := resources.NewResourceManager(
+		map[string]sources.Source{},
+		map[string]auth.AuthService{},
+		map[string]embeddingmodels.EmbeddingModel{},
+		map[string]tools.Tool{},
+		map[string]tools.Toolset{},
+		map[string]prompts.Prompt{},
+		map[string]prompts.Promptset{},
+	)
+
+	// create primitives
+	sourceConfig := &testutils.MockSourceConfig{}
+	err = resMgr.UpdateSource(ctx, "test-source", sourceConfig)
+	assert.NoError(t, err)
+	_, ok := resMgr.GetSource("test-source")
+	if !ok {
+		t.Fatalf("missing source")
+	}
+
+	asConfig := &testutils.MockAuthServiceConfig{}
+	err = resMgr.UpdateAuthService(ctx, "test-auth-service", asConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetAuthService("test-auth-service")
+	if !ok {
+		t.Fatalf("missing auth service")
+	}
+
+	emConfig := &testutils.MockEmbeddingModelConfig{}
+	err = resMgr.UpdateEmbeddingModel(ctx, "test-embedding-model", emConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetEmbeddingModel("test-embedding-model")
+	if !ok {
+		t.Fatalf("missing embedding model")
+	}
+
+	toolConfig := &testutils.MockToolConfig{}
+	err = resMgr.UpdateTool(ctx, "test-tool", toolConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetTool("test-tool")
+	if !ok {
+		t.Fatalf("missing tool")
+	}
+
+	tsConfig := tools.ToolsetConfig{
+		Name:      "test-toolset",
+		ToolNames: []string{},
+	}
+	err = resMgr.UpdateToolset(ctx, "test-toolset", tsConfig, "test-version")
+	assert.NoError(t, err)
+	_, ok = resMgr.GetToolset("test-toolset")
+	if !ok {
+		t.Fatalf("missing toolset")
+	}
+
+	pConfig := &testutils.MockPromptConfig{}
+	err = resMgr.UpdatePrompt(ctx, "test-prompt", pConfig)
+	assert.NoError(t, err)
+	_, ok = resMgr.GetPrompt("test-prompt")
+	if !ok {
+		t.Fatalf("missing prompt")
+	}
+
+	// Update primitives
+	sourceConfig = &testutils.MockSourceConfig{Foo: "foo"}
+	err = resMgr.UpdateSource(ctx, "test-source", sourceConfig)
+	assert.NoError(t, err)
+	source, ok := resMgr.GetSource("test-source")
+	if !ok {
+		t.Fatalf("missing source")
+	}
+	sc := source.ToConfig()
+	if !reflect.DeepEqual(sc, sourceConfig) {
+		t.Fatalf("update failed: got %s, want %s", sc, sourceConfig)
+	}
+
+	asConfig = &testutils.MockAuthServiceConfig{}
+	err = resMgr.UpdateAuthService(ctx, "test-auth-service", asConfig)
+	assert.NoError(t, err)
+	as, ok := resMgr.GetAuthService("test-auth-service")
+	if !ok {
+		t.Fatalf("missing auth service")
+	}
+	if !reflect.DeepEqual(as, asConfig) {
+		t.Fatalf("update failed: got %s, want %s", as, asConfig)
+	}
+
+	emConfig = &testutils.MockEmbeddingModelConfig{}
+	err = resMgr.UpdateEmbeddingModel(ctx, "test-embedding-model", emConfig)
+	assert.NoError(t, err)
+	em, ok := resMgr.GetEmbeddingModel("test-embedding-model")
+	if !ok {
+		t.Fatalf("missing embedding model")
+	}
+	if !reflect.DeepEqual(em, emConfig) {
+		t.Fatalf("update failed: got %s, want %s", em, emConfig)
+	}
+
+	toolConfig = &testutils.MockToolConfig{}
+	err = resMgr.UpdateTool(ctx, "test-tool", toolConfig)
+	assert.NoError(t, err)
+	tool, ok := resMgr.GetTool("test-tool")
+	if !ok {
+		t.Fatalf("missing tool")
+	}
+	if !reflect.DeepEqual(tool, toolConfig) {
+		t.Fatalf("update failed: got %s, want %s", tool, toolConfig)
+	}
+
+	tsConfig = tools.ToolsetConfig{
+		Name:      "test-toolset",
+		ToolNames: []string{"test-tool"},
+	}
+	err = resMgr.UpdateToolset(ctx, "test-toolset", tsConfig, "test-version")
+	assert.NoError(t, err)
+	ts, ok := resMgr.GetToolset("test-toolset")
+	if !ok {
+		t.Fatalf("missing toolset")
+	}
+	if !reflect.DeepEqual(ts, tsConfig) {
+		t.Fatalf("update failed: got %v, want %v", ts, tsConfig)
+	}
+
+	pConfig = &testutils.MockPromptConfig{}
+	err = resMgr.UpdatePrompt(ctx, "test-prompt", pConfig)
+	assert.NoError(t, err)
+	p, ok := resMgr.GetPrompt("test-prompt")
+	if !ok {
+		t.Fatalf("missing prompt")
+	}
+	if !reflect.DeepEqual(p, pConfig) {
+		t.Fatalf("update failed: got %s, want %s", p, pConfig)
 	}
 }

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -255,3 +255,94 @@ func TestCreateAndUpdatePrimitives(t *testing.T) {
 		t.Fatalf("update failed: got %+v, want %+v", pc, pConfig)
 	}
 }
+
+func TestDeletePrimitives(t *testing.T) {
+	resMgr := resources.NewResourceManager(
+		map[string]sources.Source{"foo": testutils.MockSource{}},
+		map[string]auth.AuthService{"foo": testutils.MockAuthService{}},
+		map[string]embeddingmodels.EmbeddingModel{"foo": testutils.MockEmbeddingModel{}},
+		map[string]tools.Tool{"foo": testutils.MockTool{}},
+		map[string]tools.Toolset{"foo": tools.Toolset{}},
+		map[string]prompts.Prompt{"foo": testutils.MockPrompt{}},
+		map[string]prompts.Promptset{},
+	)
+
+	var deleted, found bool
+	deleted = resMgr.DeleteSource("foo")
+	if !deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+	_, found = resMgr.GetSource("foo")
+	if found {
+		t.Fatalf("found source but expected to be deleted")
+	}
+	deleted = resMgr.DeleteSource("nonexistent")
+	if deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+
+	deleted = resMgr.DeleteAuthService("foo")
+	if !deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+	_, found = resMgr.GetAuthService("foo")
+	if found {
+		t.Fatalf("found auth service but expected to be deleted")
+	}
+	deleted = resMgr.DeleteAuthService("nonexistent")
+	if deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+
+	deleted = resMgr.DeleteEmbeddingModel("foo")
+	if !deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+	_, found = resMgr.GetEmbeddingModel("foo")
+	if found {
+		t.Fatalf("found embedding model but expected to be deleted")
+	}
+	deleted = resMgr.DeleteEmbeddingModel("nonexistent")
+	if deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+
+	deleted = resMgr.DeleteTool("foo")
+	if !deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+	_, found = resMgr.GetTool("foo")
+	if found {
+		t.Fatalf("found tool but expected to be deleted")
+	}
+	deleted = resMgr.DeleteTool("nonexistent")
+	if deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+
+	deleted = resMgr.DeleteToolset("foo")
+	if !deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+	_, found = resMgr.GetToolset("foo")
+	if found {
+		t.Fatalf("found toolset but expected to be deleted")
+	}
+	deleted = resMgr.DeleteToolset("nonexistent")
+	if deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+
+	deleted = resMgr.DeletePrompt("foo")
+	if !deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+	_, found = resMgr.GetPrompt("foo")
+	if found {
+		t.Fatalf("found prompt but expected to be deleted")
+	}
+	deleted = resMgr.DeletePrompt("nonexistent")
+	if deleted {
+		t.Fatalf("expected delete to be successful")
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -327,7 +327,7 @@ func TestPRMEndpoint(t *testing.T) {
 	}
 
 	// Initialize and start the server
-	s, err := server.NewServer(ctx, cfg)
+	s, err := server.NewServer(ctx, cfg, false)
 	if err != nil {
 		t.Fatalf("unable to initialize server: %v", err)
 	}
@@ -429,7 +429,7 @@ func TestPRMOverride(t *testing.T) {
 	}
 
 	// Initialize and Start the Server
-	s, err := server.NewServer(ctx, cfg)
+	s, err := server.NewServer(ctx, cfg, false)
 	if err != nil {
 		t.Fatalf("unable to initialize server: %v", err)
 	}

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -56,8 +56,8 @@ type Config struct {
 	Cluster  string         `yaml:"cluster" validate:"required"`
 	Instance string         `yaml:"instance" validate:"required"`
 	IPType   sources.IPType `yaml:"ipType" validate:"required"`
-	User     string         `yaml:"user"`
-	Password string         `yaml:"password"`
+	User     util.Secret    `yaml:"user"`
+	Password util.Secret    `yaml:"password"`
 	Database string         `yaml:"database" validate:"required"`
 }
 
@@ -66,7 +66,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User.String(), r.Password.String(), r.Database)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/alloydbpg/alloydb_pg_test.go
+++ b/internal/sources/alloydbpg/alloydb_pg_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/alloydbpg"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlAlloyDBPg(t *testing.T) {
@@ -55,8 +56,8 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "public",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -85,8 +86,8 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "public",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -115,8 +116,8 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "private",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},

--- a/internal/sources/clickhouse/clickhouse.go
+++ b/internal/sources/clickhouse/clickhouse.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -48,15 +49,15 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"type" validate:"required"`
-	Host     string `yaml:"host" validate:"required"`
-	Port     string `yaml:"port" validate:"required"`
-	Database string `yaml:"database" validate:"required"`
-	User     string `yaml:"user" validate:"required"`
-	Password string `yaml:"password"`
-	Protocol string `yaml:"protocol"`
-	Secure   bool   `yaml:"secure"`
+	Name     string      `yaml:"name" validate:"required"`
+	Type     string      `yaml:"type" validate:"required"`
+	Host     string      `yaml:"host" validate:"required"`
+	Port     string      `yaml:"port" validate:"required"`
+	Database string      `yaml:"database" validate:"required"`
+	User     util.Secret `yaml:"user" validate:"required"`
+	Password util.Secret `yaml:"password"`
+	Protocol string      `yaml:"protocol"`
+	Secure   bool        `yaml:"secure"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -64,7 +65,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initClickHouseConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.Protocol, r.Secure)
+	pool, err := initClickHouseConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.Protocol, r.Secure)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
@@ -56,8 +56,8 @@ type Config struct {
 	Region   string         `yaml:"region" validate:"required"`
 	Instance string         `yaml:"instance" validate:"required"`
 	IPType   sources.IPType `yaml:"ipType" validate:"required"`
-	User     string         `yaml:"user" validate:"required"`
-	Password string         `yaml:"password" validate:"required"`
+	User     util.Secret    `yaml:"user" validate:"required"`
+	Password util.Secret    `yaml:"password" validate:"required"`
 	Database string         `yaml:"database" validate:"required"`
 }
 
@@ -68,7 +68,7 @@ func (r Config) SourceConfigType() string {
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
 	// Initializes a Cloud SQL MSSQL source
-	db, err := initCloudSQLMssqlConnection(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	db, err := initCloudSQLMssqlConnection(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User.String(), r.Password.String(), r.Database)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create db connection: %w", err)
 	}

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql_test.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/cloudsqlmssql"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlCloudSQLMssql(t *testing.T) {
@@ -53,8 +54,8 @@ func TestParseFromYamlCloudSQLMssql(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "public",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -81,8 +82,8 @@ func TestParseFromYamlCloudSQLMssql(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "psc",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -56,8 +56,8 @@ type Config struct {
 	Region   string         `yaml:"region" validate:"required"`
 	Instance string         `yaml:"instance" validate:"required"`
 	IPType   sources.IPType `yaml:"ipType"`
-	User     string         `yaml:"user"`
-	Password string         `yaml:"password"`
+	User     util.Secret    `yaml:"user"`
+	Password util.Secret    `yaml:"password"`
 	Database string         `yaml:"database"`
 }
 
@@ -66,7 +66,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initCloudSQLMySQLConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initCloudSQLMySQLConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User.String(), r.Password.String(), r.Database)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql_test.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/cloudsqlmysql"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
@@ -51,8 +52,8 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 					Region:   "my-region",
 					Instance: "my-instance",
 					IPType:   "public",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -79,8 +80,8 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "public",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -107,8 +108,8 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "private",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -135,8 +136,8 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "psc",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -55,8 +55,8 @@ type Config struct {
 	Instance string         `yaml:"instance" validate:"required"`
 	IPType   sources.IPType `yaml:"ipType" validate:"required"`
 	Database string         `yaml:"database" validate:"required"`
-	User     string         `yaml:"user"`
-	Password string         `yaml:"password"`
+	User     util.Secret    `yaml:"user"`
+	Password util.Secret    `yaml:"password"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -64,7 +64,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User.String(), r.Password.String(), r.Database)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/cloudsqlpg"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlCloudSQLPg(t *testing.T) {
@@ -53,8 +54,8 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "public",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -81,8 +82,8 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "public",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -109,8 +110,8 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "private",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -137,8 +138,8 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 					Instance: "my-instance",
 					IPType:   "psc",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},

--- a/internal/sources/cockroachdb/cockroachdb.go
+++ b/internal/sources/cockroachdb/cockroachdb.go
@@ -74,8 +74,8 @@ type Config struct {
 	Type           string            `yaml:"type" validate:"required"`
 	Host           string            `yaml:"host" validate:"required"`
 	Port           string            `yaml:"port" validate:"required"`
-	User           string            `yaml:"user" validate:"required"`
-	Password       string            `yaml:"password"`
+	User           util.Secret       `yaml:"user" validate:"required"`
+	Password       util.Secret       `yaml:"password"`
 	Database       string            `yaml:"database" validate:"required"`
 	QueryParams    map[string]string `yaml:"queryParams"`
 	MaxRetries     int               `yaml:"maxRetries"`
@@ -103,7 +103,7 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 		return nil, fmt.Errorf("invalid retryBaseDelay: %w", err)
 	}
 
-	pool, err := initCockroachDBConnectionPoolWithRetry(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.QueryParams, r.MaxRetries, retryBaseDelay)
+	pool, err := initCockroachDBConnectionPoolWithRetry(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.QueryParams, r.MaxRetries, retryBaseDelay)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -350,7 +350,7 @@ func (s *Source) EmitTelemetry(ctx context.Context, event TelemetryEvent) {
 		event.Database = s.Database
 	}
 	if event.User == "" {
-		event.User = s.User
+		event.User = s.User.String()
 	}
 
 	// Log as structured JSON

--- a/internal/sources/couchbase/couchbase.go
+++ b/internal/sources/couchbase/couchbase.go
@@ -25,6 +25,7 @@ import (
 	tlsutil "github.com/couchbase/tools-common/http/tls"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -49,21 +50,21 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name                 string `yaml:"name" validate:"required"`
-	Type                 string `yaml:"type" validate:"required"`
-	ConnectionString     string `yaml:"connectionString" validate:"required"`
-	Bucket               string `yaml:"bucket" validate:"required"`
-	Scope                string `yaml:"scope" validate:"required"`
-	Username             string `yaml:"username"`
-	Password             string `yaml:"password"`
-	ClientCert           string `yaml:"clientCert"`
-	ClientCertPassword   string `yaml:"clientCertPassword"`
-	ClientKey            string `yaml:"clientKey"`
-	ClientKeyPassword    string `yaml:"clientKeyPassword"`
-	CACert               string `yaml:"caCert"`
-	NoSSLVerify          bool   `yaml:"noSslVerify"`
-	Profile              string `yaml:"profile"`
-	QueryScanConsistency uint   `yaml:"queryScanConsistency"`
+	Name                 string      `yaml:"name" validate:"required"`
+	Type                 string      `yaml:"type" validate:"required"`
+	ConnectionString     string      `yaml:"connectionString" validate:"required"`
+	Bucket               string      `yaml:"bucket" validate:"required"`
+	Scope                string      `yaml:"scope" validate:"required"`
+	Username             util.Secret `yaml:"username"`
+	Password             util.Secret `yaml:"password"`
+	ClientCert           string      `yaml:"clientCert"`
+	ClientCertPassword   util.Secret `yaml:"clientCertPassword"`
+	ClientKey            string      `yaml:"clientKey"`
+	ClientKeyPassword    util.Secret `yaml:"clientKeyPassword"`
+	CACert               string      `yaml:"caCert"`
+	NoSSLVerify          bool        `yaml:"noSslVerify"`
+	Profile              string      `yaml:"profile"`
+	QueryScanConsistency uint        `yaml:"queryScanConsistency"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -138,8 +139,8 @@ func (r Config) createCouchbaseOptions() (gocb.ClusterOptions, error) {
 
 	if r.Username != "" {
 		auth := gocb.PasswordAuthenticator{
-			Username: r.Username,
-			Password: r.Password,
+			Username: r.Username.String(),
+			Password: r.Password.String(),
 		}
 		cbOpts.Authenticator = auth
 	}
@@ -170,7 +171,7 @@ func (r Config) createCouchbaseOptions() (gocb.ClusterOptions, error) {
 		tlsConfig, err := tlsutil.NewConfig(tlsutil.ConfigOptions{
 			ClientCert:     clientCert,
 			ClientKey:      clientKey,
-			Password:       []byte(getCertKeyPassword(r.ClientCertPassword, r.ClientKeyPassword)),
+			Password:       []byte(getCertKeyPassword(r.ClientCertPassword.String(), r.ClientKeyPassword.String())),
 			ClientAuthType: tls.VerifyClientCertIfGiven,
 			RootCAs:        caCert,
 			NoSSLVerify:    r.NoSSLVerify,

--- a/internal/sources/dgraph/dgraph.go
+++ b/internal/sources/dgraph/dgraph.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -66,13 +67,13 @@ type DgraphClient struct {
 }
 
 type Config struct {
-	Name      string `yaml:"name" validate:"required"`
-	Type      string `yaml:"type" validate:"required"`
-	DgraphUrl string `yaml:"dgraphUrl" validate:"required"`
-	User      string `yaml:"user"`
-	Password  string `yaml:"password"`
-	Namespace uint64 `yaml:"namespace"`
-	ApiKey    string `yaml:"apiKey"`
+	Name      string      `yaml:"name" validate:"required"`
+	Type      string      `yaml:"type" validate:"required"`
+	DgraphUrl string      `yaml:"dgraphUrl" validate:"required"`
+	User      util.Secret `yaml:"user"`
+	Password  util.Secret `yaml:"password"`
+	Namespace uint64      `yaml:"namespace"`
+	ApiKey    string      `yaml:"apiKey"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -150,9 +151,9 @@ func initDgraphHttpClient(ctx context.Context, tracer trace.Tracer, r Config) (*
 		httpClient: &http.Client{},
 		baseUrl:    r.DgraphUrl,
 		HttpToken: &HttpToken{
-			UserId:    r.User,
+			UserId:    r.User.String(),
 			Namespace: r.Namespace,
-			Password:  r.Password,
+			Password:  r.Password.String(),
 		},
 		apiKey: r.ApiKey,
 	}

--- a/internal/sources/elasticsearch/elasticsearch.go
+++ b/internal/sources/elasticsearch/elasticsearch.go
@@ -50,12 +50,12 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name      string   `yaml:"name" validate:"required"`
-	Type      string   `yaml:"type" validate:"required"`
-	Addresses []string `yaml:"addresses" validate:"required"`
-	Username  string   `yaml:"username"`
-	Password  string   `yaml:"password"`
-	APIKey    string   `yaml:"apikey"`
+	Name      string      `yaml:"name" validate:"required"`
+	Type      string      `yaml:"type" validate:"required"`
+	Addresses []string    `yaml:"addresses" validate:"required"`
+	Username  util.Secret `yaml:"username"`
+	Password  util.Secret `yaml:"password"`
+	APIKey    string      `yaml:"apikey"`
 }
 
 func (c Config) SourceConfigType() string {
@@ -103,8 +103,8 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	// Client need either username and password or an API key
 	if c.Username != "" && c.Password != "" {
-		cfg.Username = c.Username
-		cfg.Password = c.Password
+		cfg.Username = c.Username.String()
+		cfg.Password = c.Password.String()
 	} else if c.APIKey != "" {
 		// API key will be set below
 		cfg.APIKey = c.APIKey

--- a/internal/sources/firebird/firebird.go
+++ b/internal/sources/firebird/firebird.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 const SourceType string = "firebird"
@@ -46,13 +47,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"type" validate:"required"`
-	Host     string `yaml:"host" validate:"required"`
-	Port     string `yaml:"port" validate:"required"`
-	User     string `yaml:"user" validate:"required"`
-	Password string `yaml:"password" validate:"required"`
-	Database string `yaml:"database" validate:"required"`
+	Name     string      `yaml:"name" validate:"required"`
+	Type     string      `yaml:"type" validate:"required"`
+	Host     string      `yaml:"host" validate:"required"`
+	Port     string      `yaml:"port" validate:"required"`
+	User     util.Secret `yaml:"user" validate:"required"`
+	Password util.Secret `yaml:"password" validate:"required"`
+	Database string      `yaml:"database" validate:"required"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -60,7 +61,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initFirebirdConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database)
+	pool, err := initFirebirdConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/firebird/firebird_test.go
+++ b/internal/sources/firebird/firebird_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/firebird"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlFirebird(t *testing.T) {
@@ -50,8 +51,8 @@ func TestParseFromYamlFirebird(t *testing.T) {
 					Host:     "my-host",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},

--- a/internal/sources/mindsdb/mindsdb.go
+++ b/internal/sources/mindsdb/mindsdb.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/tools/mysql/mysqlcommon"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -47,14 +48,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name         string `yaml:"name" validate:"required"`
-	Type         string `yaml:"type" validate:"required"`
-	Host         string `yaml:"host" validate:"required"`
-	Port         string `yaml:"port" validate:"required"`
-	User         string `yaml:"user" validate:"required"`
-	Password     string `yaml:"password"`
-	Database     string `yaml:"database" validate:"required"`
-	QueryTimeout string `yaml:"queryTimeout"`
+	Name         string      `yaml:"name" validate:"required"`
+	Type         string      `yaml:"type" validate:"required"`
+	Host         string      `yaml:"host" validate:"required"`
+	Port         string      `yaml:"port" validate:"required"`
+	User         util.Secret `yaml:"user" validate:"required"`
+	Password     util.Secret `yaml:"password"`
+	Database     string      `yaml:"database" validate:"required"`
+	QueryTimeout string      `yaml:"queryTimeout"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -62,7 +63,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initMindsDBConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.QueryTimeout)
+	pool, err := initMindsDBConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.QueryTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/mindsdb/mindsdb_test.go
+++ b/internal/sources/mindsdb/mindsdb_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/mindsdb"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlMindsDB(t *testing.T) {
@@ -50,8 +51,8 @@ func TestParseFromYamlMindsDB(t *testing.T) {
 					Host:     "0.0.0.0",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -75,8 +76,8 @@ func TestParseFromYamlMindsDB(t *testing.T) {
 					Host:         "0.0.0.0",
 					Port:         "my-port",
 					Database:     "my_db",
-					User:         "my_user",
-					Password:     "my_pass",
+					User:         util.Secret("my_user"),
+					Password:     util.Secret("my_pass"),
 					QueryTimeout: "45s",
 				},
 			},

--- a/internal/sources/mssql/mssql.go
+++ b/internal/sources/mssql/mssql.go
@@ -49,14 +49,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	// Cloud SQL MSSQL configs
-	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"type" validate:"required"`
-	Host     string `yaml:"host" validate:"required"`
-	Port     string `yaml:"port" validate:"required"`
-	User     string `yaml:"user" validate:"required"`
-	Password string `yaml:"password" validate:"required"`
-	Database string `yaml:"database" validate:"required"`
-	Encrypt  string `yaml:"encrypt"`
+	Name     string      `yaml:"name" validate:"required"`
+	Type     string      `yaml:"type" validate:"required"`
+	Host     string      `yaml:"host" validate:"required"`
+	Port     string      `yaml:"port" validate:"required"`
+	User     util.Secret `yaml:"user" validate:"required"`
+	Password util.Secret `yaml:"password" validate:"required"`
+	Database string      `yaml:"database" validate:"required"`
+	Encrypt  string      `yaml:"encrypt"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -66,7 +66,7 @@ func (r Config) SourceConfigType() string {
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
 	// Initializes a MSSQL source
-	db, err := initMssqlConnection(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.Encrypt)
+	db, err := initMssqlConnection(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.Encrypt)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create db connection: %w", err)
 	}

--- a/internal/sources/mssql/mssql_test.go
+++ b/internal/sources/mssql/mssql_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/mssql"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlMssql(t *testing.T) {
@@ -50,8 +51,8 @@ func TestParseFromYamlMssql(t *testing.T) {
 					Host:     "0.0.0.0",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -75,8 +76,8 @@ func TestParseFromYamlMssql(t *testing.T) {
 					Host:     "0.0.0.0",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 					Encrypt:  "strict",
 				},
 			},

--- a/internal/sources/mysql/mysql.go
+++ b/internal/sources/mysql/mysql.go
@@ -53,8 +53,8 @@ type Config struct {
 	Type         string            `yaml:"type" validate:"required"`
 	Host         string            `yaml:"host" validate:"required"`
 	Port         string            `yaml:"port" validate:"required"`
-	User         string            `yaml:"user"`
-	Password     string            `yaml:"password"`
+	User         util.Secret       `yaml:"user"`
+	Password     util.Secret       `yaml:"password"`
 	Database     string            `yaml:"database"`
 	QueryTimeout string            `yaml:"queryTimeout"`
 	QueryParams  map[string]string `yaml:"queryParams"`
@@ -65,7 +65,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initMySQLConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.QueryTimeout, r.QueryParams)
+	pool, err := initMySQLConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.QueryTimeout, r.QueryParams)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/mysql/mysql_test.go
+++ b/internal/sources/mysql/mysql_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/mysql"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
@@ -73,8 +74,8 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 					Host:         "0.0.0.0",
 					Port:         "my-port",
 					Database:     "my_db",
-					User:         "my_user",
-					Password:     "my_pass",
+					User:         util.Secret("my_user"),
+					Password:     util.Secret("my_pass"),
 					QueryTimeout: "45s",
 				},
 			},
@@ -101,8 +102,8 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 					Host:     "0.0.0.0",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 					QueryParams: map[string]string{
 						"tls":     "preferred",
 						"charset": "utf8mb4",

--- a/internal/sources/neo4j/neo4j.go
+++ b/internal/sources/neo4j/neo4j.go
@@ -51,12 +51,12 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"type" validate:"required"`
-	Uri      string `yaml:"uri" validate:"required"`
-	User     string `yaml:"user" validate:"required"`
-	Password string `yaml:"password" validate:"required"`
-	Database string `yaml:"database" validate:"required"`
+	Name     string      `yaml:"name" validate:"required"`
+	Type     string      `yaml:"type" validate:"required"`
+	Uri      string      `yaml:"uri" validate:"required"`
+	User     util.Secret `yaml:"user" validate:"required"`
+	Password util.Secret `yaml:"password" validate:"required"`
+	Database string      `yaml:"database" validate:"required"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -64,7 +64,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	driver, err := initNeo4jDriver(ctx, tracer, r.Uri, r.User, r.Password, r.Name)
+	driver, err := initNeo4jDriver(ctx, tracer, r.Uri, r.User.String(), r.Password.String(), r.Name)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create driver: %w", err)
 	}

--- a/internal/sources/neo4j/neo4j_test.go
+++ b/internal/sources/neo4j/neo4j_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/neo4j"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlNeo4j(t *testing.T) {
@@ -48,8 +49,8 @@ func TestParseFromYamlNeo4j(t *testing.T) {
 					Type:     neo4j.SourceType,
 					Uri:      "neo4j+s://my-host:7687",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},

--- a/internal/sources/oceanbase/oceanbase.go
+++ b/internal/sources/oceanbase/oceanbase.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/tools/mysql/mysqlcommon"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -47,14 +48,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name         string `yaml:"name" validate:"required"`
-	Type         string `yaml:"type" validate:"required"`
-	Host         string `yaml:"host" validate:"required"`
-	Port         string `yaml:"port" validate:"required"`
-	User         string `yaml:"user" validate:"required"`
-	Password     string `yaml:"password" validate:"required"`
-	Database     string `yaml:"database" validate:"required"`
-	QueryTimeout string `yaml:"queryTimeout"`
+	Name         string      `yaml:"name" validate:"required"`
+	Type         string      `yaml:"type" validate:"required"`
+	Host         string      `yaml:"host" validate:"required"`
+	Port         string      `yaml:"port" validate:"required"`
+	User         util.Secret `yaml:"user" validate:"required"`
+	Password     util.Secret `yaml:"password" validate:"required"`
+	Database     string      `yaml:"database" validate:"required"`
+	QueryTimeout string      `yaml:"queryTimeout"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -62,7 +63,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initOceanBaseConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.QueryTimeout)
+	pool, err := initOceanBaseConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.QueryTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/oracle/oracle.go
+++ b/internal/sources/oracle/oracle.go
@@ -45,18 +45,18 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name             string `yaml:"name" validate:"required"`
-	Type             string `yaml:"type" validate:"required"`
-	ConnectionString string `yaml:"connectionString,omitempty"`
-	TnsAlias         string `yaml:"tnsAlias,omitempty"`
-	TnsAdmin         string `yaml:"tnsAdmin,omitempty"`
-	Host             string `yaml:"host,omitempty"`
-	Port             int    `yaml:"port,omitempty"`
-	ServiceName      string `yaml:"serviceName,omitempty"`
-	User             string `yaml:"user" validate:"required"`
-	Password         string `yaml:"password" validate:"required"`
-	UseOCI           bool   `yaml:"useOCI,omitempty"`
-	WalletLocation   string `yaml:"walletLocation,omitempty"`
+	Name             string      `yaml:"name" validate:"required"`
+	Type             string      `yaml:"type" validate:"required"`
+	ConnectionString string      `yaml:"connectionString,omitempty"`
+	TnsAlias         string      `yaml:"tnsAlias,omitempty"`
+	TnsAdmin         string      `yaml:"tnsAdmin,omitempty"`
+	Host             string      `yaml:"host,omitempty"`
+	Port             int         `yaml:"port,omitempty"`
+	ServiceName      string      `yaml:"serviceName,omitempty"`
+	User             util.Secret `yaml:"user" validate:"required"`
+	Password         util.Secret `yaml:"password" validate:"required"`
+	UseOCI           bool        `yaml:"useOCI,omitempty"`
+	WalletLocation   string      `yaml:"walletLocation,omitempty"`
 }
 
 func (c Config) validate() error {
@@ -341,7 +341,7 @@ func initOracleConnection(ctx context.Context, tracer trace.Tracer, config Confi
 		// Use go-ora driver (pure Go)
 		driverName = "oracle"
 
-		finalConnStr = buildGoOraConnString(config.User, config.Password, connectStringBase, config.WalletLocation)
+		finalConnStr = buildGoOraConnString(config.User.String(), config.Password.String(), connectStringBase, config.WalletLocation)
 
 		if hasWallet {
 			logger.DebugContext(ctx, fmt.Sprintf("Using go-ora driver (pure-Go) with wallet and serverString: %s\n", connectStringBase))

--- a/internal/sources/oracle/oracle_test.go
+++ b/internal/sources/oracle/oracle_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/server"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlOracle(t *testing.T) {
@@ -36,8 +37,8 @@ func TestParseFromYamlOracle(t *testing.T) {
 					Name:             "my-oracle-cs",
 					Type:             SourceType,
 					ConnectionString: "my-host:1521/XEPDB1",
-					User:             "my_user",
-					Password:         "my_pass",
+					User:             util.Secret("my_user"),
+					Password:         util.Secret("my_pass"),
 					UseOCI:           true,
 				},
 			},
@@ -61,8 +62,8 @@ func TestParseFromYamlOracle(t *testing.T) {
 					Host:        "my-host",
 					Port:        1521,
 					ServiceName: "ORCLPDB",
-					User:        "my_user",
-					Password:    "my_pass",
+					User:        util.Secret("my_user"),
+					Password:    util.Secret("my_pass"),
 					UseOCI:      false,
 				},
 			},
@@ -85,8 +86,8 @@ func TestParseFromYamlOracle(t *testing.T) {
 					Type:     SourceType,
 					TnsAlias: "FINANCE_DB",
 					TnsAdmin: "/opt/oracle/network/admin",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 					UseOCI:   true,
 				},
 			},

--- a/internal/sources/postgres/postgres.go
+++ b/internal/sources/postgres/postgres.go
@@ -53,8 +53,8 @@ type Config struct {
 	Type          string            `yaml:"type" validate:"required"`
 	Host          string            `yaml:"host" validate:"required"`
 	Port          string            `yaml:"port" validate:"required"`
-	User          string            `yaml:"user" validate:"required"`
-	Password      string            `yaml:"password" validate:"required"`
+	User          util.Secret       `yaml:"user" validate:"required"`
+	Password      util.Secret       `yaml:"password" validate:"required"`
 	Database      string            `yaml:"database" validate:"required"`
 	QueryParams   map[string]string `yaml:"queryParams"`
 	QueryExecMode string            `yaml:"queryExecMode" validate:"omitempty,oneof=cache_statement cache_describe describe_exec exec simple_protocol"`
@@ -65,7 +65,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initPostgresConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.QueryParams, r.QueryExecMode)
+	pool, err := initPostgresConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.QueryParams, r.QueryExecMode)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/postgres/postgres_test.go
+++ b/internal/sources/postgres/postgres_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/postgres"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -53,8 +54,8 @@ func TestParseFromYamlPostgres(t *testing.T) {
 					Host:     "my-host",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -80,8 +81,8 @@ func TestParseFromYamlPostgres(t *testing.T) {
 					Host:     "my-host",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 					QueryParams: map[string]string{
 						"sslmode":     "verify-full",
 						"sslrootcert": "/tmp/ca.crt",
@@ -109,8 +110,8 @@ func TestParseFromYamlPostgres(t *testing.T) {
 					Host:          "my-host",
 					Port:          "my-port",
 					Database:      "my_db",
-					User:          "my_user",
-					Password:      "my_pass",
+					User:          util.Secret("my_user"),
+					Password:      util.Secret("my_pass"),
 					QueryExecMode: "simple_protocol",
 				},
 			},

--- a/internal/sources/redis/redis.go
+++ b/internal/sources/redis/redis.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -45,15 +46,15 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name           string    `yaml:"name" validate:"required"`
-	Type           string    `yaml:"type" validate:"required"`
-	Address        []string  `yaml:"address" validate:"required"`
-	Username       string    `yaml:"username"`
-	Password       string    `yaml:"password"`
-	Database       int       `yaml:"database"`
-	UseGCPIAM      bool      `yaml:"useGCPIAM"`
-	ClusterEnabled bool      `yaml:"clusterEnabled"`
-	TLS            TLSConfig `yaml:"tls"`
+	Name           string      `yaml:"name" validate:"required"`
+	Type           string      `yaml:"type" validate:"required"`
+	Address        []string    `yaml:"address" validate:"required"`
+	Username       util.Secret `yaml:"username"`
+	Password       util.Secret `yaml:"password"`
+	Database       int         `yaml:"database"`
+	UseGCPIAM      bool        `yaml:"useGCPIAM"`
+	ClusterEnabled bool        `yaml:"clusterEnabled"`
+	TLS            TLSConfig   `yaml:"tls"`
 }
 
 type TLSConfig struct {
@@ -116,8 +117,8 @@ func initRedisClient(ctx context.Context, r Config) (RedisClient, error) {
 			ConnMaxIdleTime:            60 * time.Second,
 			MinIdleConns:               1,
 			CredentialsProviderContext: authFn,
-			Username:                   r.Username,
-			Password:                   r.Password,
+			Username:                   r.Username.String(),
+			Password:                   r.Password.String(),
 			TLSConfig:                  tlsConfig,
 		})
 		err = clusterClient.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
@@ -138,8 +139,8 @@ func initRedisClient(ctx context.Context, r Config) (RedisClient, error) {
 		MinIdleConns:               1,
 		DB:                         r.Database,
 		CredentialsProviderContext: authFn,
-		Username:                   r.Username,
-		Password:                   r.Password,
+		Username:                   r.Username.String(),
+		Password:                   r.Password.String(),
 		TLSConfig:                  tlsConfig,
 	})
 	_, err = standaloneClient.Ping(ctx).Result()

--- a/internal/sources/singlestore/singlestore.go
+++ b/internal/sources/singlestore/singlestore.go
@@ -26,6 +26,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/tools/mysql/mysqlcommon"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -51,14 +52,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 // Config holds the configuration parameters for connecting to a SingleStore database.
 type Config struct {
-	Name         string `yaml:"name" validate:"required"`
-	Type         string `yaml:"type" validate:"required"`
-	Host         string `yaml:"host" validate:"required"`
-	Port         string `yaml:"port" validate:"required"`
-	User         string `yaml:"user" validate:"required"`
-	Password     string `yaml:"password" validate:"required"`
-	Database     string `yaml:"database" validate:"required"`
-	QueryTimeout string `yaml:"queryTimeout"`
+	Name         string      `yaml:"name" validate:"required"`
+	Type         string      `yaml:"type" validate:"required"`
+	Host         string      `yaml:"host" validate:"required"`
+	Port         string      `yaml:"port" validate:"required"`
+	User         util.Secret `yaml:"user" validate:"required"`
+	Password     util.Secret `yaml:"password" validate:"required"`
+	Database     string      `yaml:"database" validate:"required"`
+	QueryTimeout string      `yaml:"queryTimeout"`
 }
 
 // SourceConfigType returns the type of the source configuration.
@@ -68,7 +69,7 @@ func (r Config) SourceConfigType() string {
 
 // Initialize sets up the SingleStore connection pool and returns a Source.
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initSingleStoreConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.QueryTimeout)
+	pool, err := initSingleStoreConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.QueryTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/singlestore/singlestore_test.go
+++ b/internal/sources/singlestore/singlestore_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/singlestore"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYaml(t *testing.T) {
@@ -50,8 +51,8 @@ func TestParseFromYaml(t *testing.T) {
 					Host:     "0.0.0.0",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 				},
 			},
 		},
@@ -75,8 +76,8 @@ func TestParseFromYaml(t *testing.T) {
 					Host:         "0.0.0.0",
 					Port:         "my-port",
 					Database:     "my_db",
-					User:         "my_user",
-					Password:     "my_pass",
+					User:         util.Secret("my_user"),
+					Password:     util.Secret("my_pass"),
 					QueryTimeout: "45s",
 				},
 			},

--- a/internal/sources/snowflake/snowflake.go
+++ b/internal/sources/snowflake/snowflake.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/snowflakedb/gosnowflake"
 	"go.opentelemetry.io/otel/trace"
@@ -45,15 +46,15 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name      string `yaml:"name" validate:"required"`
-	Type      string `yaml:"type" validate:"required"`
-	Account   string `yaml:"account" validate:"required"`
-	User      string `yaml:"user" validate:"required"`
-	Password  string `yaml:"password" validate:"required"`
-	Database  string `yaml:"database" validate:"required"`
-	Schema    string `yaml:"schema" validate:"required"`
-	Warehouse string `yaml:"warehouse"`
-	Role      string `yaml:"role"`
+	Name      string      `yaml:"name" validate:"required"`
+	Type      string      `yaml:"type" validate:"required"`
+	Account   string      `yaml:"account" validate:"required"`
+	User      util.Secret `yaml:"user" validate:"required"`
+	Password  util.Secret `yaml:"password" validate:"required"`
+	Database  string      `yaml:"database" validate:"required"`
+	Schema    string      `yaml:"schema" validate:"required"`
+	Warehouse string      `yaml:"warehouse"`
+	Role      string      `yaml:"role"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -61,7 +62,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	db, err := initSnowflakeConnection(ctx, tracer, r.Name, r.Account, r.User, r.Password, r.Database, r.Schema, r.Warehouse, r.Role)
+	db, err := initSnowflakeConnection(ctx, tracer, r.Name, r.Account, r.User.String(), r.Password.String(), r.Database, r.Schema, r.Warehouse, r.Role)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create connection: %w", err)
 	}

--- a/internal/sources/snowflake/snowflake_test.go
+++ b/internal/sources/snowflake/snowflake_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/snowflake"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlSnowflake(t *testing.T) {
@@ -48,8 +49,8 @@ func TestParseFromYamlSnowflake(t *testing.T) {
 					Name:      "my-snowflake-instance",
 					Type:      snowflake.SourceType,
 					Account:   "my-account",
-					User:      "my_user",
-					Password:  "my_pass",
+					User:      util.Secret("my_user"),
+					Password:  util.Secret("my_pass"),
 					Database:  "my_db",
 					Schema:    "my_schema",
 					Warehouse: "",

--- a/internal/sources/tidb/tidb.go
+++ b/internal/sources/tidb/tidb.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -54,14 +55,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string `yaml:"name" validate:"required"`
-	Type     string `yaml:"type" validate:"required"`
-	Host     string `yaml:"host" validate:"required"`
-	Port     string `yaml:"port" validate:"required"`
-	User     string `yaml:"user" validate:"required"`
-	Password string `yaml:"password" validate:"required"`
-	Database string `yaml:"database" validate:"required"`
-	UseSSL   bool   `yaml:"ssl"`
+	Name     string      `yaml:"name" validate:"required"`
+	Type     string      `yaml:"type" validate:"required"`
+	Host     string      `yaml:"host" validate:"required"`
+	Port     string      `yaml:"port" validate:"required"`
+	User     util.Secret `yaml:"user" validate:"required"`
+	Password util.Secret `yaml:"password" validate:"required"`
+	Database string      `yaml:"database" validate:"required"`
+	UseSSL   bool        `yaml:"ssl"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -69,7 +70,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initTiDBConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.UseSSL)
+	pool, err := initTiDBConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.UseSSL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/tidb/tidb_test.go
+++ b/internal/sources/tidb/tidb_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/sources/tidb"
 	"github.com/googleapis/genai-toolbox/internal/testutils"
+	"github.com/googleapis/genai-toolbox/internal/util"
 )
 
 func TestParseFromYamlTiDB(t *testing.T) {
@@ -50,8 +51,8 @@ func TestParseFromYamlTiDB(t *testing.T) {
 					Host:     "0.0.0.0",
 					Port:     "my-port",
 					Database: "my_db",
-					User:     "my_user",
-					Password: "my_pass",
+					User:     util.Secret("my_user"),
+					Password: util.Secret("my_pass"),
 					UseSSL:   false,
 				},
 			},

--- a/internal/sources/trino/trino.go
+++ b/internal/sources/trino/trino.go
@@ -50,21 +50,21 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name                   string `yaml:"name" validate:"required"`
-	Type                   string `yaml:"type" validate:"required"`
-	Host                   string `yaml:"host" validate:"required"`
-	Port                   string `yaml:"port" validate:"required"`
-	User                   string `yaml:"user"`
-	Password               string `yaml:"password"`
-	Catalog                string `yaml:"catalog" validate:"required"`
-	Schema                 string `yaml:"schema" validate:"required"`
-	QueryTimeout           string `yaml:"queryTimeout"`
-	AccessToken            string `yaml:"accessToken"`
-	KerberosEnabled        bool   `yaml:"kerberosEnabled"`
-	SSLEnabled             bool   `yaml:"sslEnabled"`
-	SSLCertPath            string `yaml:"sslCertPath"`
-	SSLCert                string `yaml:"sslCert"`
-	DisableSslVerification bool   `yaml:"disableSslVerification"`
+	Name                   string      `yaml:"name" validate:"required"`
+	Type                   string      `yaml:"type" validate:"required"`
+	Host                   string      `yaml:"host" validate:"required"`
+	Port                   string      `yaml:"port" validate:"required"`
+	User                   util.Secret `yaml:"user"`
+	Password               util.Secret `yaml:"password"`
+	Catalog                string      `yaml:"catalog" validate:"required"`
+	Schema                 string      `yaml:"schema" validate:"required"`
+	QueryTimeout           string      `yaml:"queryTimeout"`
+	AccessToken            string      `yaml:"accessToken"`
+	KerberosEnabled        bool        `yaml:"kerberosEnabled"`
+	SSLEnabled             bool        `yaml:"sslEnabled"`
+	SSLCertPath            string      `yaml:"sslCertPath"`
+	SSLCert                string      `yaml:"sslCert"`
+	DisableSslVerification bool        `yaml:"disableSslVerification"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -72,7 +72,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initTrinoConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Catalog, r.Schema, r.QueryTimeout, r.AccessToken, r.KerberosEnabled, r.SSLEnabled, r.SSLCertPath, r.SSLCert, r.DisableSslVerification)
+	pool, err := initTrinoConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Catalog, r.Schema, r.QueryTimeout, r.AccessToken, r.KerberosEnabled, r.SSLEnabled, r.SSLCertPath, r.SSLCert, r.DisableSslVerification)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/sources/valkey/valkey.go
+++ b/internal/sources/valkey/valkey.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/valkey-io/valkey-go"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -44,14 +45,14 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name         string   `yaml:"name" validate:"required"`
-	Type         string   `yaml:"type" validate:"required"`
-	Address      []string `yaml:"address" validate:"required"`
-	Username     string   `yaml:"username"`
-	Password     string   `yaml:"password"`
-	Database     int      `yaml:"database"`
-	UseGCPIAM    bool     `yaml:"useGCPIAM"`
-	DisableCache bool     `yaml:"disableCache"`
+	Name         string      `yaml:"name" validate:"required"`
+	Type         string      `yaml:"type" validate:"required"`
+	Address      []string    `yaml:"address" validate:"required"`
+	Username     util.Secret `yaml:"username"`
+	Password     util.Secret `yaml:"password"`
+	Database     int         `yaml:"database"`
+	UseGCPIAM    bool        `yaml:"useGCPIAM"`
+	DisableCache bool        `yaml:"disableCache"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -88,8 +89,8 @@ func initValkeyClient(ctx context.Context, r Config) (valkey.Client, error) {
 	client, err := valkey.NewClient(valkey.ClientOption{
 		InitAddress:       r.Address,
 		SelectDB:          r.Database,
-		Username:          r.Username,
-		Password:          r.Password,
+		Username:          r.Username.String(),
+		Password:          r.Password.String(),
 		AuthCredentialsFn: authFn,
 		DisableCache:      r.DisableCache,
 	})

--- a/internal/sources/yugabytedb/yugabytedb.go
+++ b/internal/sources/yugabytedb/yugabytedb.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/internal/sources"
+	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/yugabyte/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -44,18 +45,18 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name                            string `yaml:"name" validate:"required"`
-	Type                            string `yaml:"type" validate:"required"`
-	Host                            string `yaml:"host" validate:"required"`
-	Port                            string `yaml:"port" validate:"required"`
-	User                            string `yaml:"user" validate:"required"`
-	Password                        string `yaml:"password" validate:"required"`
-	Database                        string `yaml:"database" validate:"required"`
-	LoadBalance                     string `yaml:"loadBalance"`
-	TopologyKeys                    string `yaml:"topologyKeys"`
-	YBServersRefreshInterval        string `yaml:"ybServersRefreshInterval"`
-	FallBackToTopologyKeysOnly      string `yaml:"fallbackToTopologyKeysOnly"`
-	FailedHostReconnectDelaySeconds string `yaml:"failedHostReconnectDelaySecs"`
+	Name                            string      `yaml:"name" validate:"required"`
+	Type                            string      `yaml:"type" validate:"required"`
+	Host                            string      `yaml:"host" validate:"required"`
+	Port                            string      `yaml:"port" validate:"required"`
+	User                            util.Secret `yaml:"user" validate:"required"`
+	Password                        util.Secret `yaml:"password" validate:"required"`
+	Database                        string      `yaml:"database" validate:"required"`
+	LoadBalance                     string      `yaml:"loadBalance"`
+	TopologyKeys                    string      `yaml:"topologyKeys"`
+	YBServersRefreshInterval        string      `yaml:"ybServersRefreshInterval"`
+	FallBackToTopologyKeysOnly      string      `yaml:"fallbackToTopologyKeysOnly"`
+	FailedHostReconnectDelaySeconds string      `yaml:"failedHostReconnectDelaySecs"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -63,7 +64,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initYugabyteDBConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User, r.Password, r.Database, r.LoadBalance, r.TopologyKeys, r.YBServersRefreshInterval, r.FallBackToTopologyKeysOnly, r.FailedHostReconnectDelaySeconds)
+	pool, err := initYugabyteDBConnectionPool(ctx, tracer, r.Name, r.Host, r.Port, r.User.String(), r.Password.String(), r.Database, r.LoadBalance, r.TopologyKeys, r.YBServersRefreshInterval, r.FallBackToTopologyKeysOnly, r.FailedHostReconnectDelaySeconds)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package testutils
 
 import (
 	"context"
 	"fmt"
 
+	"github.com/googleapis/genai-toolbox/internal/auth"
 	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/genai-toolbox/internal/prompts"
+	"github.com/googleapis/genai-toolbox/internal/sources"
 	"github.com/googleapis/genai-toolbox/internal/tools"
 	"github.com/googleapis/genai-toolbox/internal/util"
 	"github.com/googleapis/genai-toolbox/internal/util/parameters"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // MockTool is used to mock tools in tests
@@ -30,9 +33,9 @@ type MockTool struct {
 	Name                         string
 	Description                  string
 	Params                       []parameters.Parameter
-	manifest                     tools.Manifest
-	unauthorized                 bool
-	requiresClientAuthrorization bool
+	ToolManifest                 tools.Manifest
+	Unauthorized                 bool
+	RequiresClientAuthrorization bool
 }
 
 func (t MockTool) Invoke(context.Context, tools.SourceProvider, parameters.ParamValues, tools.AccessToken) (any, util.ToolboxError) {
@@ -63,12 +66,12 @@ func (t MockTool) Manifest() tools.Manifest {
 
 func (t MockTool) Authorized(verifiedAuthServices []string) bool {
 	// defaulted to true
-	return !t.unauthorized
+	return !t.Unauthorized
 }
 
 func (t MockTool) RequiresClientAuthorization(tools.SourceProvider) (bool, error) {
 	// defaulted to false
-	return t.requiresClientAuthrorization, nil
+	return t.RequiresClientAuthrorization, nil
 }
 
 func (t MockTool) GetParameters() parameters.Parameters {
@@ -157,4 +160,75 @@ func (p MockPrompt) McpManifest() prompts.McpManifest {
 
 func (p MockPrompt) ToConfig() prompts.PromptConfig {
 	return nil
+}
+
+type MockSourceConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockSourceConfig) SourceConfigType() string {
+	return "mock"
+}
+
+func (m *MockSourceConfig) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
+	return nil, nil
+}
+
+type MockAuthServiceConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockAuthServiceConfig) AuthServiceConfigType() string {
+	return "mock"
+}
+
+func (m *MockAuthServiceConfig) Initialize() (auth.AuthService, error) {
+	return nil, nil
+}
+
+type MockEmbeddingModelConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockEmbeddingModelConfig) EmbeddingModelConfigType() string {
+	return "mock"
+}
+
+func (m *MockEmbeddingModelConfig) Initialize(ctx context.Context) (embeddingmodels.EmbeddingModel, error) {
+	return nil, nil
+}
+
+type MockToolConfig struct {
+	Foo          string   `yaml:"foo"`
+	Type         string   `yaml:"type"`
+	AuthRequired []string `yaml:"authRequired"`
+}
+
+func (m *MockToolConfig) ToolConfigType() string {
+	return "mock"
+}
+
+func (m *MockToolConfig) Initialize(map[string]sources.Source) (tools.Tool, error) {
+	return MockTool{}, nil
+}
+
+type MockToolsetConfig struct {
+	Name      string   `yaml:"name"`
+	ToolNames []string `yaml:",inline"`
+}
+
+type MockPromptConfig struct {
+	Foo  string `yaml:"foo"`
+	Type string `yaml:"type"`
+}
+
+func (m *MockPromptConfig) PromptConfigType() string {
+	return "mock"
+}
+
+func (m *MockPromptConfig) Initialize() (prompts.Prompt, error) {
+	return nil, nil
 }

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -17,6 +17,7 @@ package testutils
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/googleapis/genai-toolbox/internal/auth"
 	"github.com/googleapis/genai-toolbox/internal/embeddingmodels"
@@ -28,8 +29,60 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+type MockSource struct {
+	MockSourceConfig
+	Name string
+}
+
+func (s MockSource) SourceType() string {
+	return "mock"
+}
+
+func (s MockSource) ToConfig() sources.SourceConfig {
+	return &s.MockSourceConfig
+}
+
+type MockAuthService struct {
+	MockAuthServiceConfig
+	Name string
+}
+
+func (a MockAuthService) AuthServiceType() string {
+	return "mock"
+}
+
+func (a MockAuthService) GetName() string {
+	return a.Name
+}
+
+func (a MockAuthService) GetClaimsFromHeader(ctx context.Context, h http.Header) (map[string]any, error) {
+	return nil, nil
+}
+
+func (a MockAuthService) ToConfig() auth.AuthServiceConfig {
+	return &a.MockAuthServiceConfig
+}
+
+type MockEmbeddingModel struct {
+	MockEmbeddingModelConfig
+	Name string
+}
+
+func (e MockEmbeddingModel) EmbeddingModelType() string {
+	return "mock"
+}
+
+func (e MockEmbeddingModel) ToConfig() embeddingmodels.EmbeddingModelConfig {
+	return &e.MockEmbeddingModelConfig
+}
+
+func (e MockEmbeddingModel) EmbedParameters(ctx context.Context, t []string) ([][]float32, error) {
+	return nil, nil
+}
+
 // MockTool is used to mock tools in tests
 type MockTool struct {
+	MockToolConfig
 	Name                         string
 	Description                  string
 	Params                       []parameters.Parameter
@@ -44,7 +97,7 @@ func (t MockTool) Invoke(context.Context, tools.SourceProvider, parameters.Param
 }
 
 func (t MockTool) ToConfig() tools.ToolConfig {
-	return nil
+	return &t.MockToolConfig
 }
 
 // claims is a map of user info decoded from an auth token
@@ -121,6 +174,7 @@ func (t MockTool) GetAuthTokenHeaderName(tools.SourceProvider) (string, error) {
 
 // MockPrompt is used to mock prompts in tests
 type MockPrompt struct {
+	MockPromptConfig
 	Name        string
 	Description string
 	Args        prompts.Arguments
@@ -159,7 +213,7 @@ func (p MockPrompt) McpManifest() prompts.McpManifest {
 }
 
 func (p MockPrompt) ToConfig() prompts.PromptConfig {
-	return nil
+	return &p.MockPromptConfig
 }
 
 type MockSourceConfig struct {
@@ -172,7 +226,7 @@ func (m *MockSourceConfig) SourceConfigType() string {
 }
 
 func (m *MockSourceConfig) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	return nil, nil
+	return MockSource{MockSourceConfig: *m}, nil
 }
 
 type MockAuthServiceConfig struct {
@@ -185,7 +239,7 @@ func (m *MockAuthServiceConfig) AuthServiceConfigType() string {
 }
 
 func (m *MockAuthServiceConfig) Initialize() (auth.AuthService, error) {
-	return nil, nil
+	return MockAuthService{MockAuthServiceConfig: *m}, nil
 }
 
 type MockEmbeddingModelConfig struct {
@@ -198,7 +252,7 @@ func (m *MockEmbeddingModelConfig) EmbeddingModelConfigType() string {
 }
 
 func (m *MockEmbeddingModelConfig) Initialize(ctx context.Context) (embeddingmodels.EmbeddingModel, error) {
-	return nil, nil
+	return MockEmbeddingModel{MockEmbeddingModelConfig: *m}, nil
 }
 
 type MockToolConfig struct {
@@ -212,12 +266,15 @@ func (m *MockToolConfig) ToolConfigType() string {
 }
 
 func (m *MockToolConfig) Initialize(map[string]sources.Source) (tools.Tool, error) {
-	return MockTool{}, nil
+	return MockTool{MockToolConfig: *m}, nil
 }
 
 type MockToolsetConfig struct {
-	Name      string   `yaml:"name"`
-	ToolNames []string `yaml:",inline"`
+	tools.ToolsetConfig
+}
+
+func (m *MockToolsetConfig) Initialize(serverVersion string, toolsMap map[string]tools.Tool) (tools.Toolset, error) {
+	return tools.Toolset{ToolsetConfig: m.ToolsetConfig}, nil
 }
 
 type MockPromptConfig struct {
@@ -230,5 +287,5 @@ func (m *MockPromptConfig) PromptConfigType() string {
 }
 
 func (m *MockPromptConfig) Initialize() (prompts.Prompt, error) {
-	return nil, nil
+	return MockPrompt{MockPromptConfig: *m}, nil
 }

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -217,8 +217,9 @@ func (p MockPrompt) ToConfig() prompts.PromptConfig {
 }
 
 type MockSourceConfig struct {
-	Foo  string `yaml:"foo"`
-	Type string `yaml:"type"`
+	Foo      string      `yaml:"foo"`
+	Password util.Secret `yaml:"password"`
+	Type     string      `yaml:"type"`
 }
 
 func (m *MockSourceConfig) SourceConfigType() string {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
@@ -39,7 +38,10 @@ func FormatYaml(in string) []byte {
 // ContextWithNewLogger create a new context with new logger
 func ContextWithNewLogger() (context.Context, error) {
 	ctx := context.Background()
-	logger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	defer pr.Close()
+	logger, err := log.NewStdLogger(pw, pw, "info")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create logger: %s", err)
 	}

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -62,7 +62,7 @@ func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool
 		toolset.Manifest.ToolsManifest[toolName] = tool.Manifest()
 		toolset.McpManifest = append(toolset.McpManifest, tool.McpManifest())
 	}
-
+	toolset.ToolsetConfig = t
 	return toolset, nil
 }
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -214,3 +214,19 @@ func GenAIMetricAttrsFromContext(ctx context.Context) *GenAIMetricAttrs {
 	}
 	return nil
 }
+
+type Secret string
+
+// MarshalJSON masks the value when converting to JSON
+func (s Secret) MarshalJSON() ([]byte, error) {
+	return []byte("\"***\""), nil
+}
+
+// MarshalYAML masks the value when converting to YAML
+func (s Secret) MarshalYAML() (interface{}, error) {
+	return "***", nil
+}
+
+func (s Secret) String() string {
+	return string(s)
+}


### PR DESCRIPTION
New GET endpoint for `/admin/{kind}/{name}`.

Created a new `type Secret string` type for all the secret value. Sensitive information with this type will not be shown with the GET endpoint. It will be replaced with`***`.