### PR TITLE
feat: add GET endpoint by primitive kind

### DIFF
--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -37,7 +37,10 @@ func adminRouter(s *Server) (chi.Router, error) {
 
 	r.Put("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { createOrUpdatePrimitives(s, w, r) })
 	r.Delete("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { deletePrimitives(s, w, r) })
-	r.Get("/{kind}/{name}", func(w http.ResponseWriter, r *http.Request) { getPrimitiveByName(s, w, r) })
+	r.Route("/{kind}", func(r chi.Router) {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) { getPrimitive(s, w, r) })
+		r.Get("/{name}", func(w http.ResponseWriter, r *http.Request) { getPrimitiveByName(s, w, r) })
+	})
 
 	return r, nil
 }
@@ -165,6 +168,34 @@ func createOrUpdatePrimitives(s *Server, w http.ResponseWriter, r *http.Request)
 		_ = render.Render(w, r, newErrResponse(updateErr, http.StatusInternalServerError))
 		return
 	}
+}
+
+func getPrimitive(s *Server, w http.ResponseWriter, r *http.Request) {
+	kind := chi.URLParam(r, "kind")
+	ctx := r.Context()
+	ctx = util.WithInstrumentation(ctx, s.instrumentation)
+
+	var names []string
+	switch strings.ToLower(kind) {
+	case "source":
+		names = s.ResourceMgr.GetSources()
+	case "authservice":
+		names = s.ResourceMgr.GetAuthServices()
+	case "embeddingmodel":
+		names = s.ResourceMgr.GetEmbeddingModels()
+	case "tool":
+		names = s.ResourceMgr.GetTools()
+	case "toolset":
+		names = s.ResourceMgr.GetToolsets()
+	case "prompt":
+		names = s.ResourceMgr.GetPrompts()
+	default:
+		err := fmt.Errorf("invalid primitive kind %q provided", kind)
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
+		return
+	}
+	render.JSON(w, r, names)
 }
 
 func getPrimitiveByName(s *Server, w http.ResponseWriter, r *http.Request) {

--- a/internal/server/admin_test.go
+++ b/internal/server/admin_test.go
@@ -230,6 +230,97 @@ func TestAdminDeleteEndpoint(t *testing.T) {
 
 func TestAdminGetEndpoint(t *testing.T) {
 	mockSource := testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{Foo: "foo", Password: "password"}}
+	mockAuthService := testutils.MockAuthService{MockAuthServiceConfig: testutils.MockAuthServiceConfig{Foo: "foo"}}
+	mockEmbeddingModel := testutils.MockEmbeddingModel{MockEmbeddingModelConfig: testutils.MockEmbeddingModelConfig{Foo: "foo"}}
+	mockTool := testutils.MockTool{MockToolConfig: testutils.MockToolConfig{Foo: "foo"}}
+	mockToolset := tools.Toolset{ToolsetConfig: tools.ToolsetConfig{ToolNames: []string{"test-tool"}}}
+	mockPrompt := testutils.MockPrompt{MockPromptConfig: testutils.MockPromptConfig{Foo: "foo"}}
+
+	mockSources := map[string]sources.Source{"test-source": mockSource}
+	mockAuthServices := map[string]auth.AuthService{"test-auth-service": mockAuthService}
+	mockEmbeddingModels := map[string]embeddingmodels.EmbeddingModel{"test-embedding-model": mockEmbeddingModel}
+	mockTools := map[string]tools.Tool{"test-tool": mockTool}
+	mockToolsets := map[string]tools.Toolset{"test-toolset": mockToolset}
+	mockPrompts := map[string]prompts.Prompt{"test-prompt": mockPrompt}
+
+	r, shutdown := setUpServer(t, "admin", mockSources, mockAuthServices, mockEmbeddingModels, mockTools, mockToolsets, mockPrompts, map[string]prompts.Promptset{})
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	tests := []struct {
+		name               string
+		kind               string
+		want               []string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Get Source - Success",
+			kind:               "source",
+			want:               []string{"test-source"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Auth Service - Success",
+			kind:               "authService",
+			want:               []string{"test-auth-service"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Embedding Model - Success",
+			kind:               "embeddingModel",
+			want:               []string{"test-embedding-model"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Tool - Success",
+			kind:               "tool",
+			want:               []string{"test-tool"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Toolset - Success",
+			kind:               "toolset",
+			want:               []string{"test-toolset"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get Prompt - Success",
+			kind:               "prompt",
+			want:               []string{"test-prompt"},
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Get with Invalid Kind - Bad Request",
+			kind:               "invalidKind",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body, err := runRequest(ts, http.MethodGet, fmt.Sprintf("/%s", tt.kind), nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error during request: %s", err)
+			}
+			if resp.StatusCode != tt.expectedStatusCode {
+				t.Fatalf("response status code is not %d, got %d, %s", tt.expectedStatusCode, resp.StatusCode, string(body))
+			}
+			if tt.expectedStatusCode == http.StatusOK {
+				var got []string
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("error unmarshaling response body")
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Fatalf("unexpected output: got %+v, want %+v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestAdminGetByNameEndpoint(t *testing.T) {
+	mockSource := testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{Foo: "foo", Password: "password"}}
 	mockSourceConfigMasked := testutils.MockSourceConfig{Foo: "foo", Password: "***"}
 	mockAuthService := testutils.MockAuthService{MockAuthServiceConfig: testutils.MockAuthServiceConfig{Foo: "foo"}}
 	mockEmbeddingModel := testutils.MockEmbeddingModel{MockEmbeddingModelConfig: testutils.MockEmbeddingModelConfig{Foo: "foo"}}

--- a/internal/server/resources/resources.go
+++ b/internal/server/resources/resources.go
@@ -17,7 +17,9 @@ package resources
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/googleapis/genai-toolbox/internal/auth"
@@ -74,6 +76,42 @@ func (r *ResourceManager) SetResources(sourcesMap map[string]sources.Source, aut
 	r.toolsets = toolsetsMap
 	r.prompts = promptsMap
 	r.promptsets = promptsetsMap
+}
+
+func (r *ResourceManager) GetSources() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Sorted(maps.Keys(r.sources))
+}
+
+func (r *ResourceManager) GetAuthServices() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Sorted(maps.Keys(r.authServices))
+}
+
+func (r *ResourceManager) GetEmbeddingModels() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Sorted(maps.Keys(r.embeddingModels))
+}
+
+func (r *ResourceManager) GetTools() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Sorted(maps.Keys(r.tools))
+}
+
+func (r *ResourceManager) GetToolsets() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Sorted(maps.Keys(r.toolsets))
+}
+
+func (r *ResourceManager) GetPrompts() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Sorted(maps.Keys(r.prompts))
 }
 
 func (r *ResourceManager) GetSource(sourceName string) (sources.Source, bool) {

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -346,3 +346,46 @@ func TestDeletePrimitives(t *testing.T) {
 		t.Fatalf("expected delete to be successful")
 	}
 }
+
+func TestGetPrimitives(t *testing.T) {
+	resMgr := resources.NewResourceManager(
+		map[string]sources.Source{"foo": testutils.MockSource{}},
+		map[string]auth.AuthService{"foo": testutils.MockAuthService{}},
+		map[string]embeddingmodels.EmbeddingModel{"foo": testutils.MockEmbeddingModel{}},
+		map[string]tools.Tool{"foo": testutils.MockTool{}},
+		map[string]tools.Toolset{"foo": tools.Toolset{}},
+		map[string]prompts.Prompt{"foo": testutils.MockPrompt{}},
+		map[string]prompts.Promptset{},
+	)
+	want := []string{"foo"}
+
+	got := resMgr.GetSources()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected sources list: got %v, want %v", got, want)
+	}
+
+	got = resMgr.GetAuthServices()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected auth services list: got %v, want %v", got, want)
+	}
+
+	got = resMgr.GetEmbeddingModels()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected embedding models list: got %v, want %v", got, want)
+	}
+
+	got = resMgr.GetTools()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected tools list: got %v, want %v", got, want)
+	}
+
+	got = resMgr.GetToolsets()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected toolsets list: got %v, want %v", got, want)
+	}
+
+	got = resMgr.GetPrompts()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected prompts list: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
This will be the path to get a list of primitives that are configured within Toolbox. 
For example, /admin/source will return a list of sources. The available api includes the following (non-case sensitive):

* /admin/source
* /admin/authService or /admin/authservice
* /admin/tool
* /admin/toolset

An invalid primitive name will result in a bad request error.
