### PR TITLE
docs: Add Loaditout Security Grade badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <a href="https://trendshift.io/repositories/13019" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13019" alt="googleapis%2Fgenai-toolbox | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/genai-toolbox)](https://goreportcard.com/report/github.com/googleapis/genai-toolbox)
+[![Loaditout Security Grade](https://loaditout.ai/badge/googleapis/genai-toolbox)](https://loaditout.ai/skills/googleapis/genai-toolbox)
 [![License: Apache
 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Docs](https://img.shields.io/badge/Docs-MCP_Toolbox-blue)](https://mcp-toolbox.dev/)


### PR DESCRIPTION
This repo passed all 7 criteria in the security grading system and earned an A grade on [Loaditout](https://www.loaditout.ai). Only 20.5% of the 20,000+ servers we scanned earn this grade.

This PR adds a security badge to the README.

Listing: https://loaditout.ai/skills/googleapis/genai-toolbox

The 7 criteria:

* zero injection flags
* zero capability flags
* `README` present
* description present
* committed within 12 months
* 5+ stars
* no secret env vars.