### PR TITLE
feat(tools/alloydb-search-catalog): Add search_catalog tool to alloydb source

### DIFF
--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -1714,6 +1714,10 @@ func TestPrebuiltTools(t *testing.T) {
 					Name:      "data",
 					ToolNames: []string{"execute_sql", "list_tables", "list_views", "list_schemas", "list_triggers", "list_indexes", "list_sequences", "list_stored_procedure"},
 				},
+				"data_with_discovery": tools.ToolsetConfig{
+					Name:      "data_with_discovery",
+					ToolNames: []string{"execute_sql", "list_tables", "list_views", "list_schemas", "list_triggers", "list_indexes", "list_sequences", "list_stored_procedure", "search_catalog"},
+				},
 				"monitor": tools.ToolsetConfig{
 					Name:      "monitor",
 					ToolNames: []string{"list_active_queries", "list_query_stats", "get_query_plan", "get_query_metrics", "get_system_metrics", "long_running_transactions", "list_locks", "list_database_stats"},

--- a/cmd/internal/imports.go
+++ b/cmd/internal/imports.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/alloydb/alloydblistclusters"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/alloydb/alloydblistinstances"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/alloydb/alloydblistusers"
+	_ "github.com/googleapis/mcp-toolbox/internal/tools/alloydb/alloydbsearchcatalog"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/alloydb/alloydbwaitforoperation"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/alloydbainl"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigqueryanalyzecontribution"

--- a/docs/ALLOYDBPG_README.md
+++ b/docs/ALLOYDBPG_README.md
@@ -67,6 +67,7 @@ The AlloyDB MCP server provides the following tools:
 | `list_top_bloated_tables`        | List top bloated tables.                                   |
 | `list_replication_slots`         | List replication slots.                                    |
 | `list_invalid_indexes`           | List invalid indexes.                                      |
+| `search_catalog`                  | Searches for data assets in Knowledge Catalog (previously known as Dataplex). |
 
 ## Custom MCP Server Configuration
 

--- a/docs/en/integrations/alloydb/prebuilt-configs/alloydb-postgres.md
+++ b/docs/en/integrations/alloydb/prebuilt-configs/alloydb-postgres.md
@@ -57,3 +57,4 @@ description: "Details of the AlloyDB Postgres prebuilt configuration."
         each database in the AlloyDB instance.
     *   `list_roles`: Lists all the user-created roles in PostgreSQL database.
     *   `list_stored_procedure`: Lists stored procedures.
+    *   `search_catalog`: Searches for data assets in Knowledge Catalog (Dataplex).

--- a/docs/en/integrations/alloydb/source.md
+++ b/docs/en/integrations/alloydb/source.md
@@ -114,6 +114,7 @@ database: my_db
 user: ${USER_NAME}
 password: ${PASSWORD}
 # ipType: "public"
+# useClientOAuth: false
 ```
 
 {{< notice tip >}}
@@ -142,4 +143,5 @@ The interface is identical, so there's no additional configuration required on t
 | database  |  string  |     true     | Name of the Postgres database to connect to (e.g. "my_db").                                                              |
 | user      |  string  |    false     | Name of the Postgres user to connect as (e.g. "my-pg-user"). Defaults to IAM auth using [ADC][adc] email if unspecified. |
 | password  |  string  |    false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
-| ipType    |  string  |    false     | IP Type of the AlloyDB instance; must be one of `public` or `private`. Default: `public`.                                |
+| ipType         |  string  |    false     | IP Type of the AlloyDB instance; must be one of `public` or `private`. Default: `public`.                                |
+| useClientOAuth | boolean  |    false     | If true, the source will use client-side OAuth for authorizing Catalog/Dataplex search requests. Defaults to `false`.   |

--- a/docs/en/integrations/alloydb/tools/alloydb-search-catalog.md
+++ b/docs/en/integrations/alloydb/tools/alloydb-search-catalog.md
@@ -1,23 +1,23 @@
 ---
-title: "spanner-search-catalog"
+title: "alloydb-search-catalog"
 type: docs
 weight: 1
 description: >
-  A "spanner-search-catalog" tool allows to search for entries based on the provided query.
+  A "alloydb-search-catalog" tool allows to search for entries based on the provided query.
 ---
 
 ## About
 
-A `spanner-search-catalog` tool returns all entries in Knowledge Catalog (e.g.
-tables, views, databases) with system=Spanner that matches given user query.
+A `alloydb-search-catalog` tool returns all entries in Knowledge Catalog (e.g.
+tables, views, columns, databases, clusters, instances) with system=AlloyDB that matches given user query.
 
-`spanner-search-catalog` takes a required `prompt` parameter based on which
+`alloydb-search-catalog` takes a required `prompt` parameter based on which
 entries are filtered and returned to the user. It also optionally accepts
 following parameters:
 
-- `databaseIds` - The IDs of the spanner database.
+- `databaseIds` - The IDs of the postgres database.
 - `projectIds` - The IDs of the GCP project.
-- `types` - The type of the data. Accepted values are: DATABASE, TABLE, VIEW.
+- `types` - The type of the data. Accepted values are: DATABASE, COLUMN, TABLE, VIEW, CLUSTER, INSTANCE.
 - `pageSize` - Number of results in the search page. Defaults to `5`.
 
 ## Compatible Sources
@@ -51,15 +51,15 @@ applying IAM permissions and roles to an identity.
 ```yaml
 kind: tool
 name: search_catalog
-type: spanner-search-catalog
-source: spanner-source
-description: Searches for data assets (eg. Spanner tables, views, or databases) in Knowledge Catalog (formerly known as Dataplex) based on the provided search query
+type: alloydb-search-catalog
+source: alloydb-pg-source
+description: Searches for data assets (eg. AlloyDB tables, views, columns, databases, clusters or instances) in Catalog based on the provided search query
 ```
 
 ## Reference
 
 | **field**   |                  **type**                  | **required** | **description**                                                                                  |
 |-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
-| type        |                   string                   |     true     | Must be "spanner-search-catalog".                                                               |
+| type        |                   string                   |     true     | Must be "alloydb-search-catalog".                                                               |
 | source      |                   string                   |     true     | Name of the source the tool should execute on.                                                   |
 | description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |

--- a/docs/en/integrations/bigquery/tools/bigquery-search-catalog.md
+++ b/docs/en/integrations/bigquery/tools/bigquery-search-catalog.md
@@ -29,8 +29,8 @@ following parameters:
 
 ### IAM Permissions
 
-Bigquery uses [Identity and Access Management (IAM)][iam-overview] to control
-user and group access to Knowledge Catalog (formerly known as Dataplex) resources. Toolbox will use your
+Knowledge Catalog (formerly known as Dataplex) uses [Identity and Access Management (IAM)][iam-overview] to control
+user and group access to its resources. Toolbox will use your
 [Application Default Credentials (ADC)][adc] to authorize and authenticate when
 interacting with [Knowledge Catalog][dataplex-docs].
 
@@ -45,6 +45,8 @@ applying IAM permissions and roles to an identity.
 [set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
 [iam-permissions]: https://cloud.google.com/dataplex/docs/iam-permissions
 [iam-roles]: https://cloud.google.com/dataplex/docs/iam-roles
+[dataplex-docs]: https://cloud.google.com/dataplex/docs
+
 
 ## Example
 

--- a/docs/en/integrations/spanner/source.md
+++ b/docs/en/integrations/spanner/source.md
@@ -64,6 +64,7 @@ project: "my-project-id"
 instance: "my-instance"
 database: "my_db"
 # dialect: "googlesql"
+# useClientOAuth: false
 ```
 
 ## Reference
@@ -74,4 +75,5 @@ database: "my_db"
 | project   |  string  |     true     | Id of the GCP project that the cluster was created in (e.g. "my-project-id").                                       |
 | instance  |  string  |     true     | Name of the Spanner instance.                                                                                       |
 | database  |  string  |     true     | Name of the database on the Spanner instance                                                                        |
-| dialect   |  string  |    false     | Name of the dialect type of the Spanner database, must be either `googlesql` or `postgresql`. Default: `googlesql`. |
+| dialect        |  string  |    false     | Name of the dialect type of the Spanner database, must be either `googlesql` or `postgresql`. Default: `googlesql`. |
+| useClientOAuth | boolean  |    false     | If true, the source will use client-side OAuth for authorizing Catalog/Dataplex search requests. Defaults to `false`.   |

--- a/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
@@ -421,6 +421,12 @@ name: list_instances
 type: alloydb-list-instances
 source: alloydb-admin-source
 ---
+kind: tool
+name: search_catalog
+type: alloydb-search-catalog
+source: alloydb-pg-source
+description: Searches for data assets (eg. AlloyDB tables, views, schemas or databases) in Catalog based on the provided search query.
+---
 kind: toolset
 name: admin
 tools:
@@ -454,6 +460,19 @@ tools:
 - list_indexes
 - list_sequences
 - list_stored_procedure
+---
+kind: toolset
+name: data_with_discovery
+tools:
+- execute_sql
+- list_tables
+- list_views
+- list_schemas
+- list_triggers
+- list_indexes
+- list_sequences
+- list_stored_procedure
+- search_catalog
 ---
 kind: toolset
 name: monitor

--- a/internal/server/resources/resources_test.go
+++ b/internal/server/resources/resources_test.go
@@ -23,17 +23,15 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
-	"github.com/googleapis/mcp-toolbox/internal/sources/alloydbpg"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 )
 
 func TestUpdateServer(t *testing.T) {
 	newSources := map[string]sources.Source{
-		"example-source": &alloydbpg.Source{
-			Config: alloydbpg.Config{
-				Name: "example-alloydb-source",
-				Type: "alloydb-postgres",
-			},
+		"example-source": testutils.MockSource{
+			Name: "example-source",
+			Type: "mock-type",
 		},
 	}
 	newAuth := map[string]auth.AuthService{"example-auth": nil}
@@ -89,11 +87,9 @@ func TestUpdateServer(t *testing.T) {
 	}
 
 	updateSource := map[string]sources.Source{
-		"example-source2": &alloydbpg.Source{
-			Config: alloydbpg.Config{
-				Name: "example-alloydb-source2",
-				Type: "alloydb-postgres",
-			},
+		"example-source2": testutils.MockSource{
+			Name: "example-source2",
+			Type: "mock-type",
 		},
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
-	"github.com/googleapis/mcp-toolbox/internal/sources/alloydbpg"
 	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -240,11 +239,9 @@ func TestUpdateServer(t *testing.T) {
 	}
 
 	newSources := map[string]sources.Source{
-		"example-source": &alloydbpg.Source{
-			Config: alloydbpg.Config{
-				Name: "example-alloydb-source",
-				Type: "alloydb-postgres",
-			},
+		"example-source": testutils.MockSource{
+			Name: "example-source",
+			Type: "mock-type",
 		},
 	}
 	newAuth := map[string]auth.AuthService{"example-auth": nil}

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -21,8 +21,10 @@ import (
 	"strings"
 
 	"cloud.google.com/go/alloydbconn"
+	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/sources/sqlcommenter"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/orderedmap"
@@ -50,16 +52,17 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string         `yaml:"name" validate:"required"`
-	Type     string         `yaml:"type" validate:"required"`
-	Project  string         `yaml:"project" validate:"required"`
-	Region   string         `yaml:"region" validate:"required"`
-	Cluster  string         `yaml:"cluster" validate:"required"`
-	Instance string         `yaml:"instance" validate:"required"`
-	IPType   sources.IPType `yaml:"ipType" validate:"required"`
-	User     string         `yaml:"user"`
-	Password string         `yaml:"password"`
-	Database string         `yaml:"database" validate:"required"`
+	Name           string         `yaml:"name" validate:"required"`
+	Type           string         `yaml:"type" validate:"required"`
+	Project        string         `yaml:"project" validate:"required"`
+	Region         string         `yaml:"region" validate:"required"`
+	Cluster        string         `yaml:"cluster" validate:"required"`
+	Instance       string         `yaml:"instance" validate:"required"`
+	IPType         sources.IPType `yaml:"ipType" validate:"required"`
+	User           string         `yaml:"user"`
+	Password       string         `yaml:"password"`
+	Database       string         `yaml:"database" validate:"required"`
+	UseClientOAuth bool           `yaml:"useClientOAuth"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -77,9 +80,19 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 
+	onDataplexEvict := func(key string, value interface{}) {
+		if client, ok := value.(*dataplexapi.CatalogClient); ok && client != nil {
+			client.Close()
+		}
+	}
+
 	s := &Source{
 		Config: r,
 		Pool:   pool,
+		dataplexMgr: &searchcatalog.DataplexClientManager{
+			UseClientOAuth: r.UseClientOAuth,
+			Cache:          sources.NewCache(onDataplexEvict),
+		},
 	}
 	return s, nil
 }
@@ -88,7 +101,8 @@ var _ sources.Source = &Source{}
 
 type Source struct {
 	Config
-	Pool *pgxpool.Pool
+	Pool        *pgxpool.Pool
+	dataplexMgr *searchcatalog.DataplexClientManager
 }
 
 func (s *Source) SourceType() string {
@@ -101,6 +115,18 @@ func (s *Source) ToConfig() sources.SourceConfig {
 
 func (s *Source) PostgresPool() *pgxpool.Pool {
 	return s.Pool
+}
+
+func (s *Source) ProjectID() string {
+	return s.Project
+}
+
+func (s *Source) UseClientAuthorization() bool {
+	return s.UseClientOAuth
+}
+
+func (s *Source) GetCatalogClient(ctx context.Context, tokenString string) (*dataplexapi.CatalogClient, error) {
+	return s.dataplexMgr.GetCatalogClient(ctx, tokenString)
 }
 
 func (s *Source) RunSQL(ctx context.Context, statement string, params []any) (any, error) {
@@ -223,4 +249,27 @@ func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name,
 		return nil, err
 	}
 	return pool, nil
+}
+
+func (s *Source) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	typeMap := map[string]string{
+		"alloydb-cluster":  "CLUSTER",
+		"alloydb-database": "DATABASE",
+		"alloydb-instance": "INSTANCE",
+		"alloydb-table":    "TABLE",
+		"alloydb-view":     "VIEW",
+		"alloydb-schema":   "DATABASE_SCHEMA",
+	}
+	return searchcatalog.InvokeSearchCatalog(
+		ctx,
+		params,
+		tokenStr,
+		"AlloyDB",
+		"databaseIds",
+		typeMap,
+		s.ProjectID(),
+		func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error) {
+			return s.GetCatalogClient(ctx, token)
+		},
+	)
 }

--- a/internal/sources/alloydbpg/alloydb_pg_test.go
+++ b/internal/sources/alloydbpg/alloydb_pg_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/alloydbpg"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
 
@@ -200,6 +201,71 @@ func TestFailParseFromYaml(t *testing.T) {
 			errStr := err.Error()
 			if errStr != tc.err {
 				t.Fatalf("unexpected error: got %q, want %q", errStr, tc.err)
+			}
+		})
+	}
+}
+
+func TestExtractType(t *testing.T) {
+	typeMap := map[string]string{
+		"alloydb-cluster":  "CLUSTER",
+		"alloydb-database": "DATABASE",
+		"alloydb-instance": "INSTANCE",
+		"alloydb-table":    "TABLE",
+		"alloydb-view":     "VIEW",
+		"alloydb-schema":   "DATABASE_SCHEMA",
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want string
+	}{
+		{
+			desc: "mapped type cluster",
+			in:   "projects/my-project/locations/global/entryTypes/alloydb-cluster",
+			want: "CLUSTER",
+		},
+		{
+			desc: "mapped type database",
+			in:   "projects/my-project/locations/global/entryTypes/alloydb-database",
+			want: "DATABASE",
+		},
+		{
+			desc: "mapped type instance",
+			in:   "projects/my-project/locations/global/entryTypes/alloydb-instance",
+			want: "INSTANCE",
+		},
+		{
+			desc: "mapped type table",
+			in:   "projects/my-project/locations/global/entryTypes/alloydb-table",
+			want: "TABLE",
+		},
+		{
+			desc: "mapped type view",
+			in:   "projects/my-project/locations/global/entryTypes/alloydb-view",
+			want: "VIEW",
+		},
+		{
+			desc: "mapped type schema",
+			in:   "projects/my-project/locations/global/entryTypes/alloydb-schema",
+			want: "DATABASE_SCHEMA",
+		},
+		{
+			desc: "no slash returns input",
+			in:   "alloydb-table",
+			want: "alloydb-table",
+		},
+		{
+			desc: "unknown type with slash returns empty",
+			in:   "projects/my-project/locations/global/entryTypes/unknown-type",
+			want: "",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := searchcatalog.ExtractType(tc.in, typeMap)
+			if got != tc.want {
+				t.Errorf("ExtractType(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/internal/sources/dataplex/searchcatalog/search_catalog.go
+++ b/internal/sources/dataplex/searchcatalog/search_catalog.go
@@ -70,7 +70,7 @@ func ConstructSearchQuery(prompt string, projectIds []string, parentIds []string
 		queryParts = append(queryParts, clause)
 	}
 
-	if clause := ConstructSearchQueryHelper("parent", "=", parentIds); clause != "" {
+	if clause := ConstructSearchQueryHelper("parent", ":", parentIds); clause != "" {
 		queryParts = append(queryParts, clause)
 	}
 

--- a/internal/sources/dataplex/searchcatalog/search_catalog_test.go
+++ b/internal/sources/dataplex/searchcatalog/search_catalog_test.go
@@ -98,7 +98,7 @@ func TestConstructSearchQuery(t *testing.T) {
 			parentIds:  []string{"d1"},
 			types:      []string{"t1"},
 			system:     "sys1",
-			want:       "search projectid=p1 AND parent=d1 AND type=t1 AND system=sys1",
+			want:       "search projectid=p1 AND parent:d1 AND type=t1 AND system=sys1",
 		},
 		{
 			name:       "with multiple items",
@@ -107,7 +107,7 @@ func TestConstructSearchQuery(t *testing.T) {
 			parentIds:  []string{"d1"},
 			types:      []string{},
 			system:     "",
-			want:       "search (projectid=p1 OR projectid=p2) AND parent=d1",
+			want:       "search (projectid=p1 OR projectid=p2) AND parent:d1",
 		},
 	}
 

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // MockTool is used to mock tools in tests
@@ -179,4 +181,32 @@ func NewMockPrompt(name, desc string, args prompts.Arguments) MockPrompt {
 		Args:        args,
 		manifest:    manifest,
 	}
+}
+
+// MockSource is used to mock sources in tests
+type MockSource struct {
+	Name string
+	Type string
+}
+
+func (m MockSource) SourceType() string {
+	return m.Type
+}
+
+func (m MockSource) ToConfig() sources.SourceConfig {
+	return MockSourceConfig(m)
+}
+
+// MockSourceConfig is used to mock source configs in tests
+type MockSourceConfig struct {
+	Name string
+	Type string
+}
+
+func (mc MockSourceConfig) SourceConfigType() string {
+	return mc.Type
+}
+
+func (mc MockSourceConfig) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
+	return MockSource(mc), nil
 }

--- a/internal/tools/alloydb/alloydbsearchcatalog/alloydbsearchcatalog.go
+++ b/internal/tools/alloydb/alloydbsearchcatalog/alloydbsearchcatalog.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bigquerysearchcatalog
+package alloydbsearchcatalog
 
 import (
 	"context"
 	"fmt"
 	"net/http"
 
-	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
-	bigqueryds "github.com/googleapis/mcp-toolbox/internal/sources/bigquery"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
-const resourceType string = "bigquery-search-catalog"
+const resourceType string = "alloydb-search-catalog"
 
 func init() {
 	if !tools.Register(resourceType, newConfig) {
@@ -46,10 +44,8 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
-	MakeDataplexCatalogClient() func() (*dataplexapi.CatalogClient, bigqueryds.DataplexClientCreator, error)
-	BigQueryProject() string
+	ProjectID() string
 	UseClientAuthorization() bool
-	GetAuthTokenHeaderName() string
 	InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error)
 }
 
@@ -69,21 +65,25 @@ func (cfg Config) ToolConfigType() string {
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
 	prompt := parameters.NewStringParameter("prompt", "Prompt representing search intention. Do not rewrite the prompt.")
-	datasetIds := parameters.NewArrayParameterWithDefault("datasetIds", []any{}, "Array of dataset IDs.", parameters.NewStringParameter("datasetId", "The IDs of the bigquery dataset."))
-	projectIds := parameters.NewArrayParameterWithDefault("projectIds", []any{}, "Array of project IDs.", parameters.NewStringParameter("projectId", "The IDs of the bigquery project."))
-	types := parameters.NewArrayParameterWithDefault("types", []any{}, "Array of data types to filter by.", parameters.NewStringParameter("type", "The type of the data. Accepted values are: CONNECTION, POLICY, DATASET, MODEL, ROUTINE, TABLE, VIEW."))
+	databaseIds := parameters.NewArrayParameterWithDefault("databaseIds", []any{}, "Array of database IDs.", parameters.NewStringParameter("databaseId", "The IDs of the alloydb database."))
+	projectIds := parameters.NewArrayParameterWithDefault("projectIds", []any{}, "Array of project IDs.", parameters.NewStringParameter("projectId", "The IDs of the GCP project."))
+	types := parameters.NewArrayParameterWithDefault("types", []any{}, "Array of data types to filter by.", parameters.NewStringParameter("type", "The type of the data. Accepted values are: DATABASE, TABLE, VIEW, CLUSTER, INSTANCE, DATABASE_SCHEMA."))
 	pageSize := parameters.NewIntParameterWithDefault("pageSize", 5, "Number of results in the search page.")
-	params := parameters.Parameters{prompt, datasetIds, projectIds, types, pageSize}
+	params := parameters.Parameters{prompt, databaseIds, projectIds, types, pageSize}
 
 	if cfg.Description == "" {
-		cfg.Description = "Use this tool to find tables, views, models, routines or connections."
+		cfg.Description = "Searches for data assets (eg. AlloyDB tables, views, schemas, databases, clusters or instances) in Catalog based on the provided search query."
 	}
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
 			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewReadOnlyAnnotations),
-			tools.Manifest{Description: cfg.Description, Parameters: params.Manifest(), AuthRequired: cfg.AuthRequired},
+			tools.Manifest{
+				Description:  cfg.Description,
+				Parameters:   params.Manifest(),
+				AuthRequired: cfg.AuthRequired,
+			},
 			params,
 		),
 	}, nil
@@ -108,6 +108,10 @@ func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (boo
 	return source.UseClientAuthorization(), nil
 }
 
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	return "", nil
+}
+
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {
@@ -118,7 +122,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
-			return nil, util.NewClientServerError("error parsing access token", http.StatusUnauthorized, err)
+			return nil, util.NewClientServerError("failed to parse access token", http.StatusInternalServerError, err)
 		}
 	}
 
@@ -128,12 +132,4 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	return results, nil
-}
-
-func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
-	}
-	return source.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/alloydb/alloydbsearchcatalog/alloydbsearchcatalog_test.go
+++ b/internal/tools/alloydb/alloydbsearchcatalog/alloydbsearchcatalog_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alloydbsearchcatalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/tools/alloydb/alloydbsearchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+func TestParseFromYamlAlloyDBSearch(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+            kind: tool
+            name: example_tool
+            type: alloydb-search-catalog
+            source: my-instance
+            description: some description
+            `,
+			want: server.ToolConfigs{
+				"example_tool": alloydbsearchcatalog.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "example_tool",
+						Description:  "some description",
+						AuthRequired: []string{},
+					},
+					Type:   "alloydb-search-catalog",
+					Source: "my-instance",
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Parse contents
+			_, _, _, got, _, _, err := server.UnmarshalResourceConfig(ctx, testutils.FormatYaml(tc.in))
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+}
+
+type mockAlloyDBSource struct {
+	projectID              string
+	useClientAuthorization bool
+	searchResponse         []searchcatalog.DataplexSearchResponse
+	err                    error
+}
+
+func (m mockAlloyDBSource) ProjectID() string            { return m.projectID }
+func (m mockAlloyDBSource) UseClientAuthorization() bool { return m.useClientAuthorization }
+func (m mockAlloyDBSource) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	return m.searchResponse, m.err
+}
+func (m mockAlloyDBSource) SourceType() string             { return "alloydb-postgres" }
+func (m mockAlloyDBSource) ToConfig() sources.SourceConfig { return nil }
+
+type mockSourceProvider struct {
+	source sources.Source
+}
+
+func (m mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	if m.source != nil {
+		return m.source, true
+	}
+	return nil, false
+}
+
+func TestConfig_Initialize(t *testing.T) {
+	cfg := alloydbsearchcatalog.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "test-tool",
+			Description: "Test description",
+		},
+		Type:   "alloydb-search-catalog",
+		Source: "test-source",
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	if tool.GetName() != "test-tool" {
+		t.Errorf("GetName() = %v, want %v", tool.GetName(), "test-tool")
+	}
+
+	if tool.GetDescription() != "Test description" {
+		t.Errorf("GetDescription() = %v, want %v", tool.GetDescription(), "Test description")
+	}
+}
+
+func TestTool_Invoke(t *testing.T) {
+	ctx := context.Background()
+	mockSource := mockAlloyDBSource{
+		searchResponse: []searchcatalog.DataplexSearchResponse{
+			{
+				DataplexEntry: "test-entry",
+			},
+		},
+	}
+	sourceProvider := mockSourceProvider{source: mockSource}
+
+	cfg := alloydbsearchcatalog.Config{
+		ConfigBase: tools.ConfigBase{
+			Name: "test-tool",
+		},
+		Type:   "alloydb-search-catalog",
+		Source: "test-source",
+	}
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	params := parameters.ParamValues{
+		{
+			Name:  "prompt",
+			Value: "test prompt",
+		},
+	}
+
+	resp, err := tool.Invoke(ctx, sourceProvider, params, tools.AccessToken(""))
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+
+	results, ok := resp.([]searchcatalog.DataplexSearchResponse)
+	if !ok {
+		t.Fatalf("expected []searchcatalog.DataplexSearchResponse, got %T", resp)
+	}
+
+	if len(results) != 1 || results[0].DataplexEntry != "test-entry" {
+		t.Errorf("unexpected results: %v", results)
+	}
+}

--- a/tests/alloydb/alloydb_mcp_test.go
+++ b/tests/alloydb/alloydb_mcp_test.go
@@ -93,6 +93,7 @@ func getAlloyDBToolsConfig() map[string]any {
 				"source":      "alloydb-admin-source",
 				"description": "Tool that will fail",
 			},
+
 			// AlloyDB specific tools
 			"alloydb-list-clusters": map[string]any{
 				"type":        "alloydb-list-clusters",

--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -168,6 +168,8 @@ func TestAlloyDBPgToolEndpoints(t *testing.T) {
 
 	toolsFile = tests.AddPostgresPrebuiltConfig(t, toolsFile)
 
+	toolsFile = tests.AddSearchCatalogConfig(t, toolsFile, "alloydb-search-catalog")
+
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
@@ -215,6 +217,17 @@ func TestAlloyDBPgToolEndpoints(t *testing.T) {
 	tests.RunPostgresListDatabaseStatsTest(t, ctx, pool)
 	tests.RunPostgresListRolesTest(t, ctx, pool)
 	tests.RunPostgresListStoredProcedureTest(t, ctx, pool)
+
+	// Run search catalog test
+	tests.RunSearchCatalogToolTest(t, tests.SearchCatalogTestParams{
+		ContainerParamName: "databaseIds",
+		ContainerName:      AlloyDBPostgresCluster,
+		ProjectID:          AlloyDBPostgresProject,
+		TargetName:         "test-table",
+		WantKey:            "DisplayName",
+		AllowEmpty:         true,
+		CheckValue:         false,
+	})
 }
 
 func TestAlloyDBPgPrebuiltStatementTools(t *testing.T) {

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -881,25 +881,8 @@ func addBigQueryPrebuiltToolsConfig(t *testing.T, config map[string]any) map[str
 		"source":      "my-client-auth-source",
 		"description": "Tool to ask BigQuery conversational analytics",
 	}
-	tools["my-search-catalog-tool"] = map[string]any{
-		"type":        "bigquery-search-catalog",
-		"source":      "my-instance",
-		"description": "Tool to search the BiqQuery catalog",
-	}
-	tools["my-auth-search-catalog-tool"] = map[string]any{
-		"type":        "bigquery-search-catalog",
-		"source":      "my-instance",
-		"description": "Tool to search the BiqQuery catalog",
-		"authRequired": []string{
-			"my-google-auth",
-		},
-	}
-	tools["my-client-auth-search-catalog-tool"] = map[string]any{
-		"type":        "bigquery-search-catalog",
-		"source":      "my-client-auth-source",
-		"description": "Tool to search the BiqQuery catalog",
-	}
 	config["tools"] = tools
+	config = tests.AddSearchCatalogConfig(t, config, "bigquery-search-catalog")
 	return config
 }
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -192,6 +192,54 @@ func AddExecuteSqlConfig(t *testing.T, config map[string]any, toolType string) m
 	return config
 }
 
+// AddSearchCatalogConfig adds the search-catalog tool configuration for a given toolType and source
+func AddSearchCatalogConfig(t *testing.T, config map[string]any, toolType string) map[string]any {
+	tools, ok := config["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get tools from config")
+	}
+	sources, ok := config["sources"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get sources from config")
+	}
+	myInstanceConfig, ok := sources["my-instance"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get my-instance from sources")
+	}
+
+	// Create a copy of the source config with client OAuth enabled
+	oauthSourceConfig := make(map[string]any)
+	for k, v := range myInstanceConfig {
+		oauthSourceConfig[k] = v
+	}
+	oauthSourceConfig["useClientOAuth"] = true
+	sources["my-oauth-source"] = oauthSourceConfig
+
+	// Add tools
+	tools["my-search-catalog-tool"] = map[string]any{
+		"type":        toolType,
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+	}
+	tools["my-auth-search-catalog-tool"] = map[string]any{
+		"type":        toolType,
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+		"authRequired": []string{
+			"my-google-auth",
+		},
+	}
+	tools["my-client-auth-search-catalog-tool"] = map[string]any{
+		"type":        toolType,
+		"source":      "my-oauth-source",
+		"description": "Searches for data assets in catalog",
+	}
+
+	config["tools"] = tools
+	config["sources"] = sources
+	return config
+}
+
 func AddPostgresPrebuiltConfig(t *testing.T, config map[string]any) map[string]any {
 	var (
 		PostgresListSchemasToolType             = "postgres-list-schemas"

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -162,7 +162,7 @@ func TestSpannerToolEndpoints(t *testing.T) {
 	toolsFile = addTemplateParamConfig(t, toolsFile)
 	toolsFile = addSpannerListTablesConfig(t, toolsFile)
 	toolsFile = addSpannerListGraphsConfig(t, toolsFile)
-	toolsFile = addSpannerSearchCatalogConfig(t, toolsFile)
+	toolsFile = tests.AddSearchCatalogConfig(t, toolsFile, "spanner-search-catalog")
 
 	// Set up table for semantic search
 	vectorTableName, tearDownVectorTable := setupSpannerVectorTable(t, ctx, adminClient, dbString)
@@ -402,54 +402,6 @@ func addSpannerListTablesConfig(t *testing.T, config map[string]any) map[string]
 	}
 
 	config["tools"] = tools
-	return config
-}
-
-// addSpannerSearchCatalogConfig adds the spanner-search-catalog tool configuration
-func addSpannerSearchCatalogConfig(t *testing.T, config map[string]any) map[string]any {
-	tools, ok := config["tools"].(map[string]any)
-	if !ok {
-		t.Fatalf("unable to get tools from config")
-	}
-	sources, ok := config["sources"].(map[string]any)
-	if !ok {
-		t.Fatalf("unable to get sources from config")
-	}
-	myInstanceConfig, ok := sources["my-instance"].(map[string]any)
-	if !ok {
-		t.Fatalf("unable to get my-instance from sources")
-	}
-
-	// Create a copy of the source config with client OAuth enabled
-	oauthSourceConfig := make(map[string]any)
-	for k, v := range myInstanceConfig {
-		oauthSourceConfig[k] = v
-	}
-	oauthSourceConfig["useClientOAuth"] = true
-	sources["my-oauth-instance"] = oauthSourceConfig
-
-	// Add tools
-	tools["my-search-catalog-tool"] = map[string]any{
-		"type":        "spanner-search-catalog",
-		"source":      "my-instance",
-		"description": "Searches for data assets in catalog",
-	}
-	tools["my-auth-search-catalog-tool"] = map[string]any{
-		"type":        "spanner-search-catalog",
-		"source":      "my-instance",
-		"description": "Searches for data assets in catalog",
-		"authRequired": []string{
-			"my-google-auth",
-		},
-	}
-	tools["my-client-auth-search-catalog-tool"] = map[string]any{
-		"type":        "spanner-search-catalog",
-		"source":      "my-oauth-instance",
-		"description": "Searches for data assets in catalog",
-	}
-
-	config["tools"] = tools
-	config["sources"] = sources
 	return config
 }
 


### PR DESCRIPTION
Implements alloydbsearchcatalog tool to search data assets using Dataplex.

- Adds unit tests for the new tool.
- Updates alloydb-postgres.yaml prebuilt configuration.
- Registers the new tool in cmd/internal/imports.go.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
