### PR TITLE
docs: fix typo in extensions command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ After installing a [Gemini CLI extensions](https://geminicli.com/extensions/), t
 gemini
 
 # List extensions
-/exttensions list
+/extensions list
 # List MCP servers
 /mcp list
 ```


### PR DESCRIPTION
### 🛠️ Fix typo in Gemini CLI section

This pull request fixes a typo in the **Gemini CLI** section of the README.

* Corrected `/exttensions list` → `/extensions list`

### ✅ Why this change?

The incorrect command may confuse users when trying to list extensions in the CLI.

### 📌 Scope

* Documentation update only
* No code changes

---

Let me know if any changes are needed.
