### PR TITLE
chore: avoid silent exit by printing server error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,7 @@ func Execute() {
 	opts := internal.NewToolboxOptions()
 
 	if err := NewCommand(opts).Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		exit := 1
 		os.Exit(exit)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func Execute() {
 	opts := internal.NewToolboxOptions()
 
 	if err := NewCommand(opts).Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintf(opts.IOStreams.ErrOut, "Error: %v\n", err)
 		exit := 1
 		os.Exit(exit)
 	}


### PR DESCRIPTION
printing server startup error if an error was discovered. Previously it will just exit silently if theres an unknown flag caught by Cobra.

🛠️ Fixes #3063
