### PR TITLE
feat(bigquery): add proxy support for API calls

### DIFF
--- a/docs/en/integrations/bigquery/source.md
+++ b/docs/en/integrations/bigquery/source.md
@@ -112,6 +112,7 @@ project: "my-project-id"
 # scopes: # Optional: List of OAuth scopes to request.
 #   - "https://www.googleapis.com/auth/bigquery"
 #   - "https://www.googleapis.com/auth/drive.readonly"
+# proxy: "https://proxy.company:8443" # Optional: Route API calls through a proxy. If unset, HTTPS_PROXY/HTTP_PROXY are honored.
 # maxQueryResultRows: 50 # Optional: Limits the number of rows returned by queries. Defaults to 50.
 # maximumBytesBilled: 10737418240 # Optional: Per-query bytes scanned cap (in bytes).
 ```
@@ -133,6 +134,7 @@ useClientOAuth: true
 # scopes: # Optional: List of OAuth scopes to request.
 #   - "https://www.googleapis.com/auth/bigquery"
 #   - "https://www.googleapis.com/auth/drive.readonly"
+# proxy: "https://proxy.company:8443" # Optional: Route API calls through a proxy. If unset, HTTPS_PROXY/HTTP_PROXY are honored.
 # maxQueryResultRows: 50 # Optional: Limits the number of rows returned by queries. Defaults to 50.
 # maximumBytesBilled: 10737418240 # Optional: Per-query bytes scanned cap (in bytes).
 ```
@@ -148,6 +150,7 @@ useClientOAuth: true
 | allowedDatasets           | []string |    false     | An optional list of dataset IDs that tools using this source are allowed to access. If provided, any tool operation attempting to access a dataset not in this list will be rejected. To enforce this, two types of operations are also disallowed: 1) Dataset-level operations (e.g., `CREATE SCHEMA`), and 2) operations where table access cannot be statically analyzed (e.g., `EXECUTE IMMEDIATE`, `CREATE PROCEDURE`). If a single dataset is provided, it will be treated as the default for prebuilt tools. |
 | useClientOAuth            |  string  |    false     | If set to `'true'`, forwards the client's OAuth access token from the default `Authorization` header. If set to a custom header name (e.g., `X-My-Auth`), that header will be used instead. An empty string or `'false'` disables this feature. Defaults to `""` (disabled). |
 | scopes                    | []string |    false     | A list of OAuth 2.0 scopes to use for the credentials. If not provided, default scopes are used.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| proxy                     |  string  |    false     | Optional HTTP(S) proxy URL to route API calls through. If unset, HTTPS_PROXY/HTTP_PROXY are honored.                                                                                                                                                                                                                                                                                                                                                                                                              |
 | impersonateServiceAccount |  string  |    false     | Service account email to impersonate when making BigQuery and Dataplex API calls. The authenticated principal must have the `roles/iam.serviceAccountTokenCreator` role on the target service account. [Learn More](https://cloud.google.com/iam/docs/service-account-impersonation)                                                                                                                                                                                                                                |
 | maxQueryResultRows             |   int    |    false     | The maximum number of rows to return from a query. Defaults to 50. |
 | maximumBytesBilled             |  int64   |    false     | The maximum bytes billed per query. When set, queries that exceed this limit fail before executing. |

--- a/internal/sources/bigquery/bigquery.go
+++ b/internal/sources/bigquery/bigquery.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"sync"
@@ -92,6 +94,7 @@ type Config struct {
 	Scopes                    StringOrStringSlice `yaml:"scopes"`
 	MaxQueryResultRows        int                 `yaml:"maxQueryResultRows"`
 	MaximumBytesBilled        int64               `yaml:"maximumBytesBilled" validate:"gte=0"`
+	Proxy                     string              `yaml:"proxy"`
 }
 
 // StringOrStringSlice is a custom type that can unmarshal both a single string
@@ -166,7 +169,7 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	if strings.ToLower(r.UseClientOAuth) == "false" || r.UseClientOAuth == "" {
 		// Initializes a BigQuery Google SQL source
-		client, restService, tokenSource, err = initBigQueryConnection(ctx, tracer, r.Name, r.Project, r.Location, r.ImpersonateServiceAccount, r.Scopes)
+		client, restService, tokenSource, err = initBigQueryConnection(ctx, tracer, r.Name, r.Project, r.Location, r.ImpersonateServiceAccount, r.Scopes, r.Proxy)
 		if err != nil {
 			return nil, fmt.Errorf("error creating client from ADC: %w", err)
 		}
@@ -183,7 +186,7 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 			s.AuthTokenHeaderName = r.UseClientOAuth
 		}
 		// use client OAuth
-		baseClientCreator, err := newBigQueryClientCreator(ctx, tracer, r.Project, r.Location, r.Name)
+		baseClientCreator, err := newBigQueryClientCreator(ctx, tracer, r.Project, r.Location, r.Name, r.Proxy)
 		if err != nil {
 			return nil, fmt.Errorf("error constructing client creator: %w", err)
 		}
@@ -519,7 +522,7 @@ func (s *Source) lazyInitDataplexClient(ctx context.Context, tracer trace.Tracer
 
 	return func() (*dataplexapi.CatalogClient, DataplexClientCreator, error) {
 		once.Do(func() {
-			c, cc, e := initDataplexConnection(ctx, tracer, s.Name, s.Project, s.UseClientAuthorization(), s.ImpersonateServiceAccount, s.Scopes)
+			c, cc, e := initDataplexConnection(ctx, tracer, s.Name, s.Project, s.UseClientAuthorization(), s.ImpersonateServiceAccount, s.Scopes, s.Proxy)
 			if e != nil {
 				err = fmt.Errorf("failed to initialize dataplex client: %w", e)
 				return
@@ -684,6 +687,65 @@ func NormalizeValue(v any) any {
 	return v
 }
 
+func newProxyTransport(proxyAddress string) (*http.Transport, error) {
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
+	var transport *http.Transport
+	if ok {
+		transport = baseTransport.Clone()
+	} else {
+		transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+	}
+	if proxyAddress != "" {
+		proxyURL, err := url.Parse(proxyAddress)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy URL %q: %w", proxyAddress, err)
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	} else {
+		transport.Proxy = http.ProxyFromEnvironment
+	}
+	return transport, nil
+}
+
+func newBaseRoundTripper(userAgent, proxyAddress string) (http.RoundTripper, error) {
+	transport, err := newProxyTransport(proxyAddress)
+	if err != nil {
+		return nil, err
+	}
+	return util.NewUserAgentRoundTripper(userAgent, transport), nil
+}
+
+func newHTTPClient(base http.RoundTripper, tokenSource oauth2.TokenSource) *http.Client {
+	rt := base
+	if tokenSource != nil {
+		rt = &oauth2.Transport{Source: tokenSource, Base: base}
+	}
+	return &http.Client{Transport: rt}
+}
+
+func shouldUseRESTClient(proxyAddress string) bool {
+	if proxyAddress != "" {
+		return true
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://bigquery.googleapis.com", nil)
+	if err != nil {
+		return false
+	}
+	proxyURL, err := http.ProxyFromEnvironment(req)
+	return err == nil && proxyURL != nil
+}
+
 func initBigQueryConnection(
 	ctx context.Context,
 	tracer trace.Tracer,
@@ -692,6 +754,7 @@ func initBigQueryConnection(
 	location string,
 	impersonateServiceAccount string,
 	scopes []string,
+	proxyAddress string,
 ) (*bigqueryapi.Client, *bigqueryrestapi.Service, oauth2.TokenSource, error) {
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
@@ -702,7 +765,6 @@ func initBigQueryConnection(
 	}
 
 	var tokenSource oauth2.TokenSource
-	var opts []option.ClientOption
 
 	var credScopes []string
 	if len(scopes) > 0 {
@@ -713,21 +775,33 @@ func initBigQueryConnection(
 		credScopes = []string{bigqueryapi.Scope}
 	}
 
+	baseRT, err := newBaseRoundTripper(userAgent, proxyAddress)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to configure base transport: %w", err)
+	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: baseRT})
+
 	if impersonateServiceAccount != "" {
+		// Use default credentials to call IAMCredentials and mint impersonated tokens.
+		baseCreds, err := google.FindDefaultCredentials(ctx, CloudPlatformScope)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to find default Google Cloud credentials for impersonation: %w", err)
+		}
+		baseHTTPClient := newHTTPClient(baseRT, baseCreds.TokenSource)
 		// Create impersonated credentials token source
 		// This broader scope is needed for tools like conversational analytics
-		cloudPlatformTokenSource, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
-			TargetPrincipal: impersonateServiceAccount,
-			Scopes:          credScopes,
-		})
+		cloudPlatformTokenSource, err := impersonate.CredentialsTokenSource(
+			ctx,
+			impersonate.CredentialsConfig{
+				TargetPrincipal: impersonateServiceAccount,
+				Scopes:          credScopes,
+			},
+			option.WithHTTPClient(baseHTTPClient),
+		)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to create impersonated credentials for %q: %w", impersonateServiceAccount, err)
 		}
 		tokenSource = cloudPlatformTokenSource
-		opts = []option.ClientOption{
-			option.WithUserAgent(userAgent),
-			option.WithTokenSource(cloudPlatformTokenSource),
-		}
 	} else {
 		// Use default credentials
 		cred, err := google.FindDefaultCredentials(ctx, credScopes...)
@@ -735,21 +809,19 @@ func initBigQueryConnection(
 			return nil, nil, nil, fmt.Errorf("failed to find default Google Cloud credentials with scopes %v: %w", credScopes, err)
 		}
 		tokenSource = cred.TokenSource
-		opts = []option.ClientOption{
-			option.WithUserAgent(userAgent),
-			option.WithCredentials(cred),
-		}
 	}
 
+	httpClient := newHTTPClient(baseRT, tokenSource)
+
 	// Initialize the high-level BigQuery client
-	client, err := bigqueryapi.NewClient(ctx, project, opts...)
+	client, err := bigqueryapi.NewClient(ctx, project, option.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create BigQuery client for project %q: %w", project, err)
 	}
 	client.Location = location
 
 	// Initialize the low-level BigQuery REST service using the same credentials
-	restService, err := bigqueryrestapi.NewService(ctx, opts...)
+	restService, err := bigqueryrestapi.NewService(ctx, option.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create BigQuery v2 service: %w", err)
 	}
@@ -765,9 +837,9 @@ func initBigQueryConnectionWithOAuthToken(
 	project string,
 	location string,
 	name string,
-	userAgent string,
 	tokenString string,
 	wantRestService bool,
+	baseRT http.RoundTripper,
 ) (*bigqueryapi.Client, *bigqueryrestapi.Service, error) {
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
@@ -777,8 +849,10 @@ func initBigQueryConnectionWithOAuthToken(
 	}
 	ts := oauth2.StaticTokenSource(token)
 
+	httpClient := newHTTPClient(baseRT, ts)
+
 	// Initialize the BigQuery client with tokenSource
-	client, err := bigqueryapi.NewClient(ctx, project, option.WithUserAgent(userAgent), option.WithTokenSource(ts))
+	client, err := bigqueryapi.NewClient(ctx, project, option.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create BigQuery client for project %q: %w", project, err)
 	}
@@ -786,7 +860,7 @@ func initBigQueryConnectionWithOAuthToken(
 
 	if wantRestService {
 		// Initialize the low-level BigQuery REST service using the same credentials
-		restService, err := bigqueryrestapi.NewService(ctx, option.WithUserAgent(userAgent), option.WithTokenSource(ts))
+		restService, err := bigqueryrestapi.NewService(ctx, option.WithHTTPClient(httpClient))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create BigQuery v2 service: %w", err)
 		}
@@ -805,14 +879,21 @@ func newBigQueryClientCreator(
 	project string,
 	location string,
 	name string,
+	proxyAddress string,
 ) (func(string, bool) (*bigqueryapi.Client, *bigqueryrestapi.Service, error), error) {
 	userAgent, err := util.UserAgentFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	baseRT, err := newBaseRoundTripper(userAgent, proxyAddress)
+	if err != nil {
+		return nil, err
+	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: baseRT})
+
 	return func(tokenString string, wantRestService bool) (*bigqueryapi.Client, *bigqueryrestapi.Service, error) {
-		return initBigQueryConnectionWithOAuthToken(ctx, tracer, project, location, name, userAgent, tokenString, wantRestService)
+		return initBigQueryConnectionWithOAuthToken(ctx, tracer, project, location, name, tokenString, wantRestService, baseRT)
 	}, nil
 }
 
@@ -824,6 +905,7 @@ func initDataplexConnection(
 	useClientOAuth bool,
 	impersonateServiceAccount string,
 	scopes []string,
+	proxyAddress string,
 ) (*dataplexapi.CatalogClient, DataplexClientCreator, error) {
 	var client *dataplexapi.CatalogClient
 	var clientCreator DataplexClientCreator
@@ -838,43 +920,59 @@ func initDataplexConnection(
 	}
 
 	if useClientOAuth {
-		clientCreator = newDataplexClientCreator(ctx, project, userAgent)
+		clientCreator = newDataplexClientCreator(ctx, project, userAgent, proxyAddress)
 	} else {
-		var opts []option.ClientOption
-
 		credScopes := scopes
 		if len(credScopes) == 0 {
 			credScopes = []string{CloudPlatformScope}
 		}
 
+		baseRT, err := newBaseRoundTripper(userAgent, proxyAddress)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to configure base transport: %w", err)
+		}
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: baseRT})
+
+		var tokenSource oauth2.TokenSource
 		if impersonateServiceAccount != "" {
+			baseCreds, err := google.FindDefaultCredentials(ctx, CloudPlatformScope)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to find default Google Cloud credentials for impersonation: %w", err)
+			}
+			baseHTTPClient := newHTTPClient(baseRT, baseCreds.TokenSource)
 			// Create impersonated credentials token source
-			ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
-				TargetPrincipal: impersonateServiceAccount,
-				Scopes:          credScopes,
-			})
+			ts, err := impersonate.CredentialsTokenSource(
+				ctx,
+				impersonate.CredentialsConfig{
+					TargetPrincipal: impersonateServiceAccount,
+					Scopes:          credScopes,
+				},
+				option.WithHTTPClient(baseHTTPClient),
+			)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to create impersonated credentials for %q: %w", impersonateServiceAccount, err)
 			}
-			opts = []option.ClientOption{
-				option.WithUserAgent(userAgent),
-				option.WithTokenSource(ts),
-			}
+			tokenSource = ts
 		} else {
 			// Use default credentials
 			cred, err := google.FindDefaultCredentials(ctx, credScopes...)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to find default Google Cloud credentials: %w", err)
 			}
-			opts = []option.ClientOption{
-				option.WithUserAgent(userAgent),
-				option.WithCredentials(cred),
-			}
+			tokenSource = cred.TokenSource
 		}
 
-		client, err = dataplexapi.NewCatalogClient(ctx, opts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create Dataplex client for project %q: %w", project, err)
+		if shouldUseRESTClient(proxyAddress) {
+			httpClient := newHTTPClient(baseRT, tokenSource)
+			client, err = dataplexapi.NewCatalogRESTClient(ctx, option.WithHTTPClient(httpClient))
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to create Dataplex REST client for project %q: %w", project, err)
+			}
+		} else {
+			client, err = dataplexapi.NewCatalogClient(ctx, option.WithUserAgent(userAgent), option.WithTokenSource(tokenSource))
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to create Dataplex client for project %q: %w", project, err)
+			}
 		}
 	}
 
@@ -886,12 +984,23 @@ func initDataplexConnectionWithOAuthToken(
 	project string,
 	userAgent string,
 	tokenString string,
+	useREST bool,
+	baseRT http.RoundTripper,
 ) (*dataplexapi.CatalogClient, error) {
 	// Construct token source
 	token := &oauth2.Token{
 		AccessToken: string(tokenString),
 	}
 	ts := oauth2.StaticTokenSource(token)
+
+	if useREST {
+		httpClient := newHTTPClient(baseRT, ts)
+		client, err := dataplexapi.NewCatalogRESTClient(ctx, option.WithHTTPClient(httpClient))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Dataplex REST client for project %q: %w", project, err)
+		}
+		return client, nil
+	}
 
 	client, err := dataplexapi.NewCatalogClient(ctx, option.WithUserAgent(userAgent), option.WithTokenSource(ts))
 	if err != nil {
@@ -904,9 +1013,22 @@ func newDataplexClientCreator(
 	ctx context.Context,
 	project string,
 	userAgent string,
+	proxyAddress string,
 ) func(string) (*dataplexapi.CatalogClient, error) {
+	useREST := shouldUseRESTClient(proxyAddress)
+	var baseRT http.RoundTripper
+	if useREST {
+		var err error
+		baseRT, err = newBaseRoundTripper(userAgent, proxyAddress)
+		if err != nil {
+			return func(string) (*dataplexapi.CatalogClient, error) {
+				return nil, err
+			}
+		}
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: baseRT})
+	}
 	return func(tokenString string) (*dataplexapi.CatalogClient, error) {
-		return initDataplexConnectionWithOAuthToken(ctx, project, userAgent, tokenString)
+		return initDataplexConnectionWithOAuthToken(ctx, project, userAgent, tokenString, useREST, baseRT)
 	}
 }
 

--- a/internal/sources/bigquery/bigquery_test.go
+++ b/internal/sources/bigquery/bigquery_test.go
@@ -75,6 +75,24 @@ func TestParseFromYamlBigQuery(t *testing.T) {
 			},
 		},
 		{
+			desc: "with proxy example",
+			in: `
+			kind: source
+			name: my-instance
+			type: bigquery
+			project: my-project
+			proxy: https://proxy.example:8443
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-instance": bigquery.Config{
+					Name:    "my-instance",
+					Type:    bigquery.SourceType,
+					Project: "my-project",
+					Proxy:   "https://proxy.example:8443",
+				},
+			},
+		},
+		{
 			desc: "use client auth example",
 			in: `
 			kind: source

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -20,12 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"reflect"
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3215,4 +3217,131 @@ func getBigQueryVectorSearchStmts(vectorTableName string) (string, string) {
 	insertStmt := fmt.Sprintf("INSERT INTO %s (id, content, embedding) VALUES (1, @content, @text_to_embed)", vectorTableName)
 	searchStmt := fmt.Sprintf("SELECT id, content, ML.DISTANCE(embedding, @query, 'COSINE') AS distance FROM %s ORDER BY distance LIMIT 1", vectorTableName)
 	return insertStmt, searchStmt
+}
+
+func TestBigQueryProxy(t *testing.T) {
+	// Start local proxy server
+	var proxyCount int32
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodConnect {
+				atomic.AddInt32(&proxyCount, 1)
+				destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusServiceUnavailable)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				hijacker, ok := w.(http.Hijacker)
+				if !ok {
+					http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+					return
+				}
+				clientConn, _, err := hijacker.Hijack()
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusServiceUnavailable)
+					return
+				}
+				go func() {
+					defer destConn.Close()
+					defer clientConn.Close()
+					io.Copy(destConn, clientConn)
+				}()
+				go func() {
+					defer destConn.Close()
+					defer clientConn.Close()
+					io.Copy(clientConn, destConn)
+				}()
+			} else {
+				http.Error(w, "Only CONNECT method is supported", http.StatusMethodNotAllowed)
+			}
+		}),
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to start proxy: %v", err)
+	}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	proxyURL := "http://" + listener.Addr().String()
+
+	sourceConfig := getBigQueryVars(t)
+	sourceConfig["proxy"] = proxyURL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	datasetName := fmt.Sprintf("temp_toolbox_test_proxy_%s", strings.ReplaceAll(uuid.New().String(), "-", ""))
+
+	client, err := initBigQueryConnection(BigqueryProject)
+	if err != nil {
+		t.Fatalf("unable to create BigQuery connection: %s", err)
+	}
+
+	dataset := client.Dataset(datasetName)
+	if err := dataset.Create(ctx, &bigqueryapi.DatasetMetadata{Name: datasetName}); err != nil {
+		t.Fatalf("Failed to create dataset %q: %v", datasetName, err)
+	}
+	defer func() {
+		if err := dataset.DeleteWithContents(ctx); err != nil {
+			t.Logf("failed to cleanup dataset %s: %v", datasetName, err)
+		}
+	}()
+
+	toolsFile := map[string]any{
+		"sources": map[string]any{
+			"my-instance": sourceConfig,
+		},
+		"tools": map[string]any{
+			"my-list-dataset-tool": map[string]any{
+				"type":        "bigquery-list-dataset-ids",
+				"source":      "my-instance",
+				"description": "Tool to list dataset",
+			},
+		},
+	}
+
+	args := []string{"--enable-api"}
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+	defer cmd.Close()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	// Make a tool call and verify it succeeds
+	reqBody := []byte(`{}`)
+	req, err := http.NewRequest("POST", "http://127.0.0.1:5000/api/tool/my-list-dataset-tool/invoke", bytes.NewBuffer(reqBody))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to invoke tool: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected status 200, got %d. Body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	if atomic.LoadInt32(&proxyCount) == 0 {
+		t.Errorf("Proxy was not used during the API call")
+	}
 }


### PR DESCRIPTION
   ## Summary                                                                   
   - add optional `proxy` field to BigQuery source config                       
   - route BigQuery client + REST service through proxy-aware HTTP client (uses 
 explicit proxy or HTTP(S)_PROXY)                                               
   - document proxy option in BigQuery source docs                              
                                                                                
   
                                            
                                                                       
   This wasn’t supported yet — BigQuery client creation didn’t wire proxy    transports, so HTTPS_PROXY/HTTP_PROXY were ignored.                            
   this PR that adds a `proxy` field on the BigQuery source config and routes both the client and REST service through a proxy-aware HTTP client (explicit proxy or HTTP(S)_PROXY). Docs updated.                               
                                                                                
   Example:                                                                     
   proxy: "https://proxy.company:8443"         

fixes #2766