### PR TITLE
fix(tool/looker-conversational-analytics): OAuth token in GDA payload fix

### DIFF
--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -249,7 +249,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	oauth_creds := OAuthCredentials{}
 	if source.UseClientAuthorization() {
-		oauth_creds.Token = TokenBased{AccessToken: string(accessToken)}
+		rawToken, err := accessToken.ParseBearerToken()
+		if err != nil {
+			return nil, util.NewClientServerError("invalid access token format: expected 'Bearer <token>'", http.StatusUnauthorized, err)
+		}
+		oauth_creds.Token = TokenBased{AccessToken: rawToken}
 	} else {
 		oauth_creds.Secret = SecretBased{ClientId: source.LookerApiSettings().ClientId, ClientSecret: source.LookerApiSettings().ClientSecret}
 	}

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -249,7 +249,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	oauth_creds := OAuthCredentials{}
 	if source.UseClientAuthorization() {
-rawToken, err := accessToken.ParseBearerToken()
+		rawToken, err := accessToken.ParseBearerToken()
 		if err != nil {
 			return nil, err.(util.ToolboxError)
 		}

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -249,9 +249,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	oauth_creds := OAuthCredentials{}
 	if source.UseClientAuthorization() {
-		rawToken, err := accessToken.ParseBearerToken()
+rawToken, err := accessToken.ParseBearerToken()
 		if err != nil {
-			return nil, util.NewClientServerError("invalid access token format: expected 'Bearer <token>'", http.StatusUnauthorized, err)
+			return nil, err.(util.ToolboxError)
 		}
 		oauth_creds.Token = TokenBased{AccessToken: rawToken}
 	} else {


### PR DESCRIPTION

When using per-user OAuth (`use_client_oauth: true`), the `ask_data_insights` tool fails to authenticate with the Gemini Data Analytics API, while `get_models` and `get_explores` work correctly with the same token.

The MCP server extracts the full `Authorization` header value (e.g., `"Bearer abc123"`) and passes it as `accessToken` to each tool's `Invoke()` method. The `get_models`/`get_explores` tools pass this to `GetLookerSDK()`, which sets it as an HTTP `Authorization` header where the `"Bearer "` prefix is expected. However, `ask_data_insights` was embedding the full `"Bearer abc123"` string into the JSON payload's `access_token` field sent to the GDA API, which expects only the raw token value.

The fix calls `accessToken.ParseBearerToken()` to strip the `"Bearer "` prefix before placing the token into the `TokenBased` struct. This only affects the OAuth code path; the `SecretBased` (client_id/client_secret) path is unchanged.

### Before

```go
oauth_creds.Token = TokenBased{AccessToken: string(accessToken)}
// Produces: {"access_token": "Bearer abc123"} -- rejected by GDA API
```

### After

```go
rawToken, err := accessToken.ParseBearerToken()
oauth_creds.Token = TokenBased{AccessToken: rawToken}
// Produces: {"access_token": "abc123"} -- correct
```

### Files Changed

- `internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go`

## PR Checklist

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #3057
