### PR TITLE
fix(tests/spanner): Fix swallowing of spanner integration test failures

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -593,7 +593,7 @@ steps:
           .ci/test_with_coverage.sh \
             "Spanner" \
             spanner \
-            spanner || echo "Integration tests failed."
+            spanner || { echo "Integration tests failed."; exit 1; }
         else
           echo "No relevant changes for Spanner. Skipping shard."
           exit 0


### PR DESCRIPTION
## Description

This PR resolves an issue in our CI/CD where Spanner integration test failures were being incorrectly suppressed. Previously, test errors were only logged while the pipeline continued to report a passing status.

This is fixed by updating the execution command for the Spanner tests to ensure failure exit codes are properly caught by the runner.

> [!NOTE]
> Because this PR successfully exposes previously hidden failures, the Spanner integration tests will currently fail on this branch due to a pre-existing issue. Fixing the underlying Spanner test is out of scope for this PR and will be handled separately.