### PR TITLE
fix(auth)!: prevent fail-open bypass on generic auth errors

### DIFF
--- a/internal/auth/generic/generic.go
+++ b/internal/auth/generic/generic.go
@@ -308,7 +308,7 @@ func (a AuthService) validateOpaqueToken(ctx context.Context, tokenStr string) e
 
 	if resp.StatusCode != http.StatusOK {
 		logger.WarnContext(ctx, "introspection failed with status: %d", resp.StatusCode)
-		return &MCPAuthError{Code: http.StatusUnauthorized, Message: fmt.Sprintf("introspection failed with status: %d", resp.StatusCode), ScopesRequired: a.ScopesRequired}
+		return &MCPAuthError{Code: http.StatusInternalServerError, Message: fmt.Sprintf("introspection failed with status: %d", resp.StatusCode), ScopesRequired: a.ScopesRequired}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -503,6 +503,10 @@ func mcpAuthMiddleware(s *Server) func(http.Handler) http.Handler {
 				}
 			}
 
+			// Add logger to context
+			ctx := util.WithLogger(r.Context(), s.logger)
+			r = r.WithContext(ctx)
+
 			// MCP Auth not enabled
 			if mcpSvc == nil {
 				next.ServeHTTP(w, r)
@@ -525,8 +529,19 @@ func mcpAuthMiddleware(s *Server) func(http.Handler) http.Handler {
 						w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="insufficient_scope", scope="%s", resource_metadata="%s", error_description="%s"`, strings.Join(mcpErr.ScopesRequired, " "), s.toolboxUrl+"/.well-known/oauth-protected-resource", mcpErr.Message))
 						http.Error(w, mcpErr.Message, http.StatusForbidden)
 						return
+					default:
+						if mcpErr.Code >= 500 {
+							s.logger.ErrorContext(r.Context(), "internal authentication error", "error", mcpErr.Message)
+							http.Error(w, "internal server error during authentication", mcpErr.Code)
+						} else {
+							http.Error(w, mcpErr.Message, mcpErr.Code)
+						}
+						return
 					}
 				}
+				s.logger.ErrorContext(r.Context(), "unexpected error during authentication", "error", err)
+				http.Error(w, "internal server error during authentication", http.StatusInternalServerError)
+				return
 			}
 
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
## Description
Fixes a critical vulnerability where MCP server middleware failed to safely handle validation errors with `http.StatusInternalServerError` codes, leading to unauthorized actors bypassing the authentication layer if the external OIDC Authorization Server experiences an outage or DoS.

## PR Checklist
- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involves a breaking change

Fixes #3076 