### PR TITLE
fix(config): add doc/line context to parse errors

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -65,50 +65,76 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 	}
 
 	var err error
-	output := re.ReplaceAllStringFunc(input, func(match string) string {
-		parts := re.FindStringSubmatch(match)
+	matches := re.FindAllStringSubmatchIndex(input, -1)
+	var output strings.Builder
+	lastIndex := 0
+	for _, match := range matches {
+		start, end := match[0], match[1]
+		output.WriteString(input[lastIndex:start])
 
-		// extract the variable name
-		variableName := parts[1]
+		variableName := input[match[2]:match[3]]
+		defaultValue := ""
+		defaultProvided := match[4] != -1 && match[5] != -1
+		if defaultProvided {
+			defaultValue = input[match[6]:match[7]]
+		}
 
-		isOptional := len(parts) >= 4 && parts[2] != ""
-		if isOptional {
-			// Add to optional list only if it hasn't been explicitly required
-			if !slices.Contains(p.requiredEnvVars, variableName) && !slices.Contains(p.OptionalEnvVars, variableName) {
-				p.OptionalEnvVars = append(p.OptionalEnvVars, variableName)
-			}
+		if defaultProvided {
+			p.OptionalEnvVars = append(p.OptionalEnvVars, variableName)
 		} else {
-			// Mark as required
-			if !slices.Contains(p.requiredEnvVars, variableName) {
-				p.requiredEnvVars = append(p.requiredEnvVars, variableName)
-			}
-
-			// Remove from optional list if it's there
-			if i := slices.Index(p.OptionalEnvVars, variableName); i != -1 {
-				p.OptionalEnvVars = slices.Delete(p.OptionalEnvVars, i, i+1)
-			}
+			p.requiredEnvVars = append(p.requiredEnvVars, variableName)
 		}
 
 		if value, found := os.LookupEnv(variableName); found {
 			p.EnvVars[variableName] = value
-			return value
+			output.WriteString(value)
+		} else if defaultProvided {
+			p.EnvVars[variableName] = defaultValue
+			output.WriteString(defaultValue)
+		} else {
+			if p.AllowMissingEnvVars {
+				p.EnvVars[variableName] = variableName
+				output.WriteString(variableName)
+			} else if err == nil {
+				line, column := lineColumnAt(input, start)
+				err = fmt.Errorf("environment variable not found: %q (line %d, column %d)", variableName, line, column)
+			}
 		}
-		if len(parts) >= 4 && parts[2] != "" {
-			value := parts[3]
-			p.EnvVars[variableName] = value
-			return value
+
+		lastIndex = end
+	}
+	output.WriteString(input[lastIndex:])
+
+	// Filter out OptionalEnvVars that were also found as required
+	var finalOptional []string
+	for _, v := range p.OptionalEnvVars {
+		if !slices.Contains(p.requiredEnvVars, v) && !slices.Contains(finalOptional, v) {
+			finalOptional = append(finalOptional, v)
 		}
-		if p.AllowMissingEnvVars {
-			p.EnvVars[variableName] = variableName
-			return variableName
-		}
-		err = fmt.Errorf("environment variable not found: %q", variableName)
-		return ""
-	})
-	return output, err
+	}
+	p.OptionalEnvVars = finalOptional
+
+	return output.String(), err
 }
 
 // ParseConfig parses the provided yaml into appropriate configs.
+func lineColumnAt(input string, index int) (int, int) {
+	line := 1
+	column := 1
+	for i, r := range input {
+		if i >= index {
+			break
+		}
+		if r == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return line, column
+}
+
 func (p *ConfigParser) ParseConfig(ctx context.Context, raw []byte) (Config, error) {
 	var config Config
 	// Replace environment variables if found

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -52,7 +52,7 @@ func TestParseEnv(t *testing.T) {
 			in:        "${FOO}",
 			want:      "",
 			err:       true,
-			errString: `environment variable not found: "FOO"`,
+			errString: `environment variable not found: "FOO" (line 1, column 1)`,
 		},
 		{
 			desc:    "without default without env, lenient",

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"regexp"
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
+	"github.com/goccy/go-yaml/token"
 	"github.com/googleapis/mcp-toolbox/internal/auth"
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/auth/google"
@@ -169,22 +171,40 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 	var promptConfigs PromptConfigs
 	// promptset configs is not yet supported
 
+	file, err := parser.ParseBytes(raw, 0)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("unable to parse YAML: %s", yaml.FormatError(err, false, false))
+	}
+
 	decoder := yaml.NewDecoder(bytes.NewReader(raw))
-	// for loop to unmarshal documents with the `---` separator
-	for {
+	for index, doc := range file.Docs {
+		if doc == nil || doc.Body == nil {
+			continue
+		}
+		docIndex := index + 1
 		var resource map[string]any
-		if err := decoder.DecodeContext(ctx, &resource); err != nil {
-			if err == io.EOF {
-				break
+		if err := decoder.DecodeFromNodeContext(ctx, doc.Body, &resource); err != nil {
+			if len(file.Docs) > 1 {
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: %s", docIndex, yaml.FormatError(err, false, false))
 			}
-			return nil, nil, nil, nil, nil, nil, fmt.Errorf("unable to decode YAML document: %w", err)
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("unable to decode YAML document: %s", yaml.FormatError(err, false, false))
 		}
 		var kind, name string
 		var ok bool
 		if kind, ok = resource["kind"].(string); !ok {
+			if len(file.Docs) > 1 {
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("%s missing 'kind' field or it is not a string", formatDocLocation(docIndex, keyToken(doc.Body, "kind"), doc.Body))
+			}
 			return nil, nil, nil, nil, nil, nil, fmt.Errorf("missing 'kind' field or it is not a string: %v", resource)
 		}
 		if name, ok = resource["name"].(string); !ok {
+			if len(file.Docs) > 1 {
+				fallbackToken := keyToken(doc.Body, "name")
+				if fallbackToken == nil {
+					fallbackToken = keyToken(doc.Body, "kind")
+				}
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("%s missing 'name' field or it is not a string", formatDocLocation(docIndex, fallbackToken, doc.Body))
+			}
 			return nil, nil, nil, nil, nil, nil, fmt.Errorf("missing 'name' field or it is not a string")
 		}
 		// remove 'kind' from map for strict unmarshaling
@@ -194,7 +214,10 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 		case "source":
 			c, err := UnmarshalYAMLSourceConfig(ctx, name, resource)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+				if len(file.Docs) > 1 {
+					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
+				}
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
 			if sourceConfigs == nil {
 				sourceConfigs = make(SourceConfigs)
@@ -203,7 +226,10 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 		case "authService":
 			c, err := UnmarshalYAMLAuthServiceConfig(ctx, name, resource)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+				if len(file.Docs) > 1 {
+					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
+				}
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
 			if authServiceConfigs == nil {
 				authServiceConfigs = make(AuthServiceConfigs)
@@ -212,7 +238,10 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 		case "tool":
 			c, err := UnmarshalYAMLToolConfig(ctx, name, resource)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+				if len(file.Docs) > 1 {
+					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
+				}
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
 			if c == nil {
 				continue
@@ -224,7 +253,10 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 		case "toolset":
 			c, err := UnmarshalYAMLToolsetConfig(ctx, name, resource)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+				if len(file.Docs) > 1 {
+					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
+				}
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
 			if toolsetConfigs == nil {
 				toolsetConfigs = make(ToolsetConfigs)
@@ -233,7 +265,10 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 		case "embeddingModel":
 			c, err := UnmarshalYAMLEmbeddingModelConfig(ctx, name, resource)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+				if len(file.Docs) > 1 {
+					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
+				}
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
 			if embeddingModelConfigs == nil {
 				embeddingModelConfigs = make(EmbeddingModelConfigs)
@@ -242,13 +277,19 @@ func UnmarshalResourceConfig(ctx context.Context, raw []byte) (SourceConfigs, Au
 		case "prompt":
 			c, err := UnmarshalYAMLPromptConfig(ctx, name, resource)
 			if err != nil {
-				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %s", kind, err)
+				if len(file.Docs) > 1 {
+					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
+				}
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
 			if promptConfigs == nil {
 				promptConfigs = make(PromptConfigs)
 			}
 			promptConfigs[name] = c
 		default:
+			if len(file.Docs) > 1 {
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("%s invalid kind %q", formatDocLocation(docIndex, keyToken(doc.Body, "kind"), doc.Body), kind)
+			}
 			return nil, nil, nil, nil, nil, nil, fmt.Errorf("invalid kind %s", kind)
 		}
 	}
@@ -483,6 +524,43 @@ func NameValidation(name string) error {
 	isValid := validChars.MatchString(name)
 	if !isValid {
 		return fmt.Errorf("invalid character for resource name; only uppercase and lowercase ASCII letters (A-Z, a-z), digits (0-9), underscore (_), hyphen (-), and dot (.) is allowed")
+	}
+	return nil
+}
+
+func formatDocLocation(docIndex int, keyToken *token.Token, body ast.Node) string {
+	line, column := 0, 0
+	if keyToken != nil {
+		line = keyToken.Position.Line
+		column = keyToken.Position.Column
+	} else if body != nil && body.GetToken() != nil {
+		line = body.GetToken().Position.Line
+		column = body.GetToken().Position.Column
+	}
+	if line > 0 && column > 0 {
+		return fmt.Sprintf("document %d (line %d, column %d):", docIndex, line, column)
+	}
+	return fmt.Sprintf("document %d:", docIndex)
+}
+
+func keyToken(body ast.Node, key string) *token.Token {
+	if body == nil {
+		return nil
+	}
+	mapping, ok := body.(*ast.MappingNode)
+	if !ok {
+		return nil
+	}
+	iter := mapping.MapRange()
+	for iter.Next() {
+		mapKey := iter.Key()
+		if mapKey == nil {
+			continue
+		}
+		token := mapKey.GetToken()
+		if token != nil && token.Value == key {
+			return token
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
  ## Description                                                               
   Add document index + line/column context to YAML config parsing errors so users can locate issues fast in multi‑doc configs. Errors now includedoc/line/col, resource name when available, and env‑var substitution points.   
                                                                                
   ## PR Checklist                                                              
   - [x] Make sure you reviewed CONTRIBUTING.md                                 
   - [x] Make sure to open an issue as a bug/issue before writing your code     
   - [ ] Ensure the tests and linter pass                                       
   - [ ] Code coverage does not decrease (if any source code was changed)       
   - [ ] Appropriate docs were updated (if necessary)                           
   - [ ] Make sure to add `!` if this involve a breaking change                 
                                                                                
Fixes #2927                           