### PR TITLE
fix(skill): fix skill generation template

### DIFF
--- a/cmd/internal/skills/generator.go
+++ b/cmd/internal/skills/generator.go
@@ -130,7 +130,8 @@ const configArgs = [{{.ConfigArgs}}];
 
 function getToolboxPath() {
     if (process.env.GEMINI_CLI === '1') {
-        const localPath = path.resolve(__dirname, '../../../toolbox');
+        const ext = process.platform === 'win32' ? '.exe' : '';
+        const localPath = path.resolve(__dirname, '../../../toolbox' + ext);
         if (fs.existsSync(localPath)) {
             return localPath;
         }


### PR DESCRIPTION
This PR fixes the skill generation template to properly locate the toolbox.exe for windows
