### PR TITLE
feat: add support for HTTPS/TLS listener

### DIFF
--- a/cmd/internal/flags.go
+++ b/cmd/internal/flags.go
@@ -61,6 +61,8 @@ func ConfigFileFlags(flags *pflag.FlagSet, opts *ToolboxOptions) {
 func ServeFlags(flags *pflag.FlagSet, opts *ToolboxOptions) {
 	flags.StringVarP(&opts.Cfg.Address, "address", "a", "127.0.0.1", "Address of the interface the server will listen on.")
 	flags.IntVarP(&opts.Cfg.Port, "port", "p", 5000, "Port the server will listen on.")
+	flags.StringVar(&opts.Cfg.CertFile, "tls-cert", "", "Path to TLS certificate file")
+	flags.StringVar(&opts.Cfg.KeyFile, "tls-key", "", "Path to TLS key file")
 	flags.BoolVar(&opts.Cfg.Stdio, "stdio", false, "Listens via MCP STDIO instead of acting as a remote HTTP server.")
 	flags.BoolVar(&opts.Cfg.UI, "ui", false, "Launches the Toolbox UI web server.")
 	flags.BoolVar(&opts.Cfg.EnableAPI, "enable-api", false, "Enable the /api endpoint.")

--- a/cmd/internal/serve/command.go
+++ b/cmd/internal/serve/command.go
@@ -79,6 +79,12 @@ func runServe(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 		return errMsg
 	}
 
+	useTLS := opts.Cfg.CertFile != "" || opts.Cfg.KeyFile != ""
+	protocol := "http"
+	if useTLS {
+		protocol = "https"
+	}
+
 	// run server in background
 	srvErr := make(chan error, 1)
 	if opts.Cfg.Stdio {
@@ -90,7 +96,7 @@ func runServe(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 			}
 		}()
 	} else {
-		err = s.Listen(ctx)
+		err = s.Listen(ctx, opts.Cfg.CertFile, opts.Cfg.KeyFile)
 		if err != nil {
 			errMsg := fmt.Errorf("toolbox failed to start listener: %w", err)
 			opts.Logger.ErrorContext(ctx, errMsg.Error())
@@ -98,7 +104,7 @@ func runServe(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 		}
 		opts.Logger.InfoContext(ctx, "Server ready to serve!")
 		if opts.Cfg.UI {
-			opts.Logger.InfoContext(ctx, fmt.Sprintf("Toolbox UI is up and running at: http://%s:%d/ui", opts.Cfg.Address, opts.Cfg.Port))
+			opts.Logger.InfoContext(ctx, fmt.Sprintf("Toolbox UI is up and running at: %s://%s:%d/ui", protocol, opts.Cfg.Address, opts.Cfg.Port))
 		}
 
 		go func() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -476,6 +476,12 @@ func run(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 		return errMsg
 	}
 
+	useTLS := opts.Cfg.CertFile != "" || opts.Cfg.KeyFile != ""
+	protocol := "http"
+	if useTLS {
+		protocol = "https"
+	}
+
 	// run server in background
 	srvErr := make(chan error)
 	if opts.Cfg.Stdio {
@@ -487,7 +493,7 @@ func run(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 			}
 		}()
 	} else {
-		err = s.Listen(ctx)
+		err = s.Listen(ctx, opts.Cfg.CertFile, opts.Cfg.KeyFile)
 		if err != nil {
 			errMsg := fmt.Errorf("toolbox failed to start listener: %w", err)
 			opts.Logger.ErrorContext(ctx, errMsg.Error())
@@ -495,7 +501,7 @@ func run(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 		}
 		opts.Logger.InfoContext(ctx, "Server ready to serve!")
 		if opts.Cfg.UI {
-			opts.Logger.InfoContext(ctx, fmt.Sprintf("Toolbox UI is up and running at: http://%s:%d/ui", opts.Cfg.Address, opts.Cfg.Port))
+			opts.Logger.InfoContext(ctx, fmt.Sprintf("Toolbox UI is up and running at: %s://%s:%d/ui", protocol, opts.Cfg.Address, opts.Cfg.Port))
 		}
 
 		go func() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -232,6 +232,20 @@ func TestServerConfigFlags(t *testing.T) {
 				UserAgentMetadata: []string{"foo", "bar"},
 			}),
 		},
+		{
+			desc: "cert file",
+			args: []string{"--tls-cert", "cert.pem"},
+			want: withDefaults(server.ServerConfig{
+				CertFile: "cert.pem",
+			}),
+		},
+		{
+			desc: "key file",
+			args: []string{"--tls-key", "key.pem"},
+			want: withDefaults(server.ServerConfig{
+				KeyFile: "key.pem",
+			}),
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/docs/en/documentation/deploy-to/_index.md
+++ b/docs/en/documentation/deploy-to/_index.md
@@ -15,5 +15,11 @@ Choose your preferred deployment platform below to get started:
 *   **[Kubernetes](./kubernetes/)**: Deploy the Toolbox as a microservice using GKE.
 
 {{< notice tip >}}
-**Production Security:** When moving to production, never hardcode passwords or API keys directly into your `tools.yaml`. Always use environment variable substitution and inject those values securely through your deployment platform's secret manager.
+**Production Security:** When moving to production, never hardcode passwords or
+API keys directly into your `tools.yaml`. Always use environment variable
+substitution and inject those values securely through your deployment platform's
+secret manager.
+
+To enable HTTPS, you must provide a valid pair of `--tls-cert` and `--tls-key`
+files; specifying only one will cause the server to fail at startup.
 {{< /notice >}}

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -8,29 +8,31 @@ description: >
 
 ## Reference
 
-| Flag (Short) | Flag (Long)                | Description                                                                                                                                                                      | Default     |
-|--------------|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| `-a`         | `--address`                | Address of the interface the server will listen on.                                                                                                                              | `127.0.0.1` |
+| Flag (Short) | Flag (Long)                | Description                                                                                                                                                               | Default     |
+|--------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `-a`         | `--address`                | Address of the interface the server will listen on.                                                                                                                       | `127.0.0.1` |
 |              | `--disable-reload`         | Disables dynamic reloading config.                                                                                                                                        |             |
-| `-h`         | `--help`                   | help for toolbox                                                                                                                                                                 |             |
-|              | `--log-level`              | Specify the minimum level logged. Allowed: 'DEBUG', 'INFO', 'WARN', 'ERROR'.                                                                                                     | `info`      |
-|              | `--logging-format`         | Specify logging format to use. Allowed: 'standard' or 'JSON'.                                                                                                                    | `standard`  |
-|              | `--mcp-prm-file`           | Path to a manual Protected Resource Metadata (PRM) JSON file. If provided, overrides auto-generation for MCP Server-Wide Authentication.                                         |             |
-| `-p`         | `--port`                   | Port the server will listen on.                                                                                                                                                  | `5000`      |
-|              | `--prebuilt`               | Use one or more prebuilt tool configuration by source type. See [Prebuilt Tools Reference](../documentation/configuration/prebuilt-configs/_index.md) for allowed values.                                                |             |
-|              | `--stdio`                  | Listens via MCP STDIO instead of acting as a remote HTTP server.                                                                                                                 |             |
-|              | `--telemetry-gcp`          | Enable exporting directly to Google Cloud Monitoring.                                                                                                                            |             |
-|              | `--telemetry-otlp`         | Enable exporting using OpenTelemetry Protocol (OTLP) to the specified endpoint (e.g. 'http://127.0.0.1:4318')                                                                    |             |
-|              | `--telemetry-service-name` | Sets the value of the service.name resource attribute for telemetry data.                                                                                                        | `toolbox`   |
-|              | `--config`             | File path specifying the tool configuration. Cannot be used with --configs or --config-folder.                                                                                |             |
-|              | `--configs`            | Multiple file paths specifying tool configurations. Files will be merged. Cannot be used with --config or --config-folder.                                                    |             |
-|              | `--config-folder`           | Directory path containing YAML tool configuration files. All .yaml and .yml files in the directory will be loaded and merged. Cannot be used with --config or --configs. |             |
-|              | `--ui`                     | Launches the Toolbox UI web server.                                                                                                                                              |             |
-|              | `--allowed-origins`        | Specifies a list of origins permitted to access this server for CORs access.                                                                                                     | `*`         |
-|              | `--allowed-hosts`          | Specifies a list of hosts permitted to access this server to prevent DNS rebinding attacks.                                                                                      | `*`         |
-|              | `--user-agent-metadata`    | Appends additional metadata to the User-Agent.                                                                                                                                   |             |
-|              | `--poll-interval`          | Specifies the polling frequency (seconds) for configuration file updates.                                                                                                        | `0`         |
-| `-v`         | `--version`                | version for toolbox                                                                                                                                                              |             |
+| `-h`         | `--help`                   | help for toolbox                                                                                                                                                          |             |
+|              | `--log-level`              | Specify the minimum level logged. Allowed: 'DEBUG', 'INFO', 'WARN', 'ERROR'.                                                                                              | `info`      |
+|              | `--logging-format`         | Specify logging format to use. Allowed: 'standard' or 'JSON'.                                                                                                             | `standard`  |
+|              | `--mcp-prm-file`           | Path to a manual Protected Resource Metadata (PRM) JSON file. If provided, overrides auto-generation for MCP Server-Wide Authentication.                                  |             |
+| `-p`         | `--port`                   | Port the server will listen on.                                                                                                                                           | `5000`      |
+|              | `--tls-cert`               | Path to the PEM-encoded TLS certificate file.                                                                                                                             |             |
+|              | `--tls-key`                | Path to the PEM-encoded TLS private key file.                                                                                                                             |             |
+|              | `--prebuilt`               | Use one or more prebuilt tool configuration by source type. See [Prebuilt Tools Reference](../documentation/configuration/prebuilt-configs/_index.md) for allowed values. |             |
+|              | `--stdio`                  | Listens via MCP STDIO instead of acting as a remote HTTP server.                                                                                                          |             |
+|              | `--telemetry-gcp`          | Enable exporting directly to Google Cloud Monitoring.                                                                                                                     |             |
+|              | `--telemetry-otlp`         | Enable exporting using OpenTelemetry Protocol (OTLP) to the specified endpoint (e.g. 'http://127.0.0.1:4318')                                                             |             |
+|              | `--telemetry-service-name` | Sets the value of the service.name resource attribute for telemetry data.                                                                                                 | `toolbox`   |
+|              | `--config`                 | File path specifying the tool configuration. Cannot be used with --configs or --config-folder.                                                                            |             |
+|              | `--configs`                | Multiple file paths specifying tool configurations. Files will be merged. Cannot be used with --config or --config-folder.                                                |             |
+|              | `--config-folder`          | Directory path containing YAML tool configuration files. All .yaml and .yml files in the directory will be loaded and merged. Cannot be used with --config or --configs.  |             |
+|              | `--ui`                     | Launches the Toolbox UI web server.                                                                                                                                       |             |
+|              | `--allowed-origins`        | Specifies a list of origins permitted to access this server for CORs access.                                                                                              | `*`         |
+|              | `--allowed-hosts`          | Specifies a list of hosts permitted to access this server to prevent DNS rebinding attacks.                                                                               | `*`         |
+|              | `--user-agent-metadata`    | Appends additional metadata to the User-Agent.                                                                                                                            |             |
+|              | `--poll-interval`          | Specifies the polling frequency (seconds) for configuration file updates.                                                                                                 | `0`         |
+| `-v`         | `--version`                | version for toolbox                                                                                                                                                       |             |
 
 ## Sub Commands
 
@@ -81,6 +83,55 @@ For more detailed instructions, see [Generate Agent Skills](../documentation/con
 </details>
 
 ## Examples
+
+### Hardening Toolbox
+
+Toolbox is designed for flexibility, but security should not be ignored—even in
+local development. When exposing the server to a network or running it alongside
+a web browser, use these configurations to protect your data and system.
+
+#### Host Validation & DNS Rebinding Protection
+The `--allowed-hosts` flag controls which Host headers the server accepts.
+Restricting this is the primary defense against DNS Rebinding attacks.
+
+* Flag: `--allowed-hosts`
+* Local Development: Set to localhost or 127.0.0.1.
+* Production: Set to your specific FQDN (e.g., toolbox.example.com).
+* Example:
+  ```
+  ./toolbox --allowed-hosts="localhost,127.0.0.1"
+  ```
+
+
+{{< notice tip >}}
+**The "Local" Fallacy:** Using `--allowed-hosts="*"` is unsafe even on localhost. A
+malicious website can trick your browser into making requests to `127.0.0.1`,
+effectively bypassing the browser's security to control your local Toolbox.
+{{< /notice >}}
+
+#### Cross-Origin Resource Sharing (CORS)
+The `--allowed-origins` flag dictates which web applications (frontends) are
+permitted to communicate with your Toolbox API.
+
+* Flag: `--allowed-origins`
+* Recommendation: Avoid `*` in any environment containing sensitive data. Explicitly list your trusted frontend URLs.
+* Example: 
+  ```
+  ./toolbox --allowed-origins="https://my-mcp-ui.internal.com"
+  ```
+
+#### Transport Layer Security (TLS/HTTPS)
+By default, traffic is unencrypted (HTTP). In production or shared networks, you must enable TLS to prevent Man-in-the-Middle (MitM) attacks and packet sniffing.
+
+* Flag: `--tls-cert` and `--tls-key` (Both cert and key files are required for
+  TLS activation)
+* Protocol: Toolbox enforces TLS 1.2 as a minimum version to ensure modern encryption standards.
+* Use Case: Use Certbot for public domains or mkcert for locally-trusted development certificates.
+* Example:
+  ```
+  ./toolbox --tls-cert=cert.pem --tls-key=key.pem
+  ```
+
 
 ### Transport Configuration
 

--- a/docs/en/reference/faq.md
+++ b/docs/en/reference/faq.md
@@ -15,6 +15,7 @@ For detailed instructions, check out these resources:
 
 - [Quickstart: How to Run Locally](../documentation/getting-started/local_quickstart.md)
 - [Deploy to Cloud Run](../documentation/deploy-to/cloud-run/_index.md)
+- To run Toolbox more securely or harden security, check out our [hardening guidelines](./cli.md#hardening-toolbox)
 
 [release-notes]: https://github.com/googleapis/mcp-toolbox/releases/
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -40,6 +40,10 @@ type ServerConfig struct {
 	Address string
 	// Port is the port the server will listen on.
 	Port int
+	// CertFile is the path to tls certificate file
+	CertFile string
+	// KeyFile is the path to TLS key file
+	KeyFile string
 	// SourceConfigs defines what sources of data are available for tools.
 	SourceConfigs SourceConfigs
 	// AuthServiceConfigs defines what sources of authentication are available for tools.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -535,7 +536,7 @@ func mcpAuthMiddleware(s *Server) func(http.Handler) http.Handler {
 }
 
 // Listen starts a listener for the given Server instance.
-func (s *Server) Listen(ctx context.Context) error {
+func (s *Server) Listen(ctx context.Context, certFile, keyFile string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -543,11 +544,26 @@ func (s *Server) Listen(ctx context.Context) error {
 		return fmt.Errorf("server is already listening: %s", s.listener.Addr().String())
 	}
 	lc := net.ListenConfig{KeepAlive: 30 * time.Second}
-	var err error
-	if s.listener, err = lc.Listen(ctx, "tcp", s.srv.Addr); err != nil {
+	ln, err := lc.Listen(ctx, "tcp", s.srv.Addr)
+	if err != nil {
 		return fmt.Errorf("failed to open listener for %q: %w", s.srv.Addr, err)
 	}
-	s.logger.DebugContext(ctx, fmt.Sprintf("server listening on %s", s.srv.Addr))
+
+	if certFile != "" || keyFile != "" {
+		// Load the certificates
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			ln.Close()
+			return fmt.Errorf("failed to load TLS key pair (cert: %q, key: %q): %w", certFile, keyFile, err)
+		}
+		// Wrap the listener with TLS
+		config := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+		s.listener = tls.NewListener(ln, config)
+		s.logger.DebugContext(ctx, fmt.Sprintf("secure server listening on %s", s.srv.Addr))
+	} else {
+		s.listener = ln
+		s.logger.DebugContext(ctx, fmt.Sprintf("server listening on %s", s.srv.Addr))
+	}
 	return nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,9 +16,16 @@ package server_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -27,6 +34,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/auth"
@@ -43,17 +51,62 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/util"
 )
 
+// Helper function to create temporary self-signed certs for the test
+func generateTestCerts(t *testing.T) (string, string, func()) {
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{Organization: []string{"Test Co"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	// Create temp files
+	certFile, err := os.CreateTemp("", "cert.*.pem")
+	if err != nil {
+		t.Fatalf("failed to create temp cert file: %v", err)
+	}
+
+	keyFile, err := os.CreateTemp("", "key.*.pem")
+	if err != nil {
+		t.Fatalf("failed to create temp key file: %v", err)
+	}
+
+	// Check the error return values for pem.Encode
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		t.Fatalf("failed to encode certificate: %v", err)
+	}
+
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		t.Fatalf("failed to encode key: %v", err)
+	}
+
+	certFile.Close()
+	keyFile.Close()
+
+	cleanup := func() {
+		os.Remove(certFile.Name())
+		os.Remove(keyFile.Name())
+	}
+
+	return certFile.Name(), keyFile.Name(), cleanup
+}
+
 func TestServe(t *testing.T) {
+	certFile, keyFile, cleanupCerts := generateTestCerts(t)
+	defer cleanupCerts()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	addr, port := "127.0.0.1", 5000
-	cfg := server.ServerConfig{
-		Version:      "0.0.0",
-		Address:      addr,
-		Port:         port,
-		AllowedHosts: []string{"*"},
-	}
 
 	otelShutdown, err := telemetry.SetupOTel(ctx, "0.0.0", "", false, "toolbox")
 	if err != nil {
@@ -72,46 +125,92 @@ func TestServe(t *testing.T) {
 	}
 	ctx = util.WithLogger(ctx, testLogger)
 
-	instrumentation, err := telemetry.CreateTelemetryInstrumentation(cfg.Version)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	tests := []struct {
+		name string
+		cert string
+		key  string
+		addr string
+		port int
+	}{
+		{
+			name: "HTTP mode",
+			addr: "127.0.0.1",
+			port: 5001,
+		},
+		{
+			name: "HTTPS mode",
+			cert: certFile,
+			key:  keyFile,
+			addr: "127.0.0.1",
+			port: 5002,
+		},
 	}
 
-	ctx = util.WithInstrumentation(ctx, instrumentation)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := server.ServerConfig{
+				Version:      "0.0.0",
+				Address:      tt.addr,
+				Port:         tt.port,
+				AllowedHosts: []string{"*"},
+			}
 
-	s, err := server.NewServer(ctx, cfg)
-	if err != nil {
-		t.Fatalf("unable to initialize server: %v", err)
+			instrumentation, err := telemetry.CreateTelemetryInstrumentation(cfg.Version)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			ctx = util.WithInstrumentation(ctx, instrumentation)
+
+			s, err := server.NewServer(ctx, cfg)
+			if err != nil {
+				t.Fatalf("unable to initialize server: %v", err)
+			}
+
+			err = s.Listen(ctx, tt.cert, tt.key)
+			if err != nil {
+				t.Fatalf("unable to start server: %v", err)
+			}
+
+			// start server in background
+			go func() {
+				if err := s.Serve(ctx); err != nil && err != http.ErrServerClosed {
+					t.Errorf("server serve error: %v", err)
+				}
+			}()
+
+			// Setup Client to handle self-signed certs
+			client := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
+			}
+
+			useTLS := tt.cert != "" || tt.key != ""
+			protocol := "http"
+			if useTLS {
+				protocol = "https"
+			}
+
+			url := fmt.Sprintf("%s://%s:%d/", protocol, tt.addr, tt.port)
+			resp, err := client.Get(url)
+			if err != nil {
+				t.Fatalf("error when sending a request: %s", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				t.Fatalf("response status code is not 200")
+			}
+			raw, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("error reading from request body: %s", err)
+			}
+			if got := string(raw); strings.Contains(got, "0.0.0") {
+				t.Fatalf("version missing from output: %q", got)
+			}
+		})
 	}
 
-	err = s.Listen(ctx)
-	if err != nil {
-		t.Fatalf("unable to start server: %v", err)
-	}
-
-	// start server in background
-	go func() {
-		if err := s.Serve(ctx); err != nil && err != http.ErrServerClosed {
-			t.Errorf("server serve error: %v", err)
-		}
-	}()
-
-	url := fmt.Sprintf("http://%s:%d/", addr, port)
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatalf("error when sending a request: %s", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		t.Fatalf("response status code is not 200")
-	}
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("error reading from request body: %s", err)
-	}
-	if got := string(raw); strings.Contains(got, "0.0.0") {
-		t.Fatalf("version missing from output: %q", got)
-	}
 }
 
 func TestUpdateServer(t *testing.T) {
@@ -256,7 +355,7 @@ func TestEndpointSecurityAllowedOrigin(t *testing.T) {
 				t.Fatalf("error setting up server: %s", err)
 			}
 
-			err = s.Listen(ctx)
+			err = s.Listen(ctx, "", "")
 			if err != nil {
 				t.Fatalf("unable to start server: %v", err)
 			}
@@ -404,7 +503,7 @@ func TestEndpointSecurityAllowedHost(t *testing.T) {
 				t.Fatalf("error setting up server: %s", err)
 			}
 
-			err = s.Listen(ctx)
+			err = s.Listen(ctx, "", "")
 			if err != nil {
 				t.Fatalf("unable to start server: %v", err)
 			}
@@ -607,7 +706,7 @@ func TestPRMEndpoint(t *testing.T) {
 	defer mockOIDC.Close()
 
 	// Configure the server
-	addr, port := "127.0.0.1", 5001
+	addr, port := "127.0.0.1", 5003
 	cfg := server.ServerConfig{
 		Version:      "0.0.0",
 		Address:      addr,
@@ -631,7 +730,7 @@ func TestPRMEndpoint(t *testing.T) {
 		t.Fatalf("unable to initialize server: %v", err)
 	}
 
-	if err := s.Listen(ctx); err != nil {
+	if err := s.Listen(ctx, "", ""); err != nil {
 		t.Fatalf("unable to start server: %v", err)
 	}
 
@@ -716,7 +815,7 @@ func TestPRMOverride(t *testing.T) {
 	ctx = util.WithInstrumentation(ctx, instrumentation)
 
 	// Configure the server with the Override Flag
-	addr, port := "127.0.0.1", 5002
+	addr, port := "127.0.0.1", 5004
 	cfg := server.ServerConfig{
 		Version:      "0.0.0",
 		Address:      addr,
@@ -731,7 +830,7 @@ func TestPRMOverride(t *testing.T) {
 		t.Fatalf("unable to initialize server: %v", err)
 	}
 
-	if err := s.Listen(ctx); err != nil {
+	if err := s.Listen(ctx, "", ""); err != nil {
 		t.Fatalf("unable to start listener: %v", err)
 	}
 
@@ -793,7 +892,7 @@ func TestLegacyAPIGone(t *testing.T) {
 	ctx = util.WithInstrumentation(ctx, instrumentation)
 
 	// Configure the server (EnableAPI defaults to false)
-	addr, port := "127.0.0.1", 5003
+	addr, port := "127.0.0.1", 5005
 	cfg := server.ServerConfig{
 		Version:      "0.0.0",
 		Address:      addr,
@@ -807,7 +906,7 @@ func TestLegacyAPIGone(t *testing.T) {
 		t.Fatalf("unable to initialize server: %v", err)
 	}
 
-	if err := s.Listen(ctx); err != nil {
+	if err := s.Listen(ctx, "", ""); err != nil {
 		t.Fatalf("unable to start listener: %v", err)
 	}
 


### PR DESCRIPTION
This PR introduces the ability to run the Toolbox server over HTTPS. While the server still defaults to HTTP for local development, users can now enable TLS encryption via command-line flags. This is essential for secure communication when the Toolbox is exposed over a network or used in production-like environments.

**New Flags:**
* `--tls`: Boolean flag to enable HTTPS.
* `--tls-cert`: String flag specifying the path to the PEM-encoded certificate file.
* `--tls-key`: String flag specifying the path to the PEM-encoded private key file.

**Use Case: How the Server Obtains .pem Files**
In a typical deployment, the server does not generate these files itself; it expects them to be provided by the environment. 

1. Local Development: Users can use tools like mkcert to generate a locally-trusted cert.pem and key.pem.
2. Production (Manual): Users obtain certificates from a Certificate Authority (CA) like Let's Encrypt via Certbot. Certbot handles the domain validation and saves the .pem files to a specific directory (e.g., /etc/letsencrypt/live/).
3. Execution: The user starts the Toolbox and points it to those specific paths:

    ```
    ./toolbox --tls --tls-cert=cert.pem --tls-key=key.pem
    ```

4. Loading: The server uses tls.LoadX509KeyPair to read these files from the disk and injects them into the listener before the HTTP server starts processing requests.

🛠️ Related https://github.com/googleapis/mcp-toolbox/issues/3113
