### PR TITLE
docs: update docsite versions for release

### DIFF
--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -78,6 +78,10 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 
 [[params.versions]]
   version = "v1.0.0"
+  url = "https://mcp-toolbox.dev/v1.1.0/"
+
+[[params.versions]]
+  version = "v1.0.0"
   url = "https://mcp-toolbox.dev/v1.0.0/"
 
 [[params.versions]]
@@ -115,10 +119,6 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 [[params.versions]]
   version = "v0.24.0"
   url = "https://mcp-toolbox.dev/v0.24.0/"
-
-[[params.versions]]
-  version = "v0.23.0"
-  url = "https://mcp-toolbox.dev/v0.23.0/"
 
 [[menu.main]]
   name = "GitHub"

--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -77,7 +77,7 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 # The order of versions in this file is mirrored into the dropdown
 
 [[params.versions]]
-  version = "v1.0.0"
+  version = "v1.1.0"
   url = "https://mcp-toolbox.dev/v1.1.0/"
 
 [[params.versions]]

--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -63,6 +63,10 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 
 [[params.versions]]
   version = "v1.0.0"
+  url = "https://mcp-toolbox.dev/v1.1.0/"
+
+[[params.versions]]
+  version = "v1.0.0"
   url = "https://mcp-toolbox.dev/v1.0.0/"
 
 [[params.versions]]

--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -62,7 +62,7 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 # The order of versions in this file is mirrored into the dropdown
 
 [[params.versions]]
-  version = "v1.0.0"
+  version = "v1.1.0"
   url = "https://mcp-toolbox.dev/v1.1.0/"
 
 [[params.versions]]


### PR DESCRIPTION
Add new versions for docsite. Also removed older version entries as we can only support the last 12 versions (20,000 pages limit on cloudflare deployment)