### PR TITLE
ci: update patterns to include postgres tools and mcp test harness

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -998,10 +998,18 @@ steps:
     args:
       - -c
       - |
-        .ci/test_with_coverage.sh \
-          "Cloud SQL Wait for Operation" \
-          cloudsql \
-          cloudsql
+        PATTERN="tests/cloudsql|internal/sources/cloudsqladmin|internal/server/|.ci/"
+
+        if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
+          echo "Changes detected. Running Cloud SQL tests..."
+          .ci/test_with_coverage.sh \
+            "Cloud SQL Wait for Operation" \
+            cloudsql \
+            cloudsql
+        else
+          echo "No relevant changes for Cloud SQL. Skipping shard."
+          exit 0
+        fi
 
   - id: "tidb"
     name: golang:1
@@ -1309,7 +1317,7 @@ steps:
 
   - id: "dataproc"
     name: golang:1
-    waitFor: ["compile-test-binary"]
+    waitFor: ["compile-test-binary", "detect-changes"]
     entrypoint: /bin/bash
     env:
       - "GOPATH=/gopath"
@@ -1323,9 +1331,17 @@ steps:
     args:
       - -c
       - |
-        .ci/test_with_coverage.sh \
-          "Dataproc" \
-          dataproc
+        PATTERN="dataproc|internal/server/|.ci/"
+
+        if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
+          echo "Changes detected. Running Dataproc tests..."
+          .ci/test_with_coverage.sh \
+            "Dataproc" \
+            dataproc
+        else
+          echo "No relevant changes for Dataproc. Skipping shard."
+          exit 0
+        fi
 
   - id: "singlestore"
     name: golang:1

--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -105,7 +105,7 @@ steps:
     args:
       - -c
       - |
-        PATTERN="cloudsqlpg|internal/sources/postgres|tests/postgres|internal/server/|tests/common.go|tests/tool.go|.ci/"
+        PATTERN="cloudsqlpg|internal/sources/postgres|internal/tools/postgres|tests/postgres|internal/server/|tests/common.go|tests/tool.go|tests/mcp_tool.go|.ci/"
         
         if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
           echo "Relevant changes detected. Starting Cloud SQL Postgres tests..."
@@ -136,7 +136,7 @@ steps:
     args:
       - -c
       - |
-        PATTERN="alloydb|internal/sources/postgres|tests/postgres|internal/server/|tests/common.go|.ci/"
+        PATTERN="alloydb|internal/sources/postgres|internal/tools/postgres|tests/postgres|internal/server/|tests/common.go|tests/tool.go|tests/mcp_tool.go|.ci/"
         
         if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
           echo "Relevant changes detected. Starting AlloyDB tests..."
@@ -168,7 +168,7 @@ steps:
     args:
       - -c
       - |
-        PATTERN="alloydbpg|internal/sources/postgres|tests/postgres|internal/server/|tests/common.go|tests/tool.go|.ci/"
+        PATTERN="alloydbpg|internal/sources/postgres|internal/tools/postgres|tests/postgres|internal/server/|tests/common.go|tests/tool.go|tests/mcp_tool.go|.ci/"
 
         if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
           echo "Changes detected. Running AlloyDB Postgres tests..."
@@ -226,7 +226,7 @@ steps:
     args:
       - -c
       - |
-        PATTERN="alloydbomni|internal/sources/postgres|internal/server/|tests/common.go|tests/tool.go|.ci/"
+        PATTERN="alloydbomni|internal/sources/postgres|internal/tools/postgres|tests/postgres|internal/server/|tests/common.go|tests/tool.go|tests/mcp_tool.go|.ci/"
 
         if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
           echo "Changes detected. Running AlloyDB Omni tests..."
@@ -454,7 +454,7 @@ steps:
     args:
       - -c
       - |
-        PATTERN="postgres|internal/server/|tests/common.go|tests/tool.go|.ci/"
+        PATTERN="postgres|internal/tools/postgres|internal/server/|tests/common.go|tests/tool.go|tests/mcp_tool.go|.ci/"
 
         if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
           echo "Changes detected. Running Postgres tests..."


### PR DESCRIPTION
This PR updates the `PATTERN` regex in `.ci/integration.cloudbuild.yaml` for all Postgres-related test shards (`cloud-sql-pg`, `alloydb`, `alloydb-pg`, `alloydb-omni`, and `postgres`).

The patterns now include `internal/tools/postgres` and `tests/mcp_tool.go`. This ensures that changes to Postgres tools or the new MCP test harness will correctly trigger the relevant integration tests in the CI pipeline. Previously, modifications to these directories would not trigger tests unless other shared files were also modified.