### PR TITLE
feat(spanner): implement search_catalog tool and add docs/tests

### DIFF
--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -1958,6 +1958,10 @@ func TestPrebuiltTools(t *testing.T) {
 					Name:      "data",
 					ToolNames: []string{"execute_sql", "execute_sql_dql", "list_tables", "list_graphs"},
 				},
+				"data_with_discovery": tools.ToolsetConfig{
+					Name:      "data_with_discovery",
+					ToolNames: []string{"execute_sql", "execute_sql_dql", "list_tables", "list_graphs", "search_catalog"},
+				},
 			},
 		},
 		{
@@ -1967,6 +1971,10 @@ func TestPrebuiltTools(t *testing.T) {
 				"data": tools.ToolsetConfig{
 					Name:      "data",
 					ToolNames: []string{"execute_sql", "execute_sql_dql", "list_tables"},
+				},
+				"data_with_discovery": tools.ToolsetConfig{
+					Name:      "data_with_discovery",
+					ToolNames: []string{"execute_sql", "execute_sql_dql", "list_tables", "search_catalog"},
 				},
 			},
 		},

--- a/cmd/internal/imports.go
+++ b/cmd/internal/imports.go
@@ -257,6 +257,7 @@ import (
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/spanner/spannerexecutesql"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/spanner/spannerlistgraphs"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/spanner/spannerlisttables"
+	_ "github.com/googleapis/mcp-toolbox/internal/tools/spanner/spannersearchcatalog"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/spanner/spannersql"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/sqlite/sqliteexecutesql"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/sqlite/sqlitesql"

--- a/docs/SPANNER_README.md
+++ b/docs/SPANNER_README.md
@@ -8,6 +8,7 @@ An editor configured to use the Cloud Spanner MCP server can use its AI capabili
 
 - **Query Data** - Execute DML and DQL SQL queries
 - **Explore Schema** - List tables and view schema details
+- **Search Catalog** - Search for data assets in Knowledge Catalog (Dataplex)
 
 ## Prerequisites
 
@@ -43,6 +44,7 @@ Once configured, the MCP server will automatically provide Cloud Spanner capabil
 *   "Execute a DML query to update customer names."
 *   "List all tables in the `my-database`."
 *   "Execute a DQL query to select data from `orders` table."
+*   "Search for tables related to customers in the catalog."
 
 ## Server Capabilities
 
@@ -54,6 +56,7 @@ The Cloud Spanner MCP server provides the following tools:
 | `execute_sql_dql` | Use this tool to execute DQL SQL.                                |
 | `list_tables`     | Lists detailed schema information for user-created tables.       |
 | `list_graphs`     | Lists detailed graph schema information for user-created graphs. |
+| `search_catalog`   | Searches for data assets in Knowledge Catalog (Dataplex).        |
 
 ## Custom MCP Server Configuration
 

--- a/docs/en/integrations/spanner/prebuilt-configs/spanner-googlesql-dialect.md
+++ b/docs/en/integrations/spanner/prebuilt-configs/spanner-googlesql-dialect.md
@@ -21,3 +21,4 @@ description: "Details of the Spanner (GoogleSQL dialect) prebuilt configuration.
     *   `execute_sql_dql`: Executes a DQL SQL query.
     *   `list_tables`: Lists tables in the database.
     *   `list_graphs`: Lists graphs in the database.
+    *   `search_catalog`: Searches for data assets in Knowledge Catalog (Dataplex).

--- a/docs/en/integrations/spanner/prebuilt-configs/spanner-postgresql-dialect.md
+++ b/docs/en/integrations/spanner/prebuilt-configs/spanner-postgresql-dialect.md
@@ -22,3 +22,4 @@ description: "Details of the Spanner (PostgreSQL dialect) prebuilt configuration
     *   `execute_sql_dql`: Executes a DQL SQL query using the PostgreSQL
         interface for Spanner.
     *   `list_tables`: Lists tables in the database.
+    *   `search_catalog`: Searches for data assets in Knowledge Catalog (Dataplex).

--- a/docs/en/integrations/spanner/tools/spanner-search-catalog.md
+++ b/docs/en/integrations/spanner/tools/spanner-search-catalog.md
@@ -1,0 +1,65 @@
+---
+title: "spanner-search-catalog"
+type: docs
+weight: 1
+description: >
+  A "spanner-search-catalog" tool allows to search for entries based on the provided query.
+---
+
+## About
+
+A `spanner-search-catalog` tool returns all entries in Knowledge Catalog (e.g.
+tables, views, databases) with system=Spanner that matches given user query.
+
+`spanner-search-catalog` takes a required `prompt` parameter based on which
+entries are filtered and returned to the user. It also optionally accepts
+following parameters:
+
+- `databaseIds` - The IDs of the spanner database.
+- `projectIds` - The IDs of the GCP project.
+- `types` - The type of the data. Accepted values are: DATABASE, TABLE, VIEW.
+- `pageSize` - Number of results in the search page. Defaults to `5`.
+
+## Compatible Sources
+
+{{< compatible-sources >}}
+
+## Requirements
+
+### IAM Permissions
+
+Spanner uses [Identity and Access Management (IAM)][iam-overview] to control
+user and group access to Knowledge Catalog (formerly known as Dataplex) resources. Toolbox will use your
+[Application Default Credentials (ADC)][adc] to authorize and authenticate when
+interacting with [Knowledge Catalog][dataplex-docs].
+
+In addition to [setting the ADC for your server][set-adc], you need to ensure
+the IAM identity has been given the correct IAM permissions for the tasks you
+intend to perform. See [Knowledge Catalog IAM permissions][iam-permissions]
+and [Knowledge Catalog IAM roles][iam-roles] for more information on
+applying IAM permissions and roles to an identity.
+
+[iam-overview]: https://cloud.google.com/dataplex/docs/iam-and-access-control
+[adc]: https://cloud.google.com/docs/authentication#adc
+[set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[iam-permissions]: https://cloud.google.com/dataplex/docs/iam-permissions
+[iam-roles]: https://cloud.google.com/dataplex/docs/iam-roles
+[dataplex-docs]: https://cloud.google.com/dataplex/docs
+
+## Example
+
+```yaml
+kind: tool
+name: search_catalog
+type: spanner-search-catalog
+source: spanner-source
+description: Searches for data assets (eg. Spanner tables, views, or databases) in Knowledge Catalog (formerly known as Dataplex) based on the provided search query
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| type        |                   string                   |     true     | Must be "spanner-search-catalog".                                                               |
+| source      |                   string                   |     true     | Name of the source the tool should execute on.                                                   |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |

--- a/internal/prebuiltconfigs/tools/spanner-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/spanner-postgres.yaml
@@ -230,9 +230,23 @@ parameters:
   description: "Optional: Use 'simple' to return table names only or use 'detailed' to return the full information schema."
   default: detailed
 ---
+kind: tool
+name: search_catalog
+type: spanner-search-catalog
+source: spanner-source
+description: Searches for data assets (eg. Spanner instances, tables, views, or databases) in catalog based on the provided search query
+---
 kind: toolset
 name: data
 tools:
 - execute_sql
 - execute_sql_dql
 - list_tables
+---
+kind: toolset
+name: data_with_discovery
+tools:
+- execute_sql
+- execute_sql_dql
+- list_tables
+- search_catalog

--- a/internal/prebuiltconfigs/tools/spanner.yaml
+++ b/internal/prebuiltconfigs/tools/spanner.yaml
@@ -45,6 +45,12 @@ type: spanner-list-graphs
 source: spanner-source
 description: Lists detailed graph schema information (node tables, edge tables, labels and property declarations) as JSON for user-created graphs. Filters by a comma-separated list of graph names. If names are omitted, lists all graphs. The output can be 'simple' (graph names only) or 'detailed' (full schema).
 ---
+kind: tool
+name: search_catalog
+type: spanner-search-catalog
+source: spanner-source
+description: Searches for data assets (eg. Spanner instances, tables, views, or databases) in catalog based on the provided search query
+---
 kind: toolset
 name: data
 tools:
@@ -52,3 +58,13 @@ tools:
 - execute_sql_dql
 - list_tables
 - list_graphs
+---
+kind: toolset
+name: data_with_discovery
+tools:
+- execute_sql
+- execute_sql_dql
+- list_tables
+- list_graphs
+- search_catalog
+

--- a/internal/sources/bigquery/bigquery.go
+++ b/internal/sources/bigquery/bigquery.go
@@ -28,6 +28,7 @@ import (
 	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/orderedmap"
@@ -904,4 +905,35 @@ func newDataplexClientCreator(
 	return func(tokenString string) (*dataplexapi.CatalogClient, error) {
 		return initDataplexConnectionWithOAuthToken(ctx, project, userAgent, tokenString)
 	}
+}
+
+func (s *Source) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	typeMap := map[string]string{
+		"bigquery-connection":  "CONNECTION",
+		"bigquery-data-policy": "POLICY",
+		"bigquery-dataset":     "DATASET",
+		"bigquery-model":       "MODEL",
+		"bigquery-routine":     "ROUTINE",
+		"bigquery-table":       "TABLE",
+		"bigquery-view":        "VIEW",
+	}
+	catalogClient, dataplexClientCreator, err := s.MakeDataplexCatalogClient()()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dataplex client: %w", err)
+	}
+	return searchcatalog.InvokeSearchCatalog(
+		ctx,
+		params,
+		tokenStr,
+		"bigquery",
+		"datasetIds",
+		typeMap,
+		s.BigQueryProject(),
+		func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error) {
+			if token != "" {
+				return dataplexClientCreator(token)
+			}
+			return catalogClient, nil
+		},
+	)
 }

--- a/internal/sources/dataplex/searchcatalog/search_catalog.go
+++ b/internal/sources/dataplex/searchcatalog/search_catalog.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searchcatalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	dataplexapi "cloud.google.com/go/dataplex/apiv1"
+	dataplexpb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+// DataplexSearchResponse represents a simplified search result.
+type DataplexSearchResponse struct {
+	DisplayName   string
+	Description   string
+	Type          string
+	Resource      string
+	DataplexEntry string
+}
+
+// ConstructSearchQueryHelper builds a query clause for a specific predicate.
+func ConstructSearchQueryHelper(predicate string, operator string, items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+
+	if len(items) == 1 {
+		return predicate + operator + items[0]
+	}
+
+	var builder strings.Builder
+	builder.WriteString("(")
+	for i, item := range items {
+		if i > 0 {
+			builder.WriteString(" OR ")
+		}
+		builder.WriteString(predicate)
+		builder.WriteString(operator)
+		builder.WriteString(item)
+	}
+	builder.WriteString(")")
+	return builder.String()
+}
+
+// ConstructSearchQuery builds the full Dataplex search query.
+func ConstructSearchQuery(prompt string, projectIds []string, parentIds []string, types []string, system string) string {
+	queryParts := []string{}
+
+	if clause := ConstructSearchQueryHelper("projectid", "=", projectIds); clause != "" {
+		queryParts = append(queryParts, clause)
+	}
+
+	if clause := ConstructSearchQueryHelper("parent", "=", parentIds); clause != "" {
+		queryParts = append(queryParts, clause)
+	}
+
+	if clause := ConstructSearchQueryHelper("type", "=", types); clause != "" {
+		queryParts = append(queryParts, clause)
+	}
+
+	if system != "" {
+		queryParts = append(queryParts, "system="+system)
+	}
+
+	return fmt.Sprintf("%s %s", prompt, strings.Join(queryParts, " AND "))
+}
+
+// ExtractType extracts the mapped type from a resource string based on a type map.
+func ExtractType(resourceString string, typeMap map[string]string) string {
+	lastIndex := strings.LastIndex(resourceString, "/")
+	if lastIndex == -1 {
+		return resourceString
+	}
+	return typeMap[resourceString[lastIndex+1:]]
+}
+
+// ExecuteSearch performs the search and processes results.
+func ExecuteSearch(ctx context.Context, client *dataplexapi.CatalogClient, req *dataplexpb.SearchEntriesRequest, typeMap map[string]string) ([]DataplexSearchResponse, error) {
+	if client == nil {
+		return nil, fmt.Errorf("dataplex catalog client is nil")
+	}
+	it := client.SearchEntries(ctx, req)
+	if it == nil {
+		return nil, fmt.Errorf("failed to create search entries iterator")
+	}
+
+	var results []DataplexSearchResponse
+	for req.PageSize <= 0 || len(results) < int(req.PageSize) {
+		entry, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		entrySource := entry.DataplexEntry.GetEntrySource()
+
+		resp := DataplexSearchResponse{
+			DisplayName:   entrySource.GetDisplayName(),
+			Description:   entrySource.GetDescription(),
+			Type:          ExtractType(entry.DataplexEntry.GetEntryType(), typeMap),
+			Resource:      entrySource.GetResource(),
+			DataplexEntry: entry.DataplexEntry.GetName(),
+		}
+		results = append(results, resp)
+	}
+	return results, nil
+}
+
+// InvokeSearchCatalog performs the common search catalog logic.
+func InvokeSearchCatalog(
+	ctx context.Context,
+	paramsMap map[string]any,
+	tokenStr string,
+	systemName string,
+	parentParamName string,
+	typeMap map[string]string,
+	projectID string,
+	getCatalogClient func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error),
+) ([]DataplexSearchResponse, error) {
+	pageSize := int32(paramsMap["pageSize"].(int))
+	prompt, _ := paramsMap["prompt"].(string)
+
+	projectIdSlice, err := parameters.ConvertAnySliceToTyped(paramsMap["projectIds"].([]any), "string")
+	if err != nil {
+		return nil, fmt.Errorf("can't convert projectIds to array of strings: %w", err)
+	}
+	projectIds := projectIdSlice.([]string)
+
+	parentIdSlice, err := parameters.ConvertAnySliceToTyped(paramsMap[parentParamName].([]any), "string")
+	if err != nil {
+		return nil, fmt.Errorf("can't convert %s to array of strings: %w", parentParamName, err)
+	}
+	parentIds := parentIdSlice.([]string)
+
+	typesSlice, err := parameters.ConvertAnySliceToTyped(paramsMap["types"].([]any), "string")
+	if err != nil {
+		return nil, fmt.Errorf("can't convert types to array of strings: %w", err)
+	}
+	types := typesSlice.([]string)
+
+	query := ConstructSearchQuery(prompt, projectIds, parentIds, types, systemName)
+
+	req := &dataplexpb.SearchEntriesRequest{
+		Query:          query,
+		Name:           fmt.Sprintf("projects/%s/locations/global", projectID),
+		PageSize:       pageSize,
+		SemanticSearch: true,
+	}
+
+	catalogClient, err := getCatalogClient(ctx, tokenStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get catalog client: %w", err)
+	}
+
+	return ExecuteSearch(ctx, catalogClient, req, typeMap)
+}
+
+// Cache is an interface for a thread-safe, expiring key-value store.
+type Cache interface {
+	Get(key string) (any, bool)
+	Set(key string, value any)
+}
+
+// DataplexClientManager manages Dataplex Catalog clients, including caching and lazy initialization.
+type DataplexClientManager struct {
+	UseClientOAuth       bool
+	Cache                Cache
+	DefaultClientCreator func(ctx context.Context) (*dataplexapi.CatalogClient, error)
+	OAuthClientCreator   func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error)
+
+	catalogClient    *dataplexapi.CatalogClient
+	catalogClientErr error
+	once             sync.Once
+	mu               sync.Mutex
+}
+
+// GetCatalogClient returns a Dataplex Catalog client.
+func (m *DataplexClientManager) GetCatalogClient(ctx context.Context, tokenString string) (*dataplexapi.CatalogClient, error) {
+	if m.UseClientOAuth && tokenString != "" {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		// Check cache
+		if m.Cache != nil {
+			if val, found := m.Cache.Get(tokenString); found {
+				return val.(*dataplexapi.CatalogClient), nil
+			}
+		}
+
+		// Cache miss - create new client
+		var client *dataplexapi.CatalogClient
+		var initErr error
+		if m.OAuthClientCreator != nil {
+			client, initErr = m.OAuthClientCreator(ctx, tokenString)
+		} else {
+			userAgent, err := util.UserAgentFromContext(ctx)
+			if err != nil {
+				userAgent = "genai-toolbox"
+			}
+			ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tokenString})
+			client, initErr = dataplexapi.NewCatalogClient(ctx, option.WithUserAgent(userAgent), option.WithTokenSource(ts))
+		}
+		if initErr != nil {
+			return nil, initErr
+		}
+
+		// Set in cache
+		if m.Cache != nil {
+			m.Cache.Set(tokenString, client)
+		}
+		return client, nil
+	}
+
+	// Fallback to default client (lazy initialized)
+	m.once.Do(func() {
+		if m.DefaultClientCreator != nil {
+			m.catalogClient, m.catalogClientErr = m.DefaultClientCreator(context.Background())
+		} else {
+			userAgent, err := util.UserAgentFromContext(ctx)
+			if err != nil {
+				userAgent = "genai-toolbox"
+			}
+			// Uses Application Default Credentials (ADC) if no token is provided.
+			m.catalogClient, m.catalogClientErr = dataplexapi.NewCatalogClient(context.Background(), option.WithUserAgent(userAgent))
+		}
+	})
+	if m.catalogClientErr != nil {
+		return nil, m.catalogClientErr
+	}
+	return m.catalogClient, nil
+}

--- a/internal/sources/dataplex/searchcatalog/search_catalog_test.go
+++ b/internal/sources/dataplex/searchcatalog/search_catalog_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package searchcatalog_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+func TestConstructSearchQueryHelper(t *testing.T) {
+	tests := []struct {
+		name      string
+		predicate string
+		operator  string
+		items     []string
+		want      string
+	}{
+		{
+			name:      "empty items",
+			predicate: "projectid",
+			operator:  "=",
+			items:     []string{},
+			want:      "",
+		},
+		{
+			name:      "single item",
+			predicate: "projectid",
+			operator:  "=",
+			items:     []string{"p1"},
+			want:      "projectid=p1",
+		},
+		{
+			name:      "multiple items",
+			predicate: "projectid",
+			operator:  "=",
+			items:     []string{"p1", "p2"},
+			want:      "(projectid=p1 OR projectid=p2)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := searchcatalog.ConstructSearchQueryHelper(tt.predicate, tt.operator, tt.items)
+			if got != tt.want {
+				t.Errorf("ConstructSearchQueryHelper() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConstructSearchQuery(t *testing.T) {
+	tests := []struct {
+		name       string
+		prompt     string
+		projectIds []string
+		parentIds  []string
+		types      []string
+		system     string
+		want       string
+	}{
+		{
+			name:       "all empty",
+			prompt:     "search",
+			projectIds: []string{},
+			parentIds:  []string{},
+			types:      []string{},
+			system:     "",
+			want:       "search ",
+		},
+		{
+			name:       "with project",
+			prompt:     "search",
+			projectIds: []string{"p1"},
+			parentIds:  []string{},
+			types:      []string{},
+			system:     "",
+			want:       "search projectid=p1",
+		},
+		{
+			name:       "with all",
+			prompt:     "search",
+			projectIds: []string{"p1"},
+			parentIds:  []string{"d1"},
+			types:      []string{"t1"},
+			system:     "sys1",
+			want:       "search projectid=p1 AND parent=d1 AND type=t1 AND system=sys1",
+		},
+		{
+			name:       "with multiple items",
+			prompt:     "search",
+			projectIds: []string{"p1", "p2"},
+			parentIds:  []string{"d1"},
+			types:      []string{},
+			system:     "",
+			want:       "search (projectid=p1 OR projectid=p2) AND parent=d1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := searchcatalog.ConstructSearchQuery(tt.prompt, tt.projectIds, tt.parentIds, tt.types, tt.system)
+			if got != tt.want {
+				t.Errorf("ConstructSearchQuery() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractType(t *testing.T) {
+	typeMap := map[string]string{
+		"type1": "MAPPED_TYPE1",
+	}
+
+	tests := []struct {
+		name           string
+		resourceString string
+		want           string
+	}{
+		{
+			name:           "found in map",
+			resourceString: "projects/p/locations/l/entryTypes/type1",
+			want:           "MAPPED_TYPE1",
+		},
+		{
+			name:           "not found in map",
+			resourceString: "projects/p/locations/l/entryTypes/type2",
+			want:           "",
+		},
+		{
+			name:           "no slash",
+			resourceString: "type1",
+			want:           "type1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := searchcatalog.ExtractType(tt.resourceString, typeMap)
+			if got != tt.want {
+				t.Errorf("ExtractType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertAnySliceToTyped(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        []any
+		itemType string
+		want     any
+		wantErr  bool
+	}{
+		{
+			name:     "strings",
+			s:        []any{"a", "b"},
+			itemType: "string",
+			want:     []string{"a", "b"},
+			wantErr:  false,
+		},
+		{
+			name:     "integers",
+			s:        []any{1, 2},
+			itemType: "integer",
+			want:     []int64{1, 2},
+			wantErr:  false,
+		},
+		{
+			name:     "floats",
+			s:        []any{1.1, 2.2},
+			itemType: "float",
+			want:     []float64{1.1, 2.2},
+			wantErr:  false,
+		},
+		{
+			name:     "booleans",
+			s:        []any{true, false},
+			itemType: "boolean",
+			want:     []bool{true, false},
+			wantErr:  false,
+		},
+		{
+			name:     "string error",
+			s:        []any{"a", 1},
+			itemType: "string",
+			want:     nil,
+			wantErr:  true,
+		},
+		{
+			name:     "unknown type returns nil and no error",
+			s:        []any{"a"},
+			itemType: "unknown",
+			want:     nil,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parameters.ConvertAnySliceToTyped(tt.s, tt.itemType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertAnySliceToTyped() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if diff := cmp.Diff(tt.want, got); diff != "" {
+					t.Errorf("ConvertAnySliceToTyped() diff (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/internal/sources/spanner/spanner.go
+++ b/internal/sources/spanner/spanner.go
@@ -19,9 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"cloud.google.com/go/spanner"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/orderedmap"
 	"go.opentelemetry.io/otel/trace"
@@ -48,12 +50,13 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string          `yaml:"name" validate:"required"`
-	Type     string          `yaml:"type" validate:"required"`
-	Project  string          `yaml:"project" validate:"required"`
-	Instance string          `yaml:"instance" validate:"required"`
-	Dialect  sources.Dialect `yaml:"dialect" validate:"required"`
-	Database string          `yaml:"database" validate:"required"`
+	Name           string          `yaml:"name" validate:"required"`
+	Type           string          `yaml:"type" validate:"required"`
+	Project        string          `yaml:"project" validate:"required"`
+	Instance       string          `yaml:"instance" validate:"required"`
+	Dialect        sources.Dialect `yaml:"dialect" validate:"required"`
+	Database       string          `yaml:"database" validate:"required"`
+	UseClientOAuth bool            `yaml:"useClientOAuth"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -66,9 +69,19 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 		return nil, fmt.Errorf("unable to create client: %w", err)
 	}
 
+	onDataplexEvict := func(key string, value interface{}) {
+		if client, ok := value.(*dataplexapi.CatalogClient); ok && client != nil {
+			client.Close()
+		}
+	}
+
 	s := &Source{
 		Config: r,
 		Client: client,
+		dataplexMgr: &searchcatalog.DataplexClientManager{
+			UseClientOAuth: r.UseClientOAuth,
+			Cache:          sources.NewCache(onDataplexEvict),
+		},
 	}
 	return s, nil
 }
@@ -77,7 +90,8 @@ var _ sources.Source = &Source{}
 
 type Source struct {
 	Config
-	Client *spanner.Client
+	Client      *spanner.Client
+	dataplexMgr *searchcatalog.DataplexClientManager
 }
 
 func (s *Source) SourceType() string {
@@ -94,6 +108,18 @@ func (s *Source) SpannerClient() *spanner.Client {
 
 func (s *Source) DatabaseDialect() string {
 	return s.Dialect.String()
+}
+
+func (s *Source) ProjectID() string {
+	return s.Project
+}
+
+func (s *Source) UseClientAuthorization() bool {
+	return s.UseClientOAuth
+}
+
+func (s *Source) GetCatalogClient(ctx context.Context, tokenString string) (*dataplexapi.CatalogClient, error) {
+	return s.dataplexMgr.GetCatalogClient(ctx, tokenString)
 }
 
 // processRows iterates over the spanner.RowIterator and converts each row to a map[string]any.
@@ -188,4 +214,25 @@ func initSpannerClient(ctx context.Context, tracer trace.Tracer, name, project, 
 	}
 
 	return client, nil
+}
+
+func (s *Source) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	typeMap := map[string]string{
+		"cloud-spanner-instance": "SERVICE",
+		"cloud-spanner-database": "DATABASE",
+		"cloud-spanner-table":    "TABLE",
+		"cloud-spanner-view":     "VIEW",
+	}
+	return searchcatalog.InvokeSearchCatalog(
+		ctx,
+		params,
+		tokenStr,
+		"CLOUD_SPANNER",
+		"databaseIds",
+		typeMap,
+		s.ProjectID(),
+		func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error) {
+			return s.GetCatalogClient(ctx, token)
+		},
+	)
 }

--- a/internal/sources/spanner/spanner_test.go
+++ b/internal/sources/spanner/spanner_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/sources/spanner"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
@@ -164,6 +165,59 @@ func TestFailParseFromYaml(t *testing.T) {
 			errStr := err.Error()
 			if errStr != tc.err {
 				t.Fatalf("unexpected error: got %q, want %q", errStr, tc.err)
+			}
+		})
+	}
+}
+
+func TestExtractType(t *testing.T) {
+	typeMap := map[string]string{
+		"cloud-spanner-instance": "SERVICE",
+		"cloud-spanner-database": "DATABASE",
+		"cloud-spanner-table":    "TABLE",
+		"cloud-spanner-view":     "VIEW",
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want string
+	}{
+		{
+			desc: "mapped type instance",
+			in:   "projects/my-project/locations/global/entryTypes/cloud-spanner-instance",
+			want: "SERVICE",
+		},
+		{
+			desc: "mapped type database",
+			in:   "projects/my-project/locations/global/entryTypes/cloud-spanner-database",
+			want: "DATABASE",
+		},
+		{
+			desc: "mapped type table",
+			in:   "projects/my-project/locations/global/entryTypes/cloud-spanner-table",
+			want: "TABLE",
+		},
+		{
+			desc: "mapped type view",
+			in:   "projects/my-project/locations/global/entryTypes/cloud-spanner-view",
+			want: "VIEW",
+		},
+		{
+			desc: "no slash returns input",
+			in:   "cloud-spanner-table",
+			want: "cloud-spanner-table",
+		},
+		{
+			desc: "unknown type with slash returns empty",
+			in:   "projects/my-project/locations/global/entryTypes/unknown-type",
+			want: "",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := searchcatalog.ExtractType(tc.in, typeMap)
+			if got != tc.want {
+				t.Errorf("ExtractType(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bigquerysearchcatalog
+package spannersearchcatalog
 
 import (
 	"context"
 	"fmt"
 	"net/http"
 
-	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
-	bigqueryds "github.com/googleapis/mcp-toolbox/internal/sources/bigquery"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
-const resourceType string = "bigquery-search-catalog"
+const resourceType string = "spanner-search-catalog"
 
 func init() {
 	if !tools.Register(resourceType, newConfig) {
@@ -47,22 +45,19 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
-	MakeDataplexCatalogClient() func() (*dataplexapi.CatalogClient, bigqueryds.DataplexClientCreator, error)
-	BigQueryProject() string
+	ProjectID() string
 	UseClientAuthorization() bool
-	GetAuthTokenHeaderName() string
 	InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error)
 }
 
 type Config struct {
-	Name         string                 `yaml:"name" validate:"required"`
-	Type         string                 `yaml:"type" validate:"required"`
-	Source       string                 `yaml:"source" validate:"required"`
-	Description  string                 `yaml:"description"`
-	AuthRequired []string               `yaml:"authRequired"`
-	Annotations  *tools.ToolAnnotations `yaml:"annotations,omitempty"`
-
-	ScopesRequired []string `yaml:"scopesRequired"`
+	Name           string                 `yaml:"name" validate:"required"`
+	Type           string                 `yaml:"type" validate:"required"`
+	Source         string                 `yaml:"source" validate:"required"`
+	Description    string                 `yaml:"description"`
+	AuthRequired   []string               `yaml:"authRequired"`
+	Annotations    *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	ScopesRequired []string               `yaml:"scopesRequired"`
 }
 
 // validate interface
@@ -74,14 +69,34 @@ func (cfg Config) ToolConfigType() string {
 
 func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
 	prompt := parameters.NewStringParameter("prompt", "Prompt representing search intention. Do not rewrite the prompt.")
-	datasetIds := parameters.NewArrayParameterWithDefault("datasetIds", []any{}, "Array of dataset IDs.", parameters.NewStringParameter("datasetId", "The IDs of the bigquery dataset."))
-	projectIds := parameters.NewArrayParameterWithDefault("projectIds", []any{}, "Array of project IDs.", parameters.NewStringParameter("projectId", "The IDs of the bigquery project."))
-	types := parameters.NewArrayParameterWithDefault("types", []any{}, "Array of data types to filter by.", parameters.NewStringParameter("type", "The type of the data. Accepted values are: CONNECTION, POLICY, DATASET, MODEL, ROUTINE, TABLE, VIEW."))
+
+	databaseIds := parameters.NewArrayParameterWithDefault(
+		"databaseIds",
+		[]any{},
+		"Array of database IDs.",
+		parameters.NewStringParameter("databaseId", "The IDs of the spanner database."),
+	)
+
+	projectIds := parameters.NewArrayParameterWithDefault(
+		"projectIds",
+		[]any{},
+		"Array of project IDs.",
+		parameters.NewStringParameter("projectId", "The IDs of the GCP project."),
+	)
+
+	types := parameters.NewArrayParameterWithDefault(
+		"types",
+		[]any{},
+		"Array of data types to filter by.",
+		parameters.NewStringParameter("type", "The type of the data. Accepted values are: SERVICE, DATABASE, TABLE, VIEW."),
+	)
+
 	pageSize := parameters.NewIntParameterWithDefault("pageSize", 5, "Number of results in the search page.")
-	params := parameters.Parameters{prompt, datasetIds, projectIds, types, pageSize}
+
+	params := parameters.Parameters{prompt, databaseIds, projectIds, types, pageSize}
 
 	if cfg.Description == "" {
-		cfg.Description = "Use this tool to find tables, views, models, routines or connections."
+		cfg.Description = "Searches for data assets (eg. Spanner tables, views, or databases) in catalog based on the provided search query"
 	}
 
 	t := Tool{
@@ -95,6 +110,9 @@ func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error)
 	}
 	return t, nil
 }
+
+// validate interface
+var _ tools.Tool = Tool{}
 
 type Tool struct {
 	Config
@@ -144,7 +162,7 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
-			return nil, util.NewClientServerError("error parsing access token", http.StatusUnauthorized, err)
+			return nil, util.NewClientServerError("failed to parse access token", http.StatusInternalServerError, err)
 		}
 	}
 
@@ -161,16 +179,11 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 }
 
 func (t Tool) Manifest() tools.Manifest {
-	// Returns the tool manifest
 	return t.manifest
 }
 
 func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Source, t.Name, t.Type)
-	if err != nil {
-		return "", err
-	}
-	return source.GetAuthTokenHeaderName(), nil
+	return "", nil
 }
 
 func (t Tool) GetParameters() parameters.Parameters {

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spannersearchcatalog_test
+
+import (
+	"context"
+	"testing"
+
+	dataplexapi "cloud.google.com/go/dataplex/apiv1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/tools/spanner/spannersearchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+func TestParseFromYamlSpannerSearch(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+            kind: tool
+            name: example_tool
+            type: spanner-search-catalog
+            source: my-instance
+            description: some description
+            `,
+			want: server.ToolConfigs{
+				"example_tool": spannersearchcatalog.Config{
+					Name:         "example_tool",
+					Type:         "spanner-search-catalog",
+					Source:       "my-instance",
+					Description:  "some description",
+					AuthRequired: []string{},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Parse contents
+			_, _, _, got, _, _, err := server.UnmarshalResourceConfig(ctx, testutils.FormatYaml(tc.in))
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+}
+
+type mockSpannerSource struct {
+	projectID              string
+	useClientAuthorization bool
+	searchResponse         []searchcatalog.DataplexSearchResponse
+	err                    error
+}
+
+func (m mockSpannerSource) ProjectID() string            { return m.projectID }
+func (m mockSpannerSource) UseClientAuthorization() bool { return m.useClientAuthorization }
+func (m mockSpannerSource) GetCatalogClient(ctx context.Context, tokenString string) (*dataplexapi.CatalogClient, error) {
+	return nil, nil
+}
+func (m mockSpannerSource) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	return m.searchResponse, m.err
+}
+func (m mockSpannerSource) SourceType() string             { return "spanner" }
+func (m mockSpannerSource) ToConfig() sources.SourceConfig { return nil }
+
+type mockSourceProvider struct {
+	source sources.Source
+}
+
+func (m mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	if m.source != nil {
+		return m.source, true
+	}
+	return nil, false
+}
+
+func TestConfig_Initialize(t *testing.T) {
+	cfg := spannersearchcatalog.Config{
+		Name:        "test-tool",
+		Type:        "spanner-search-catalog",
+		Source:      "test-source",
+		Description: "Test description",
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	if tool.GetName() != "test-tool" {
+		t.Errorf("GetName() = %v, want %v", tool.GetName(), "test-tool")
+	}
+
+	if tool.GetDescription() != "Test description" {
+		t.Errorf("GetDescription() = %v, want %v", tool.GetDescription(), "Test description")
+	}
+}
+
+func TestTool_Invoke(t *testing.T) {
+	ctx := context.Background()
+	mockSource := mockSpannerSource{
+		searchResponse: []searchcatalog.DataplexSearchResponse{
+			{
+				DataplexEntry: "test-entry",
+			},
+		},
+	}
+	sourceProvider := mockSourceProvider{source: mockSource}
+
+	cfg := spannersearchcatalog.Config{
+		Name:   "test-tool",
+		Type:   "spanner-search-catalog",
+		Source: "test-source",
+	}
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	params := parameters.ParamValues{
+		{
+			Name:  "prompt",
+			Value: "test prompt",
+		},
+	}
+
+	resp, err := tool.Invoke(ctx, sourceProvider, params, tools.AccessToken(""))
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+
+	results, ok := resp.([]searchcatalog.DataplexSearchResponse)
+	if !ok {
+		t.Fatalf("expected []searchcatalog.DataplexSearchResponse, got %T", resp)
+	}
+
+	if len(results) != 1 || results[0].DataplexEntry != "test-entry" {
+		t.Errorf("unexpected results: %v", results)
+	}
+}

--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -212,7 +212,15 @@ func TestBigQueryToolEndpoints(t *testing.T) {
 	runBigQueryListTableIdsToolInvokeTest(t, datasetName, tableName)
 	runBigQueryGetTableInfoToolInvokeTest(t, datasetName, tableName, tableInfoWant)
 	runBigQueryConversationalAnalyticsInvokeTest(t, datasetName, tableName, dataInsightsWant)
-	runBigQuerySearchCatalogToolInvokeTest(t, datasetName, tableName)
+	tests.RunSearchCatalogToolTest(t, tests.SearchCatalogTestParams{
+		ContainerParamName: "datasetIds",
+		ContainerName:      datasetName,
+		ProjectID:          BigqueryProject,
+		TargetName:         tableName,
+		WantKey:            "DisplayName",
+		AllowEmpty:         false,
+		CheckValue:         true,
+	})
 	tests.RunSemanticSearchToolInvokeTest(t, ddlWant, "", "The quick brown fox")
 }
 
@@ -2920,177 +2928,6 @@ func runConversationalAnalyticsWithRestriction(t *testing.T, allowedDatasetName,
 				bodyBytes, _ := io.ReadAll(resp.Body)
 				if !strings.Contains(string(bodyBytes), tc.wantInError) {
 					t.Errorf("unexpected error message: got %q, want to contain %q", string(bodyBytes), tc.wantInError)
-				}
-			}
-		})
-	}
-}
-
-func runBigQuerySearchCatalogToolInvokeTest(t *testing.T, datasetName string, tableName string) {
-	// Get ID token
-	idToken, err := tests.GetGoogleIdToken(t)
-	if err != nil {
-		t.Fatalf("error getting Google ID token: %s", err)
-	}
-
-	// Get access token
-	accessToken, err := sources.GetIAMAccessToken(t.Context())
-	if err != nil {
-		t.Fatalf("error getting access token from ADC: %s", err)
-	}
-	accessToken = "Bearer " + accessToken
-
-	// Test tool invoke endpoint
-	invokeTcs := []struct {
-		name          string
-		api           string
-		requestHeader map[string]string
-		requestBody   io.Reader
-		wantKey       string
-		isErr         bool
-	}{
-		{
-			name:          "invoke my-search-catalog-tool without body",
-			api:           "http://127.0.0.1:5000/api/tool/my-search-catalog-tool/invoke",
-			requestHeader: map[string]string{},
-			requestBody:   bytes.NewBuffer([]byte(`{}`)),
-			isErr:         true,
-		},
-		{
-			name:          "invoke my-search-catalog-tool",
-			api:           "http://127.0.0.1:5000/api/tool/my-search-catalog-tool/invoke",
-			requestHeader: map[string]string{},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"datasetIds\":[\"%s\"]}", tableName, datasetName))),
-			wantKey:       "DisplayName",
-			isErr:         false,
-		},
-		{
-			name:          "Invoke my-auth-search-catalog-tool with auth token",
-			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
-			requestHeader: map[string]string{"my-google-auth_token": idToken},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"datasetIds\":[\"%s\"]}", tableName, datasetName))),
-			wantKey:       "DisplayName",
-			isErr:         false,
-		},
-		{
-			name:          "Invoke my-auth-search-catalog-tool with correct project",
-			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
-			requestHeader: map[string]string{"my-google-auth_token": idToken},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"projectIds\":[\"%s\"], \"datasetIds\":[\"%s\"]}", tableName, BigqueryProject, datasetName))),
-			wantKey:       "DisplayName",
-			isErr:         false,
-		},
-		{
-			name:          "Invoke my-auth-search-catalog-tool with non-existent project",
-			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
-			requestHeader: map[string]string{"my-google-auth_token": idToken},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"projectIds\":[\"%s-%s\"], \"datasetIds\":[\"%s\"]}", tableName, BigqueryProject, uuid.NewString(), datasetName))),
-			isErr:         true,
-		},
-		{
-			name:          "Invoke my-auth-search-catalog-tool with invalid auth token",
-			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
-			requestHeader: map[string]string{"my-google-auth_token": "INVALID_TOKEN"},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"datasetIds\":[\"%s\"]}", tableName, datasetName))),
-			isErr:         true,
-		},
-		{
-			name:          "Invoke my-auth-search-catalog-tool without auth token",
-			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
-			requestHeader: map[string]string{},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"datasetIds\":[\"%s\"]}", tableName, datasetName))),
-			isErr:         true,
-		},
-		{
-			name:          "Invoke my-client-auth-search-catalog-tool without auth token",
-			api:           "http://127.0.0.1:5000/api/tool/my-client-auth-search-catalog-tool/invoke",
-			requestHeader: map[string]string{},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"datasetIds\":[\"%s\"]}", tableName, datasetName))),
-			isErr:         true,
-		},
-		{
-			name:          "Invoke my-client-auth-search-catalog-tool with auth token",
-			api:           "http://127.0.0.1:5000/api/tool/my-client-auth-search-catalog-tool/invoke",
-			requestHeader: map[string]string{"Authorization": accessToken},
-			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"datasetIds\":[\"%s\"]}", tableName, datasetName))),
-			wantKey:       "DisplayName",
-			isErr:         false,
-		},
-	}
-	for _, tc := range invokeTcs {
-		t.Run(tc.name, func(t *testing.T) {
-			// Send Tool invocation request
-			req, err := http.NewRequest(http.MethodPost, tc.api, tc.requestBody)
-			if err != nil {
-				t.Fatalf("unable to create request: %s", err)
-			}
-			req.Header.Add("Content-type", "application/json")
-			for k, v := range tc.requestHeader {
-				req.Header.Add(k, v)
-			}
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("unable to send request: %s", err)
-			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode != http.StatusOK {
-				if tc.isErr {
-					return
-				}
-				bodyBytes, _ := io.ReadAll(resp.Body)
-				t.Fatalf("response status code is not 200, got %d: %s", resp.StatusCode, string(bodyBytes))
-			}
-
-			var result map[string]interface{}
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				t.Fatalf("error parsing response body: %s", err)
-			}
-			resultStr, ok := result["result"].(string)
-			if !ok {
-				if result["result"] == nil && tc.isErr {
-					return
-				}
-				t.Fatalf("expected 'result' field to be a string, got %T", result["result"])
-			}
-
-			var errorCheck map[string]any
-			if err := json.Unmarshal([]byte(resultStr), &errorCheck); err == nil {
-				if _, hasError := errorCheck["error"]; hasError {
-					if tc.isErr {
-						return
-					}
-					t.Fatalf("unexpected error object in result: %s", resultStr)
-				}
-			}
-
-			if tc.isErr && (resultStr == "" || resultStr == "[]") {
-				return
-			}
-
-			var entries []any
-			if err := json.Unmarshal([]byte(resultStr), &entries); err != nil {
-				t.Fatalf("error unmarshalling result string: %v. Raw string: %s", err, resultStr)
-			}
-
-			if !tc.isErr {
-				if len(entries) != 1 {
-					t.Fatalf("expected exactly one entry, but got %d", len(entries))
-				}
-				entry, ok := entries[0].(map[string]interface{})
-				if !ok {
-					t.Fatalf("expected first entry to be a map, got %T", entries[0])
-				}
-				respTable, ok := entry[tc.wantKey]
-				if !ok {
-					t.Fatalf("expected entry to have key '%s', but it was not found in %v", tc.wantKey, entry)
-				}
-				if respTable != tableName {
-					t.Fatalf("expected key '%s' to have value '%s', but got %s", tc.wantKey, tableName, respTable)
-				}
-			} else {
-				if len(entries) != 0 {
-					t.Fatalf("expected 0 entries, but got %d", len(entries))
 				}
 			}
 		})

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -162,6 +162,7 @@ func TestSpannerToolEndpoints(t *testing.T) {
 	toolsFile = addTemplateParamConfig(t, toolsFile)
 	toolsFile = addSpannerListTablesConfig(t, toolsFile)
 	toolsFile = addSpannerListGraphsConfig(t, toolsFile)
+	toolsFile = addSpannerSearchCatalogConfig(t, toolsFile)
 
 	// Set up table for semantic search
 	vectorTableName, tearDownVectorTable := setupSpannerVectorTable(t, ctx, adminClient, dbString)
@@ -214,6 +215,15 @@ func TestSpannerToolEndpoints(t *testing.T) {
 	runSpannerExecuteSqlToolInvokeTest(t, select1Want, invokeParamWant, tableNameParam)
 	runSpannerListTablesTest(t, tableNameParam, tableNameAuth, tableNameTemplateParam)
 	runSpannerListGraphsTest(t, graphName)
+	tests.RunSearchCatalogToolTest(t, tests.SearchCatalogTestParams{
+		ContainerParamName: "databaseIds",
+		ContainerName:      SpannerDatabase,
+		ProjectID:          SpannerProject,
+		TargetName:         tableNameParam,
+		WantKey:            "DisplayName",
+		AllowEmpty:         true,
+		CheckValue:         false,
+	})
 	tests.RunSemanticSearchToolInvokeTest(t, "[]", "", "The quick brown fox")
 }
 
@@ -392,6 +402,54 @@ func addSpannerListTablesConfig(t *testing.T, config map[string]any) map[string]
 	}
 
 	config["tools"] = tools
+	return config
+}
+
+// addSpannerSearchCatalogConfig adds the spanner-search-catalog tool configuration
+func addSpannerSearchCatalogConfig(t *testing.T, config map[string]any) map[string]any {
+	tools, ok := config["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get tools from config")
+	}
+	sources, ok := config["sources"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get sources from config")
+	}
+	myInstanceConfig, ok := sources["my-instance"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get my-instance from sources")
+	}
+
+	// Create a copy of the source config with client OAuth enabled
+	oauthSourceConfig := make(map[string]any)
+	for k, v := range myInstanceConfig {
+		oauthSourceConfig[k] = v
+	}
+	oauthSourceConfig["useClientOAuth"] = true
+	sources["my-oauth-instance"] = oauthSourceConfig
+
+	// Add tools
+	tools["my-search-catalog-tool"] = map[string]any{
+		"type":        "spanner-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+	}
+	tools["my-auth-search-catalog-tool"] = map[string]any{
+		"type":        "spanner-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+		"authRequired": []string{
+			"my-google-auth",
+		},
+	}
+	tools["my-client-auth-search-catalog-tool"] = map[string]any{
+		"type":        "spanner-search-catalog",
+		"source":      "my-oauth-instance",
+		"description": "Searches for data assets in catalog",
+	}
+
+	config["tools"] = tools
+	config["sources"] = sources
 	return config
 }
 

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -5317,3 +5317,194 @@ func RunStatementToolsTest(t *testing.T, tools map[string]string) {
 		})
 	}
 }
+
+// SearchCatalogTestParams defines parameters for RunSearchCatalogToolTest
+type SearchCatalogTestParams struct {
+	ContainerParamName string // "databaseIds" or "datasetIds"
+	ContainerName      string // databaseName or datasetName
+	ProjectID          string // SpannerProject or BigqueryProject
+	TargetName         string // tableName
+	WantKey            string // "DisplayName"
+	AllowEmpty         bool   // true for Spanner, false for BigQuery
+	CheckValue         bool   // true for BigQuery, false for Spanner
+}
+
+// RunSearchCatalogToolTest tests the search catalog tool for Spanner or BigQuery
+func RunSearchCatalogToolTest(t *testing.T, params SearchCatalogTestParams) {
+	// Get ID token
+	idToken, err := GetGoogleIdToken(t)
+	if err != nil {
+		t.Fatalf("error getting Google ID token: %s", err)
+	}
+
+	// Get access token
+	accessToken, err := sources.GetIAMAccessToken(t.Context())
+	if err != nil {
+		t.Fatalf("error getting access token from ADC: %s", err)
+	}
+	accessToken = "Bearer " + accessToken
+
+	// Test tool invoke endpoint
+	invokeTcs := []struct {
+		name          string
+		api           string
+		requestHeader map[string]string
+		requestBody   io.Reader
+		isErr         bool
+	}{
+		{
+			name:          "invoke my-search-catalog-tool without body",
+			api:           "http://127.0.0.1:5000/api/tool/my-search-catalog-tool/invoke",
+			requestHeader: map[string]string{},
+			requestBody:   bytes.NewBuffer([]byte(`{}`)),
+			isErr:         true,
+		},
+		{
+			name:          "invoke my-search-catalog-tool",
+			api:           "http://127.0.0.1:5000/api/tool/my-search-catalog-tool/invoke",
+			requestHeader: map[string]string{},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"%s\":[\"%s\"]}", params.TargetName, params.ContainerParamName, params.ContainerName))),
+			isErr:         false,
+		},
+		{
+			name:          "Invoke my-auth-search-catalog-tool with auth token",
+			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
+			requestHeader: map[string]string{"my-google-auth_token": idToken},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"%s\":[\"%s\"]}", params.TargetName, params.ContainerParamName, params.ContainerName))),
+			isErr:         false,
+		},
+		{
+			name:          "Invoke my-auth-search-catalog-tool with correct project",
+			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
+			requestHeader: map[string]string{"my-google-auth_token": idToken},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"projectIds\":[\"%s\"], \"%s\":[\"%s\"]}", params.TargetName, params.ProjectID, params.ContainerParamName, params.ContainerName))),
+			isErr:         false,
+		},
+		{
+			name:          "Invoke my-auth-search-catalog-tool with non-existent project",
+			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
+			requestHeader: map[string]string{"my-google-auth_token": idToken},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"projectIds\":[\"%s-%s\"], \"%s\":[\"%s\"]}", params.TargetName, params.ProjectID, uuid.NewString(), params.ContainerParamName, params.ContainerName))),
+			isErr:         true,
+		},
+		{
+			name:          "Invoke my-auth-search-catalog-tool with invalid auth token",
+			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
+			requestHeader: map[string]string{"my-google-auth_token": "INVALID_TOKEN"},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"%s\":[\"%s\"]}", params.TargetName, params.ContainerParamName, params.ContainerName))),
+			isErr:         true,
+		},
+		{
+			name:          "Invoke my-auth-search-catalog-tool without auth token",
+			api:           "http://127.0.0.1:5000/api/tool/my-auth-search-catalog-tool/invoke",
+			requestHeader: map[string]string{},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"%s\":[\"%s\"]}", params.TargetName, params.ContainerParamName, params.ContainerName))),
+			isErr:         true,
+		},
+		{
+			name:          "Invoke my-client-auth-search-catalog-tool without auth token",
+			api:           "http://127.0.0.1:5000/api/tool/my-client-auth-search-catalog-tool/invoke",
+			requestHeader: map[string]string{},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"%s\":[\"%s\"]}", params.TargetName, params.ContainerParamName, params.ContainerName))),
+			isErr:         true,
+		},
+		{
+			name:          "Invoke my-client-auth-search-catalog-tool with auth token",
+			api:           "http://127.0.0.1:5000/api/tool/my-client-auth-search-catalog-tool/invoke",
+			requestHeader: map[string]string{"Authorization": accessToken},
+			requestBody:   bytes.NewBuffer([]byte(fmt.Sprintf("{\"prompt\":\"%s\", \"types\":[\"TABLE\"], \"%s\":[\"%s\"]}", params.TargetName, params.ContainerParamName, params.ContainerName))),
+			isErr:         false,
+		},
+	}
+
+	for _, tc := range invokeTcs {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, tc.api, tc.requestBody)
+			if err != nil {
+				t.Fatalf("unable to create request: %s", err)
+			}
+			req.Header.Add("Content-type", "application/json")
+			for k, v := range tc.requestHeader {
+				req.Header.Add(k, v)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("unable to send request: %s", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				if tc.isErr {
+					return
+				}
+				bodyBytes, _ := io.ReadAll(resp.Body)
+				t.Fatalf("response status code is not 200, got %d: %s", resp.StatusCode, string(bodyBytes))
+			}
+
+			var result map[string]interface{}
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				t.Fatalf("error parsing response body: %s", err)
+			}
+			resultStr, ok := result["result"].(string)
+			if !ok {
+				if result["result"] == nil && tc.isErr {
+					return
+				}
+				t.Fatalf("expected 'result' field to be a string, got %T", result["result"])
+			}
+
+			var errorCheck map[string]any
+			if err := json.Unmarshal([]byte(resultStr), &errorCheck); err == nil {
+				if _, hasError := errorCheck["error"]; hasError {
+					if tc.isErr {
+						return
+					}
+					t.Fatalf("unexpected error object in result: %s", resultStr)
+				}
+			}
+
+			if tc.isErr && (resultStr == "" || resultStr == "[]") {
+				return
+			}
+
+			var entries []any
+			if err := json.Unmarshal([]byte(resultStr), &entries); err != nil {
+				t.Fatalf("error unmarshalling result string: %v. Raw string: %s", err, resultStr)
+			}
+
+			if !tc.isErr {
+				if len(entries) == 0 {
+					if params.AllowEmpty {
+						t.Logf("No entries found, skipping content verification")
+						return
+					}
+					t.Fatalf("expected entries, but got 0")
+				}
+
+				if !params.AllowEmpty && len(entries) != 1 {
+					t.Fatalf("expected exactly one entry, but got %d", len(entries))
+				}
+
+				entry, ok := entries[0].(map[string]interface{})
+				if !ok {
+					t.Fatalf("expected first entry to be a map, got %T", entries[0])
+				}
+
+				val, ok := entry[params.WantKey]
+				if !ok {
+					t.Fatalf("expected entry to have key '%s', but it was not found", params.WantKey)
+				}
+
+				if params.CheckValue {
+					if val != params.TargetName {
+						t.Fatalf("expected key '%s' to have value '%s', but got %s", params.WantKey, params.TargetName, val)
+					}
+				}
+			} else {
+				if len(entries) != 0 {
+					t.Fatalf("expected 0 entries, but got %d", len(entries))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

- Implements search tool for Spanner assets using Dataplex.
- Updates Spanner source to handle Dataplex clients with caching and OAuth.
- Adds prebuilt tool configurations for both GoogleSQL and PostgreSQL dialects.
- Includes tests and documentation.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
