### PR TITLE
feat: add dry-run and prune flag for apply command

### DIFF
--- a/cmd/internal/apply/command.go
+++ b/cmd/internal/apply/command.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/genai-toolbox/cmd/internal"
-	"github.com/googleapis/genai-toolbox/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +34,8 @@ type applyCmd struct {
 	*cobra.Command
 	port    int
 	address string
+	dryRun  bool
+	prune   bool
 }
 
 func NewCommand(opts *internal.ToolboxOptions) *cobra.Command {
@@ -48,6 +49,8 @@ func NewCommand(opts *internal.ToolboxOptions) *cobra.Command {
 	internal.ConfigFileFlags(flags, opts)
 	flags.StringVarP(&cmd.address, "address", "a", "127.0.0.1", "Address of the server that is running on.")
 	flags.IntVarP(&cmd.port, "port", "p", 5000, "Port of the server that is listening on.")
+	flags.BoolVar(&cmd.dryRun, "dry-run", false, "Simulate the apply process and report intended updates.")
+	flags.BoolVar(&cmd.prune, "prune", false, "Remove resources from the server that are not defined in the provided YAML files.")
 	cmd.RunE = func(*cobra.Command, []string) error { return runApply(cmd, opts) }
 	return cmd.Command
 }
@@ -90,6 +93,16 @@ func (p primitives) Remove(kind, name string) {
 	if names, ok := p[strings.ToLower(kind)]; ok {
 		delete(names, name)
 	}
+}
+
+func (p primitives) GetRemaining() []struct{ kind, name string } {
+	var remaining []struct{ kind, name string }
+	for kind, names := range p {
+		for name := range names {
+			remaining = append(remaining, struct{ kind, name string }{kind, name})
+		}
+	}
+	return remaining
 }
 
 // adminRequest is a generic helper for admin api requests.
@@ -171,6 +184,17 @@ func applyPrimitive(ctx context.Context, address string, port int, kind, name st
 	return nil
 }
 
+func deletePrimitive(ctx context.Context, address string, port int, kind, name string) error {
+	url := fmt.Sprintf("http://%s:%d/admin/%s/%s", address, port, kind, name)
+
+	_, err := adminRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func runApply(cmd *applyCmd, opts *internal.ToolboxOptions) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
@@ -196,18 +220,36 @@ func runApply(cmd *applyCmd, opts *internal.ToolboxOptions) error {
 		return err
 	}
 
+	if cmd.dryRun {
+		opts.Logger.InfoContext(ctx, "simulating dry run")
+	}
 	opts.Logger.InfoContext(ctx, "starting apply sequence", "count", len(filePaths))
 	for _, filePath := range filePaths {
-		if err := processFile(ctx, opts.Logger, filePath, p, cmd.address, cmd.port); err != nil {
+		if err := processFile(ctx, opts, filePath, p, cmd); err != nil {
 			opts.Logger.ErrorContext(ctx, err.Error())
 			return err
+		}
+	}
+	if cmd.prune {
+		remaining := p.GetRemaining()
+		opts.Logger.InfoContext(ctx, "starting prune sequence", "count", len(remaining))
+		for _, resource := range remaining {
+			if cmd.dryRun {
+				fmt.Fprintf(opts.IOStreams.Out, "[dry-run] would delete %s: %s\n", resource.kind, resource.name)
+				continue
+			}
+
+			// Perform the actual deletion
+			if err := deletePrimitive(ctx, cmd.address, cmd.port, resource.kind, resource.name); err != nil {
+				return fmt.Errorf("failed to prune %s/%s: %w", resource.kind, resource.name, err)
+			}
 		}
 	}
 	opts.Logger.InfoContext(ctx, "Done applying")
 	return nil
 }
 
-func processFile(ctx context.Context, logger log.Logger, path string, p primitives, address string, port int) error {
+func processFile(ctx context.Context, opts *internal.ToolboxOptions, path string, p primitives, cmd *applyCmd) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("unable to open file at %q: %w", path, err)
@@ -231,7 +273,7 @@ func processFile(ctx context.Context, logger log.Logger, path string, p primitiv
 		kind, kOk := doc["kind"].(string)
 		name, nOk := doc["name"].(string)
 		if !kOk || !nOk || kind == "" || name == "" {
-			logger.WarnContext(ctx, fmt.Sprintf("invalid primitive schema: missing metadata in %s: kind and name are required", path))
+			opts.Logger.WarnContext(ctx, fmt.Sprintf("invalid primitive schema: missing metadata in %s: kind and name are required", path))
 			continue
 		}
 
@@ -239,7 +281,7 @@ func processFile(ctx context.Context, logger log.Logger, path string, p primitiv
 
 		if p.Exists(kind, name) {
 			p.Remove(kind, name)
-			remoteBody, err := getPrimitiveByName(ctx, address, port, kind, name)
+			remoteBody, err := getPrimitiveByName(ctx, cmd.address, cmd.port, kind, name)
 			if err != nil {
 				return err
 			}
@@ -253,17 +295,17 @@ func processFile(ctx context.Context, logger log.Logger, path string, p primitiv
 			}
 
 			if bytes.Equal(localJSON, remoteJSON) {
-				logger.DebugContext(ctx, "skipping: no changes detected", "kind", kind, "name", name)
+				opts.Logger.DebugContext(ctx, "skipping: no changes detected", "kind", kind, "name", name)
 				continue
 			}
-			logger.DebugContext(ctx, "change detected, updating resource", "kind", kind, "name", name)
+			opts.Logger.DebugContext(ctx, "change detected, updating resource", "kind", kind, "name", name)
 		}
 
-		// TODO: check --prune flag: if prune, delete primitives that are left
-		// in the primitive list
-		// TODO: check for --dry-run flag.
-
-		if err := applyPrimitive(ctx, address, port, kind, name, doc); err != nil {
+		if cmd.dryRun {
+			fmt.Fprintf(opts.IOStreams.Out, "[dry-run] would update %s: %s\n", kind, name)
+			continue
+		}
+		if err := applyPrimitive(ctx, cmd.address, cmd.port, kind, name, doc); err != nil {
 			return err
 		}
 	}

--- a/cmd/internal/apply/command_test.go
+++ b/cmd/internal/apply/command_test.go
@@ -51,64 +51,197 @@ func applyCommand(ctx context.Context, args []string) (string, error) {
 }
 
 func TestApply(t *testing.T) {
+	deleteCount := 0
+	applyCount := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Return 200 OK for the initial GET list requests
-		if r.Method == http.MethodGet && !strings.Contains(r.URL.Path, "my-source") {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.Contains(r.URL.Path, "/source/my-source") {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"url": "old-url"})
+				return
+			}
+			if strings.Contains(r.URL.Path, "/source/my-source2") {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"foo": "bar"})
+				return
+			}
+			if strings.Contains(r.URL.Path, "/source") {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode([]string{"my-source", "my-source2"}) // existing primitive
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]string{"my-source"}) // existing primitive
+			_ = json.NewEncoder(w).Encode([]string{})
 			return
-		}
-		// Return 200 OK for the GET specific primitive (for DeepEqual check)
-		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "my-source") {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"url": "old-url"})
+		case http.MethodPut:
+			applyCount++
+			w.WriteHeader(http.StatusNoContent)
 			return
-		}
-		// Return 204 No Content for the PUT/Apply request
-		if r.Method == http.MethodPut {
+		case http.MethodDelete:
+			deleteCount++
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 	}))
 	defer mockServer.Close()
 
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, "config.yaml")
+	u, _ := url.Parse(mockServer.URL)
+
+	t.Run("Run Apply", func(t *testing.T) {
+		deleteCount = 0
+		applyCount = 0
+		args := []string{
+			"apply",
+			"--address", u.Hostname(),
+			"--port", u.Port(),
+			"--config", createConfigYaml(t),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		output, err := applyCommand(ctx, args)
+		if err != nil {
+			t.Fatalf("apply command failed: %v", err)
+		}
+
+		if !strings.Contains(output, "starting apply sequence") {
+			t.Errorf("expected logs to show start of sequence, got: %s", output)
+		}
+
+		if !strings.Contains(output, "Done applying") {
+			t.Errorf("expected logs to show completion, got: %s", output)
+		}
+
+		if applyCount != 1 {
+			t.Errorf("expected 1 PUT requests, but sent %d", applyCount)
+		}
+		if deleteCount != 0 {
+			t.Errorf("expected 0 DELETE requests, but sent %d", deleteCount)
+		}
+	})
+
+	t.Run("Run Apply with Dry Run", func(t *testing.T) {
+		deleteCount = 0
+		applyCount = 0
+		args := []string{
+			"apply",
+			"--address", u.Hostname(),
+			"--port", u.Port(),
+			"--dry-run",
+			"--config", createConfigYaml(t),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		output, err := applyCommand(ctx, args)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(output, "[dry-run] would update source: my-source") {
+			t.Errorf("expected dry run to show updates")
+		}
+
+		if strings.Contains(output, "[dry-run] would delete source: my-source2") {
+			t.Errorf("expected dry run not to show delete")
+		}
+
+		if applyCount != 0 {
+			t.Errorf("expected 0 PUT requests, but sent %d", applyCount)
+		}
+		if deleteCount != 0 {
+			t.Errorf("expected 0 DELETE requests, but sent %d", deleteCount)
+		}
+	})
+
+	t.Run("Run Apply with Prune", func(t *testing.T) {
+		deleteCount = 0
+		applyCount = 0
+		args := []string{
+			"apply",
+			"--address", u.Hostname(),
+			"--port", u.Port(),
+			"--prune",
+			"--config", createConfigYaml(t),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		output, err := applyCommand(ctx, args)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(output, "starting apply sequence") {
+			t.Errorf("expected logs to show start of sequence, got: %s", output)
+		}
+
+		if !strings.Contains(output, "Done applying") {
+			t.Errorf("expected logs to show completion, got: %s", output)
+		}
+
+		if applyCount != 1 {
+			t.Errorf("expected 1 PUT requests, but sent %d", applyCount)
+		}
+		if deleteCount != 1 {
+			t.Errorf("expected 1 DELETE request with prune, got %d", deleteCount)
+		}
+	})
+
+	t.Run("Run Apply with Prune and Dry Run", func(t *testing.T) {
+		deleteCount = 0
+		applyCount = 0
+		args := []string{
+			"apply",
+			"--address", u.Hostname(),
+			"--port", u.Port(),
+			"--prune",
+			"--dry-run",
+			"--config", createConfigYaml(t),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		output, err := applyCommand(ctx, args)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(output, "[dry-run] would update source: my-source") {
+			t.Errorf("expected dry run to show updates")
+		}
+
+		if !strings.Contains(output, "[dry-run] would delete source: my-source2") {
+			t.Errorf("expected dry run to show delete")
+		}
+
+		if applyCount != 0 {
+			t.Errorf("expected 0 PUT requests, but sent %d", applyCount)
+		}
+		if deleteCount != 0 {
+			t.Errorf("Dry-run should have sent 0 DELETE requests, but sent %d", deleteCount)
+		}
+	})
+}
+
+// createConfigYaml is a helper function to create config yaml file for the test
+func createConfigYaml(t *testing.T) string {
+	tmp := filepath.Join(t.TempDir(), "config.yaml")
 	yamlContent := `
 kind: source
 name: my-source
 url: new-url
 `
 
-	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+	if err := os.WriteFile(tmp, []byte(yamlContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-
-	// 3. Prepare Command Arguments
-	u, _ := url.Parse(mockServer.URL)
-	args := []string{
-		"apply",
-		"--address", u.Hostname(),
-		"--port", u.Port(),
-		"--config", configPath, // Assuming your flags support pointing to the file/dir
-	}
-
-	// context will automatically shutdown in 1 second.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	output, err := applyCommand(ctx, args)
-	if err != nil {
-		t.Fatalf("apply command failed: %v", err)
-	}
-
-	if !strings.Contains(output, "starting apply sequence") {
-		t.Errorf("expected logs to show start of sequence, got: %s", output)
-	}
-
-	if !strings.Contains(output, "Done applying") {
-		t.Errorf("expected logs to show completion, got: %s", output)
-	}
+	return tmp
 }
 
 func TestPrimitivesLoadAndManage(t *testing.T) {
@@ -225,5 +358,31 @@ func TestPrimitivesLoadError(t *testing.T) {
 
 	if err == nil {
 		t.Error("Expected an error when server returns 500, but got nil")
+	}
+}
+
+func TestPrimitivesGetRemaining(t *testing.T) {
+	p := primitives{
+		"source": {
+			"staying": struct{}{},
+			"leaving": struct{}{},
+		},
+		"tool": {
+			"old-tool": struct{}{},
+		},
+	}
+
+	// Simulate "staying" being found in a YAML file
+	p.Remove("source", "staying")
+
+	remaining := p.GetRemaining()
+	expected := map[string]string{"leaving": "source", "old-tool": "tool"}
+	if len(remaining) != len(expected) {
+		t.Fatalf("expected %d items, got %d", len(expected), len(remaining))
+	}
+	for _, r := range remaining {
+		if expected[r.name] != r.kind {
+			t.Errorf("unexpected item: %+v", r)
+		}
 	}
 }


### PR DESCRIPTION
**New flags that will be introduced in this subcommand:**
The `--dry-run` Flag: Before sending GET/PUT/DELETE requests to the Admin API, allow users to preview the execution plan. This will print exactly which primitives will be created or updated, acting as a safeguard against misconfigurations.
The `--prune` Flag: Users must explicitly pass --prune to tell the CLI to delete missing resources.