### PR TITLE
feat(cloudsql): Implement search_catalog tool for Cloud SQL databases

### DIFF
--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -1770,7 +1770,7 @@ func TestPrebuiltTools(t *testing.T) {
 				},
 				"data": tools.ToolsetConfig{
 					Name:      "data",
-					ToolNames: []string{"execute_sql", "list_tables", "list_views", "list_schemas", "list_triggers", "list_indexes", "list_sequences", "list_stored_procedure"},
+					ToolNames: []string{"execute_sql", "list_tables", "list_views", "list_schemas", "list_triggers", "list_indexes", "list_sequences", "list_stored_procedure", "search_catalog"},
 				},
 				"monitor": tools.ToolsetConfig{
 					Name:      "monitor",
@@ -1804,7 +1804,7 @@ func TestPrebuiltTools(t *testing.T) {
 				},
 				"data": tools.ToolsetConfig{
 					Name:      "data",
-					ToolNames: []string{"execute_sql", "list_tables", "get_query_plan", "list_active_queries"},
+					ToolNames: []string{"execute_sql", "list_tables", "get_query_plan", "list_active_queries", "search_catalog"},
 				},
 				"monitor": tools.ToolsetConfig{
 					Name:      "monitor",
@@ -1826,7 +1826,7 @@ func TestPrebuiltTools(t *testing.T) {
 				},
 				"data": tools.ToolsetConfig{
 					Name:      "data",
-					ToolNames: []string{"execute_sql", "list_tables"},
+					ToolNames: []string{"execute_sql", "list_tables", "search_catalog"},
 				},
 				"monitor": tools.ToolsetConfig{
 					Name:      "monitor",

--- a/cmd/internal/imports.go
+++ b/cmd/internal/imports.go
@@ -74,6 +74,7 @@ import (
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/cloudsql/cloudsqllistdatabases"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/cloudsql/cloudsqllistinstances"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/cloudsql/cloudsqlrestorebackup"
+	_ "github.com/googleapis/mcp-toolbox/internal/tools/cloudsql/cloudsqlsearchcatalog"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/cloudsql/cloudsqlwaitforoperation"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/cloudsqladmin/cloudsqladminexecutemany"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/cloudsqladmin/cloudsqladminsqlmany"

--- a/docs/CLOUDSQLMSSQL_README.md
+++ b/docs/CLOUDSQLMSSQL_README.md
@@ -8,6 +8,7 @@ An editor configured to use the Cloud SQL for SQL Server MCP server can use its 
 
 - **Query Data** - Execute SQL queries
 - **Explore Schema** - List tables and view schema details
+- **Search Catalog** - Search for data assets in Knowledge Catalog (Dataplex)
 
 For Cloud SQL infrastructure management, search the MCP store for the Cloud SQL for SQL Server Admin MCP Server.
 
@@ -45,6 +46,7 @@ Once configured, the MCP server will automatically provide Cloud SQL for SQL Ser
 
 *   "Select top 10 rows from the customers table."
 *   "List all tables in the database."
+*   "Search for tables related to customers in the catalog."
 
 ## Server Capabilities
 
@@ -54,6 +56,7 @@ The Cloud SQL for SQL Server MCP server provides the following tools:
 |:--------------|:-----------------------------------------------------------|
 | `execute_sql` | Use this tool to execute SQL.                              |
 | `list_tables` | Lists detailed schema information for user-created tables. |
+| `search_catalog` | Searches for data assets in Knowledge Catalog (Dataplex). |
 
 ## Custom MCP Server Configuration
 

--- a/docs/CLOUDSQLMYSQL_README.md
+++ b/docs/CLOUDSQLMYSQL_README.md
@@ -9,6 +9,7 @@ An editor configured to use the Cloud SQL for MySQL MCP server can use its AI ca
 - **Query Data** - Execute SQL queries and analyze query plans
 - **Explore Schema** - List tables and view schema details
 - **Database Maintenance** - Check for fragmentation and missing indexes
+- **Search Catalog** - Search for data assets in Knowledge Catalog (Dataplex)
 - **Monitor Performance** - View active queries
 
 For Cloud SQL infrastructure management, search the MCP store for the Cloud SQL for MySQL Admin MCP Server.
@@ -47,6 +48,7 @@ Once configured, the MCP server will automatically provide Cloud SQL for MySQL c
 
 *   "Show me the schema for the 'orders' table."
 *   "List the top 10 active queries."
+*   "Search for tables related to customers in the catalog."
 *   "Check for tables missing unique indexes."
 
 ## Server Capabilities
@@ -57,6 +59,7 @@ The Cloud SQL for MySQL MCP server provides the following tools:
 |:-------------------------------------|:------------------------------------------------------------------------|
 | `execute_sql`                        | Use this tool to execute SQL.                                           |
 | `list_active_queries`                | Lists top N ongoing queries from processlist and innodb_trx.            |
+| `search_catalog`                      | Searches for data assets in Knowledge Catalog (Dataplex).               |
 | `get_query_plan`                     | Provide information about how MySQL executes a SQL statement (EXPLAIN). |
 | `list_tables`                        | Lists detailed schema information for user-created tables.              |
 | `list_tables_missing_unique_indexes` | Find tables that do not have primary or unique key constraint.          |

--- a/docs/CLOUDSQLPG_README.md
+++ b/docs/CLOUDSQLPG_README.md
@@ -10,6 +10,7 @@ An editor configured to use the Cloud SQL for PostgreSQL MCP server can use its 
 - **Explore Schema** - List tables, views, indexes, and triggers
 - **Monitor Performance** - View active queries, bloat, and memory configurations
 - **Manage Extensions** - List available and installed extensions
+- **Search Catalog** - Search for data assets in Knowledge Catalog (Dataplex)
 
 For Cloud SQL infrastructure management, search the MCP store for the Cloud SQL for PostgreSQL Admin MCP Server.
 
@@ -47,6 +48,7 @@ Once configured, the MCP server will automatically provide Cloud SQL for Postgre
 
 *   "Show me the top 5 bloated tables."
 *   "List all installed extensions."
+*   "Search for tables related to customers in the catalog."
 *   "Explain the query plan for SELECT * FROM users."
 
 ## Server Capabilities
@@ -57,6 +59,7 @@ The Cloud SQL for PostgreSQL MCP server provides the following tools:
 |:---------------------------------|:---------------------------------------------------------------|
 | `execute_sql`                    | Use this tool to execute sql.                                  |
 | `list_tables`                    | Lists detailed schema information for user-created tables.     |
+| `search_catalog`                  | Searches for data assets in Knowledge Catalog (Dataplex).      |
 | `list_active_queries`            | List the top N currently running queries.                      |
 | `list_available_extensions`      | Discover all PostgreSQL extensions available for installation. |
 | `list_installed_extensions`      | List all installed PostgreSQL extensions.                      |

--- a/docs/en/integrations/cloud-sql-mssql/prebuilt-configs/cloud-sql-for-sql-server.md
+++ b/docs/en/integrations/cloud-sql-mssql/prebuilt-configs/cloud-sql-for-sql-server.md
@@ -24,3 +24,4 @@ description: "Details of the Cloud SQL for SQL Server prebuilt configuration."
 *   **Tools:**
     *   `execute_sql`: Executes a SQL query.
     *   `list_tables`: Lists tables in the database.
+    *   `search_catalog`: Searches for data assets in Knowledge Catalog (formerly known as Dataplex).

--- a/docs/en/integrations/cloud-sql-mysql/prebuilt-configs/cloud-sql-for-mysql.md
+++ b/docs/en/integrations/cloud-sql-mysql/prebuilt-configs/cloud-sql-for-mysql.md
@@ -31,3 +31,4 @@ description: "Details of the Cloud SQL for MySQL prebuilt configuration."
         primary or unique key contraint.
     *   `list_table_fragmentation`: Displays table fragmentation in MySQL.
     *   `list_table_stats`: Displays table statistics in MySQL.
+    *   `search_catalog`: Searches for data assets in Knowledge Catalog (formerly known as Dataplex).

--- a/docs/en/integrations/cloud-sql-pg/prebuilt-configs/cloud-sql-for-postgresql.md
+++ b/docs/en/integrations/cloud-sql-pg/prebuilt-configs/cloud-sql-for-postgresql.md
@@ -57,3 +57,4 @@ description: "Details of the Cloud SQL for PostgreSQL prebuilt configuration."
         each database in the postgreSQL instance.
     *   `list_roles`: Lists all the user-created roles in PostgreSQL database.
     *   `list_stored_procedure`: Lists stored procedures.
+    *   `search_catalog`: Searches for data assets in Knowledge Catalog (formerly known as Dataplex).

--- a/docs/en/integrations/mssql/tools/mssql-search-catalog.md
+++ b/docs/en/integrations/mssql/tools/mssql-search-catalog.md
@@ -1,0 +1,65 @@
+---
+title: "mssql-search-catalog"
+type: docs
+weight: 1
+description: >
+  A "mssql-search-catalog" tool allows to search for entries based on the provided query.
+---
+
+## About
+
+A `mssql-search-catalog` tool returns all entries in Knowledge Catalog (e.g.
+tables, views, databases) with system=MSSQL that matches given user query.
+
+`mssql-search-catalog` takes a required `prompt` parameter based on which
+entries are filtered and returned to the user. It also optionally accepts
+following parameters:
+
+- `databaseIds` - The IDs of the mssql database.
+- `projectIds` - The IDs of the GCP project.
+- `types` - The type of the data. Accepted values are: DATABASE, TABLE, VIEW.
+- `pageSize` - Number of results in the search page. Defaults to `5`.
+
+## Compatible Sources
+
+{{< compatible-sources >}}
+
+## Requirements
+
+### IAM Permissions
+
+MSSQL uses [Identity and Access Management (IAM)][iam-overview] to control
+user and group access to Knowledge Catalog (formerly known as Dataplex) resources. Toolbox will use your
+[Application Default Credentials (ADC)][adc] to authorize and authenticate when
+interacting with [Knowledge Catalog][dataplex-docs].
+
+In addition to [setting the ADC for your server][set-adc], you need to ensure
+the IAM identity has been given the correct IAM permissions for the tasks you
+intend to perform. See [Knowledge Catalog IAM permissions][iam-permissions]
+and [Knowledge Catalog IAM roles][iam-roles] for more information on
+applying IAM permissions and roles to an identity.
+
+[iam-overview]: https://cloud.google.com/dataplex/docs/iam-and-access-control
+[adc]: https://cloud.google.com/docs/authentication#adc
+[set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[iam-permissions]: https://cloud.google.com/dataplex/docs/iam-permissions
+[iam-roles]: https://cloud.google.com/dataplex/docs/iam-roles
+[dataplex-docs]: https://cloud.google.com/dataplex/docs
+
+## Example
+
+```yaml
+kind: tool
+name: search_catalog
+type: mssql-search-catalog
+source: cloudsql-mssql-source
+description: Searches for data assets (eg. MSSQL tables, views, or databases) in catalog based on the provided search query
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| type        |                   string                   |     true     | Must be "mssql-search-catalog".                                                               |
+| source      |                   string                   |     true     | Name of the source the tool should execute on.                                                   |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |

--- a/docs/en/integrations/mysql/tools/mysql-search-catalog.md
+++ b/docs/en/integrations/mysql/tools/mysql-search-catalog.md
@@ -1,0 +1,65 @@
+---
+title: "mysql-search-catalog"
+type: docs
+weight: 1
+description: >
+  A "mysql-search-catalog" tool allows to search for entries based on the provided query.
+---
+
+## About
+
+A `mysql-search-catalog` tool returns all entries in Knowledge Catalog (e.g.
+tables, views, databases) with system=MySQL that matches given user query.
+
+`mysql-search-catalog` takes a required `prompt` parameter based on which
+entries are filtered and returned to the user. It also optionally accepts
+following parameters:
+
+- `databaseIds` - The IDs of the mysql database.
+- `projectIds` - The IDs of the GCP project.
+- `types` - The type of the data. Accepted values are: DATABASE, TABLE, VIEW.
+- `pageSize` - Number of results in the search page. Defaults to `5`.
+
+## Compatible Sources
+
+{{< compatible-sources >}}
+
+## Requirements
+
+### IAM Permissions
+
+MySQL uses [Identity and Access Management (IAM)][iam-overview] to control
+user and group access to Knowledge Catalog (formerly known as Dataplex) resources. Toolbox will use your
+[Application Default Credentials (ADC)][adc] to authorize and authenticate when
+interacting with [Knowledge Catalog][dataplex-docs].
+
+In addition to [setting the ADC for your server][set-adc], you need to ensure
+the IAM identity has been given the correct IAM permissions for the tasks you
+intend to perform. See [Knowledge Catalog IAM permissions][iam-permissions]
+and [Knowledge Catalog IAM roles][iam-roles] for more information on
+applying IAM permissions and roles to an identity.
+
+[iam-overview]: https://cloud.google.com/dataplex/docs/iam-and-access-control
+[adc]: https://cloud.google.com/docs/authentication#adc
+[set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[iam-permissions]: https://cloud.google.com/dataplex/docs/iam-permissions
+[iam-roles]: https://cloud.google.com/dataplex/docs/iam-roles
+[dataplex-docs]: https://cloud.google.com/dataplex/docs
+
+## Example
+
+```yaml
+kind: tool
+name: search_catalog
+type: mysql-search-catalog
+source: cloud-sql-mysql-source
+description: Searches for data assets (eg. MySQL tables, views, or databases) in catalog based on the provided search query
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| type        |                   string                   |     true     | Must be "mysql-search-catalog".                                                               |
+| source      |                   string                   |     true     | Name of the source the tool should execute on.                                                   |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |

--- a/docs/en/integrations/postgres/tools/postgres-search-catalog.md
+++ b/docs/en/integrations/postgres/tools/postgres-search-catalog.md
@@ -1,0 +1,65 @@
+---
+title: "postgres-search-catalog"
+type: docs
+weight: 1
+description: >
+  A "postgres-search-catalog" tool allows to search for entries based on the provided query.
+---
+
+## About
+
+A `postgres-search-catalog` tool returns all entries in Knowledge Catalog (e.g.
+tables, views, databases) with system=PostgreSQL that matches given user query.
+
+`postgres-search-catalog` takes a required `prompt` parameter based on which
+entries are filtered and returned to the user. It also optionally accepts
+following parameters:
+
+- `databaseIds` - The IDs of the postgres database.
+- `projectIds` - The IDs of the GCP project.
+- `types` - The type of the data. Accepted values are: DATABASE, TABLE, VIEW.
+- `pageSize` - Number of results in the search page. Defaults to `5`.
+
+## Compatible Sources
+
+{{< compatible-sources >}}
+
+## Requirements
+
+### IAM Permissions
+
+Postgres uses [Identity and Access Management (IAM)][iam-overview] to control
+user and group access to Knowledge Catalog (formerly known as Dataplex) resources. Toolbox will use your
+[Application Default Credentials (ADC)][adc] to authorize and authenticate when
+interacting with [Knowledge Catalog][dataplex-docs].
+
+In addition to [setting the ADC for your server][set-adc], you need to ensure
+the IAM identity has been given the correct IAM permissions for the tasks you
+intend to perform. See [Knowledge Catalog IAM permissions][iam-permissions]
+and [Knowledge Catalog IAM roles][iam-roles] for more information on
+applying IAM permissions and roles to an identity.
+
+[iam-overview]: https://cloud.google.com/dataplex/docs/iam-and-access-control
+[adc]: https://cloud.google.com/docs/authentication#adc
+[set-adc]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[iam-permissions]: https://cloud.google.com/dataplex/docs/iam-permissions
+[iam-roles]: https://cloud.google.com/dataplex/docs/iam-roles
+[dataplex-docs]: https://cloud.google.com/dataplex/docs
+
+## Example
+
+```yaml
+kind: tool
+name: search_catalog
+type: postgres-search-catalog
+source: cloudsql-pg-source
+description: Searches for data assets (eg. Postgres tables, views, or databases) in catalog based on the provided search query
+```
+
+## Reference
+
+| **field**   |                  **type**                  | **required** | **description**                                                                                  |
+|-------------|:------------------------------------------:|:------------:|--------------------------------------------------------------------------------------------------|
+| type        |                   string                   |     true     | Must be "postgres-search-catalog".                                                               |
+| source      |                   string                   |     true     | Name of the source the tool should execute on.                                                   |
+| description |                   string                   |     true     | Description of the tool that is passed to the LLM.                                               |

--- a/internal/prebuiltconfigs/tools/cloud-sql-mssql.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-mssql.yaml
@@ -152,6 +152,12 @@ type: cloud-sql-wait-for-operation
 source: cloud-sql-admin-source
 multiplier: 4
 ---
+kind: tool
+name: search_catalog
+type: mssql-search-catalog
+source: cloudsql-mssql-source
+description: Searches for data assets (eg. MSSQL tables, views, or databases) in catalog based on the provided search query
+---
 kind: toolset
 name: admin
 tools:
@@ -168,6 +174,13 @@ name: data
 tools:
 - execute_sql
 - list_tables
+---
+kind: toolset
+name: data_with_discovery
+tools:
+- execute_sql
+- list_tables
+- search_catalog
 ---
 kind: toolset
 name: monitor

--- a/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
@@ -217,6 +217,12 @@ name: list_databases
 type: cloud-sql-list-databases
 source: cloud-sql-admin-source
 ---
+kind: tool
+name: search_catalog
+type: mysql-search-catalog
+source: cloud-sql-mysql-source
+description: Searches for data assets (eg. MySQL tables, views, or databases) in catalog based on the provided search query
+---
 kind: toolset
 name: admin
 tools:
@@ -235,6 +241,15 @@ tools:
 - list_tables
 - get_query_plan
 - list_active_queries
+---
+kind: toolset
+name: data_with_discovery
+tools:
+- execute_sql
+- list_tables
+- get_query_plan
+- list_active_queries
+- search_catalog
 ---
 kind: toolset
 name: monitor

--- a/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
@@ -457,6 +457,12 @@ name: improve_query_recall
 type: vector-assist-improve-query-recall
 source: cloudsql-pg-source
 ---
+kind: tool
+name: search_catalog
+type: postgres-search-catalog
+source: cloudsql-pg-source
+description: Searches for data assets (eg. Postgres tables, views, or databases) in catalog based on the provided search query
+---
 kind: toolset
 name: admin
 tools:
@@ -491,6 +497,19 @@ tools:
 - list_indexes
 - list_sequences
 - list_stored_procedure
+---
+kind: toolset
+name: data_with_discovery
+tools:
+- execute_sql
+- list_tables
+- list_views
+- list_schemas
+- list_triggers
+- list_indexes
+- list_sequences
+- list_stored_procedure
+- search_catalog
 ---
 kind: toolset
 name: monitor

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
@@ -22,8 +22,10 @@ import (
 	"slices"
 
 	"cloud.google.com/go/cloudsqlconn/sqlserver/mssql"
+	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/sources/sqlcommenter"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/orderedmap"
@@ -51,15 +53,16 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 
 type Config struct {
 	// Cloud SQL MSSQL configs
-	Name     string         `yaml:"name" validate:"required"`
-	Type     string         `yaml:"type" validate:"required"`
-	Project  string         `yaml:"project" validate:"required"`
-	Region   string         `yaml:"region" validate:"required"`
-	Instance string         `yaml:"instance" validate:"required"`
-	IPType   sources.IPType `yaml:"ipType" validate:"required"`
-	User     string         `yaml:"user" validate:"required"`
-	Password string         `yaml:"password" validate:"required"`
-	Database string         `yaml:"database" validate:"required"`
+	Name           string         `yaml:"name" validate:"required"`
+	Type           string         `yaml:"type" validate:"required"`
+	Project        string         `yaml:"project" validate:"required"`
+	Region         string         `yaml:"region" validate:"required"`
+	Instance       string         `yaml:"instance" validate:"required"`
+	IPType         sources.IPType `yaml:"ipType" validate:"required"`
+	User           string         `yaml:"user" validate:"required"`
+	Password       string         `yaml:"password" validate:"required"`
+	Database       string         `yaml:"database" validate:"required"`
+	UseClientOAuth bool           `yaml:"useClientOAuth"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -80,9 +83,19 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 
+	onDataplexEvict := func(key string, value interface{}) {
+		if client, ok := value.(*dataplexapi.CatalogClient); ok && client != nil {
+			client.Close()
+		}
+	}
+
 	s := &Source{
 		Config: r,
 		Db:     db,
+		dataplexMgr: &searchcatalog.DataplexClientManager{
+			UseClientOAuth: r.UseClientOAuth,
+			Cache:          sources.NewCache(onDataplexEvict),
+		},
 	}
 	return s, nil
 }
@@ -91,7 +104,8 @@ var _ sources.Source = &Source{}
 
 type Source struct {
 	Config
-	Db *sql.DB
+	Db          *sql.DB
+	dataplexMgr *searchcatalog.DataplexClientManager
 }
 
 func (s *Source) SourceType() string {
@@ -196,4 +210,38 @@ func initCloudSQLMssqlConnection(ctx context.Context, tracer trace.Tracer, name,
 		return nil, err
 	}
 	return db, nil
+}
+
+func (s *Source) ProjectID() string {
+	return s.Config.Project
+}
+
+func (s *Source) UseClientAuthorization() bool {
+	return s.Config.UseClientOAuth
+}
+
+func (s *Source) GetCatalogClient(ctx context.Context, tokenString string) (*dataplexapi.CatalogClient, error) {
+	return s.dataplexMgr.GetCatalogClient(ctx, tokenString)
+}
+
+func (s *Source) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	typeMap := map[string]string{
+		"cloudsql-sqlserver-instance": "SERVICE",
+		"cloudsql-sqlserver-database": "DATABASE",
+		"cloudsql-sqlserver-schema":   "DATABASE_SCHEMA",
+		"cloudsql-sqlserver-table":    "TABLE",
+		"cloudsql-sqlserver-view":     "VIEW",
+	}
+	return searchcatalog.InvokeSearchCatalog(
+		ctx,
+		params,
+		tokenStr,
+		"CLOUD_SQL",
+		"databaseIds",
+		typeMap,
+		s.ProjectID(),
+		func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error) {
+			return s.GetCatalogClient(ctx, token)
+		},
+	)
 }

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -22,8 +22,10 @@ import (
 	"slices"
 
 	"cloud.google.com/go/cloudsqlconn/mysql/mysql"
+	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/sources/sqlcommenter"
 	"github.com/googleapis/mcp-toolbox/internal/tools/mysql/mysqlcommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -51,15 +53,16 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string         `yaml:"name" validate:"required"`
-	Type     string         `yaml:"type" validate:"required"`
-	Project  string         `yaml:"project" validate:"required"`
-	Region   string         `yaml:"region" validate:"required"`
-	Instance string         `yaml:"instance" validate:"required"`
-	IPType   sources.IPType `yaml:"ipType"`
-	User     string         `yaml:"user"`
-	Password string         `yaml:"password"`
-	Database string         `yaml:"database"`
+	Name           string         `yaml:"name" validate:"required"`
+	Type           string         `yaml:"type" validate:"required"`
+	Project        string         `yaml:"project" validate:"required"`
+	Region         string         `yaml:"region" validate:"required"`
+	Instance       string         `yaml:"instance" validate:"required"`
+	IPType         sources.IPType `yaml:"ipType"`
+	User           string         `yaml:"user"`
+	Password       string         `yaml:"password"`
+	Database       string         `yaml:"database"`
+	UseClientOAuth bool           `yaml:"useClientOAuth"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -77,9 +80,19 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 
+	onDataplexEvict := func(key string, value interface{}) {
+		if client, ok := value.(*dataplexapi.CatalogClient); ok && client != nil {
+			client.Close()
+		}
+	}
+
 	s := &Source{
 		Config: r,
 		Pool:   pool,
+		dataplexMgr: &searchcatalog.DataplexClientManager{
+			UseClientOAuth: r.UseClientOAuth,
+			Cache:          sources.NewCache(onDataplexEvict),
+		},
 	}
 	return s, nil
 }
@@ -88,7 +101,8 @@ var _ sources.Source = &Source{}
 
 type Source struct {
 	Config
-	Pool *sql.DB
+	Pool        *sql.DB
+	dataplexMgr *searchcatalog.DataplexClientManager
 }
 
 func (s *Source) SourceType() string {
@@ -251,4 +265,37 @@ func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, n
 		return nil, err
 	}
 	return db, nil
+}
+
+func (s *Source) ProjectID() string {
+	return s.Config.Project
+}
+
+func (s *Source) UseClientAuthorization() bool {
+	return s.Config.UseClientOAuth
+}
+
+func (s *Source) GetCatalogClient(ctx context.Context, tokenString string) (*dataplexapi.CatalogClient, error) {
+	return s.dataplexMgr.GetCatalogClient(ctx, tokenString)
+}
+
+func (s *Source) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	typeMap := map[string]string{
+		"cloudsql-mysql-instance": "SERVICE",
+		"cloudsql-mysql-database": "DATABASE",
+		"cloudsql-mysql-table":    "TABLE",
+		"cloudsql-mysql-view":     "VIEW",
+	}
+	return searchcatalog.InvokeSearchCatalog(
+		ctx,
+		params,
+		tokenStr,
+		"CLOUD_SQL",
+		"databaseIds",
+		typeMap,
+		s.ProjectID(),
+		func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error) {
+			return s.GetCatalogClient(ctx, token)
+		},
+	)
 }

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -20,8 +20,10 @@ import (
 	"net"
 
 	"cloud.google.com/go/cloudsqlconn"
+	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/sources/sqlcommenter"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/orderedmap"
@@ -49,15 +51,16 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name     string         `yaml:"name" validate:"required"`
-	Type     string         `yaml:"type" validate:"required"`
-	Project  string         `yaml:"project" validate:"required"`
-	Region   string         `yaml:"region" validate:"required"`
-	Instance string         `yaml:"instance" validate:"required"`
-	IPType   sources.IPType `yaml:"ipType" validate:"required"`
-	Database string         `yaml:"database" validate:"required"`
-	User     string         `yaml:"user"`
-	Password string         `yaml:"password"`
+	Name           string         `yaml:"name" validate:"required"`
+	Type           string         `yaml:"type" validate:"required"`
+	Project        string         `yaml:"project" validate:"required"`
+	Region         string         `yaml:"region" validate:"required"`
+	Instance       string         `yaml:"instance" validate:"required"`
+	IPType         sources.IPType `yaml:"ipType" validate:"required"`
+	Database       string         `yaml:"database" validate:"required"`
+	User           string         `yaml:"user"`
+	Password       string         `yaml:"password"`
+	UseClientOAuth bool           `yaml:"useClientOAuth"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -83,9 +86,19 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 		return nil, fmt.Errorf("failed to execute 'SELECT 1' after connection: %w", err)
 	}
 
+	onDataplexEvict := func(key string, value interface{}) {
+		if client, ok := value.(*dataplexapi.CatalogClient); ok && client != nil {
+			client.Close()
+		}
+	}
+
 	s := &Source{
 		Config: r,
 		Pool:   pool,
+		dataplexMgr: &searchcatalog.DataplexClientManager{
+			UseClientOAuth: r.UseClientOAuth,
+			Cache:          sources.NewCache(onDataplexEvict),
+		},
 	}
 	return s, nil
 }
@@ -94,7 +107,8 @@ var _ sources.Source = &Source{}
 
 type Source struct {
 	Config
-	Pool *pgxpool.Pool
+	Pool        *pgxpool.Pool
+	dataplexMgr *searchcatalog.DataplexClientManager
 }
 
 func (s *Source) SourceType() string {
@@ -212,4 +226,38 @@ func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name
 		return nil, err
 	}
 	return pool, nil
+}
+
+func (s *Source) ProjectID() string {
+	return s.Config.Project
+}
+
+func (s *Source) UseClientAuthorization() bool {
+	return s.Config.UseClientOAuth
+}
+
+func (s *Source) GetCatalogClient(ctx context.Context, tokenString string) (*dataplexapi.CatalogClient, error) {
+	return s.dataplexMgr.GetCatalogClient(ctx, tokenString)
+}
+
+func (s *Source) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	typeMap := map[string]string{
+		"cloudsql-postgresql-instance": "SERVICE",
+		"cloudsql-postgresql-database": "DATABASE",
+		"cloudsql-postgresql-schema":   "DATABASE_SCHEMA",
+		"cloudsql-postgresql-table":    "TABLE",
+		"cloudsql-postgresql-view":     "VIEW",
+	}
+	return searchcatalog.InvokeSearchCatalog(
+		ctx,
+		params,
+		tokenStr,
+		"CLOUD_SQL",
+		"databaseIds",
+		typeMap,
+		s.ProjectID(),
+		func(ctx context.Context, token string) (*dataplexapi.CatalogClient, error) {
+			return s.GetCatalogClient(ctx, token)
+		},
+	)
 }

--- a/internal/sources/dataplex/searchcatalog/search_catalog.go
+++ b/internal/sources/dataplex/searchcatalog/search_catalog.go
@@ -70,7 +70,7 @@ func ConstructSearchQuery(prompt string, projectIds []string, parentIds []string
 		queryParts = append(queryParts, clause)
 	}
 
-	if clause := ConstructSearchQueryHelper("parent", "=", parentIds); clause != "" {
+	if clause := ConstructSearchQueryHelper("parent", ":", parentIds); clause != "" {
 		queryParts = append(queryParts, clause)
 	}
 

--- a/internal/sources/dataplex/searchcatalog/search_catalog_test.go
+++ b/internal/sources/dataplex/searchcatalog/search_catalog_test.go
@@ -98,7 +98,7 @@ func TestConstructSearchQuery(t *testing.T) {
 			parentIds:  []string{"d1"},
 			types:      []string{"t1"},
 			system:     "sys1",
-			want:       "search projectid=p1 AND parent=d1 AND type=t1 AND system=sys1",
+			want:       "search projectid=p1 AND parent:d1 AND type=t1 AND system=sys1",
 		},
 		{
 			name:       "with multiple items",
@@ -107,7 +107,7 @@ func TestConstructSearchQuery(t *testing.T) {
 			parentIds:  []string{"d1"},
 			types:      []string{},
 			system:     "",
-			want:       "search (projectid=p1 OR projectid=p2) AND parent=d1",
+			want:       "search (projectid=p1 OR projectid=p2) AND parent:d1",
 		},
 	}
 

--- a/internal/tools/cloudsql/cloudsqlsearchcatalog/cloudsqlsearchcatalog.go
+++ b/internal/tools/cloudsql/cloudsqlsearchcatalog/cloudsqlsearchcatalog.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlsearchcatalog
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+func init() {
+	tools.Register("mssql-search-catalog", newConfig)
+	tools.Register("mysql-search-catalog", newConfig)
+	tools.Register("postgres-search-catalog", newConfig)
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{Name: name}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+type compatibleSource interface {
+	ProjectID() string
+	UseClientAuthorization() bool
+	InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error)
+}
+
+type Config struct {
+	Name           string                 `yaml:"name" validate:"required"`
+	Type           string                 `yaml:"type" validate:"required"`
+	Source         string                 `yaml:"source" validate:"required"`
+	Description    string                 `yaml:"description"`
+	AuthRequired   []string               `yaml:"authRequired"`
+	Annotations    *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	ScopesRequired []string               `yaml:"scopesRequired"`
+}
+
+// validate interface
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigType() string {
+	return cfg.Type
+}
+
+func (cfg Config) Initialize(srcs map[string]sources.Source) (tools.Tool, error) {
+	prompt := parameters.NewStringParameter("prompt", "Prompt representing search intention. Do not rewrite the prompt.")
+	databaseIds := parameters.NewArrayParameterWithDefault("databaseIds", []any{}, "Array of database IDs.", parameters.NewStringParameter("databaseId", "The IDs of the database."))
+	projectIds := parameters.NewArrayParameterWithDefault("projectIds", []any{}, "Array of project IDs.", parameters.NewStringParameter("projectId", "The IDs of the GCP project."))
+	types := parameters.NewArrayParameterWithDefault("types", []any{}, "Array of data types to filter by.", parameters.NewStringParameter("type", "The type of the data. Accepted values are: SERVICE, DATABASE, DATABASE_SCHEMA, TABLE, VIEW."))
+	pageSize := parameters.NewIntParameterWithDefault("pageSize", 5, "Number of results in the search page.")
+	params := parameters.Parameters{prompt, databaseIds, projectIds, types, pageSize}
+
+	description := "Searches for data assets in catalog based on the provided search query"
+	if cfg.Description != "" {
+		description = cfg.Description
+	}
+	t := Tool{
+		Config:     cfg,
+		Parameters: params,
+		manifest: tools.Manifest{
+			Description:  description,
+			Parameters:   params.Manifest(),
+			AuthRequired: cfg.AuthRequired,
+		},
+	}
+	return t, nil
+}
+
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	Config
+	Parameters parameters.Parameters
+	manifest   tools.Manifest
+}
+
+func (t Tool) ToConfig() tools.ToolConfig {
+	return t.Config
+}
+
+func (t Tool) Authorized(verifiedAuthServices []string) bool {
+	return tools.IsAuthorized(t.AuthRequired, verifiedAuthServices)
+}
+
+func (t Tool) RequiresClientAuthorization(resourceMgr tools.SourceProvider) (bool, error) {
+	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Source, t.Name, t.Type)
+	if err != nil {
+		return false, err
+	}
+	return source.UseClientAuthorization(), nil
+}
+
+func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, err := tools.GetCompatibleSource[compatibleSource](resourceMgr, t.Source, t.Name, t.Type)
+	if err != nil {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+	}
+
+	var tokenStr string
+	if source.UseClientAuthorization() {
+		tokenStr, err = accessToken.ParseBearerToken()
+		if err != nil {
+			return nil, util.NewClientServerError("failed to parse access token", http.StatusInternalServerError, err)
+		}
+	}
+
+	results, err := source.InvokeSearchCatalog(ctx, params.AsMap(), tokenStr)
+	if err != nil {
+		return nil, util.ProcessGcpError(err)
+	}
+
+	return results, nil
+}
+
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.Parameters, paramValues, embeddingModelsMap, nil)
+}
+
+func (t Tool) Manifest() tools.Manifest {
+	return t.manifest
+}
+
+func (t Tool) GetName() string {
+	return t.Name
+}
+
+func (t Tool) GetDescription() string {
+	return t.Description
+}
+
+func (t Tool) GetAuthRequired() []string {
+	return t.AuthRequired
+}
+
+func (t Tool) GetAnnotations() *tools.ToolAnnotations {
+	return tools.GetAnnotationsOrDefault(t.Annotations, tools.NewReadOnlyAnnotations)
+}
+
+func (t Tool) GetScopesRequired() []string {
+	return t.ScopesRequired
+}
+
+func (t Tool) GetAuthTokenHeaderName(resourceMgr tools.SourceProvider) (string, error) {
+	return "", nil
+}
+
+func (t Tool) GetParameters() parameters.Parameters {
+	return t.Parameters
+}

--- a/internal/tools/cloudsql/cloudsqlsearchcatalog/cloudsqlsearchcatalog_test.go
+++ b/internal/tools/cloudsql/cloudsqlsearchcatalog/cloudsqlsearchcatalog_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudsqlsearchcatalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/tools/cloudsql/cloudsqlsearchcatalog"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+func TestParseFromYamlCloudSQLSearch(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		desc string
+		in   string
+		want server.ToolConfigs
+	}{
+		{
+			desc: "mysql example",
+			in: `
+            kind: tool
+            name: example_tool
+            type: mysql-search-catalog
+            source: my-instance
+            description: some description
+            `,
+			want: server.ToolConfigs{
+				"example_tool": cloudsqlsearchcatalog.Config{
+					Name:         "example_tool",
+					Type:         "mysql-search-catalog",
+					Source:       "my-instance",
+					Description:  "some description",
+					AuthRequired: []string{},
+				},
+			},
+		},
+		{
+			desc: "mssql example",
+			in: `
+            kind: tool
+            name: example_tool_mssql
+            type: mssql-search-catalog
+            source: my-mssql-instance
+            description: some mssql description
+            `,
+			want: server.ToolConfigs{
+				"example_tool_mssql": cloudsqlsearchcatalog.Config{
+					Name:         "example_tool_mssql",
+					Type:         "mssql-search-catalog",
+					Source:       "my-mssql-instance",
+					Description:  "some mssql description",
+					AuthRequired: []string{},
+				},
+			},
+		},
+		{
+			desc: "postgres example",
+			in: `
+            kind: tool
+            name: example_tool_pg
+            type: postgres-search-catalog
+            source: my-pg-instance
+            description: some pg description
+            `,
+			want: server.ToolConfigs{
+				"example_tool_pg": cloudsqlsearchcatalog.Config{
+					Name:         "example_tool_pg",
+					Type:         "postgres-search-catalog",
+					Source:       "my-pg-instance",
+					Description:  "some pg description",
+					AuthRequired: []string{},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Parse contents
+			_, _, _, got, _, _, err := server.UnmarshalResourceConfig(ctx, testutils.FormatYaml(tc.in))
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("incorrect parse: diff %v", diff)
+			}
+		})
+	}
+}
+
+type mockCloudSQLSource struct {
+	projectID              string
+	useClientAuthorization bool
+	searchResponse         []searchcatalog.DataplexSearchResponse
+	err                    error
+}
+
+func (m mockCloudSQLSource) ProjectID() string            { return m.projectID }
+func (m mockCloudSQLSource) UseClientAuthorization() bool { return m.useClientAuthorization }
+func (m mockCloudSQLSource) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
+	return m.searchResponse, m.err
+}
+func (m mockCloudSQLSource) SourceType() string             { return "cloud-sql-postgres" }
+func (m mockCloudSQLSource) ToConfig() sources.SourceConfig { return nil }
+
+type mockSourceProvider struct {
+	source sources.Source
+}
+
+func (m mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	if m.source != nil {
+		return m.source, true
+	}
+	return nil, false
+}
+
+func TestConfig_Initialize(t *testing.T) {
+	cfg := cloudsqlsearchcatalog.Config{
+		Name:        "test-tool",
+		Type:        "postgres-search-catalog",
+		Source:      "test-source",
+		Description: "Test description",
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	if tool.GetName() != "test-tool" {
+		t.Errorf("GetName() = %v, want %v", tool.GetName(), "test-tool")
+	}
+
+	if tool.GetDescription() != "Test description" {
+		t.Errorf("GetDescription() = %v, want %v", tool.GetDescription(), "Test description")
+	}
+}
+
+func TestTool_Invoke(t *testing.T) {
+	ctx := context.Background()
+	mockSource := mockCloudSQLSource{
+		searchResponse: []searchcatalog.DataplexSearchResponse{
+			{
+				DataplexEntry: "test-entry",
+			},
+		},
+	}
+	sourceProvider := mockSourceProvider{source: mockSource}
+
+	cfg := cloudsqlsearchcatalog.Config{
+		Name:   "test-tool",
+		Type:   "postgres-search-catalog",
+		Source: "test-source",
+	}
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	params := parameters.ParamValues{
+		{
+			Name:  "prompt",
+			Value: "test prompt",
+		},
+	}
+
+	resp, err := tool.Invoke(ctx, sourceProvider, params, tools.AccessToken(""))
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+
+	results, ok := resp.([]searchcatalog.DataplexSearchResponse)
+	if !ok {
+		t.Fatalf("expected []searchcatalog.DataplexSearchResponse, got %T", resp)
+	}
+
+	if len(results) != 1 || results[0].DataplexEntry != "test-entry" {
+		t.Errorf("unexpected results: %v", results)
+	}
+}

--- a/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
+++ b/tests/cloudsqlmssql/cloud_sql_mssql_integration_test.go
@@ -141,7 +141,7 @@ func TestCloudSQLMSSQLToolEndpoints(t *testing.T) {
 	toolsFile = tests.AddMSSQLExecuteSqlConfig(t, toolsFile)
 	tmplSelectCombined, tmplSelectFilterCombined := tests.GetMSSQLTmplToolStatement()
 	toolsFile = tests.AddTemplateParamConfig(t, toolsFile, CloudSQLMSSQLToolType, tmplSelectCombined, tmplSelectFilterCombined, "")
-	toolsFile = tests.AddMSSQLPrebuiltToolConfig(t, toolsFile)
+	toolsFile = addCloudSQLMSSQLSearchCatalogConfig(t, toolsFile)
 
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
@@ -169,6 +169,16 @@ func TestCloudSQLMSSQLToolEndpoints(t *testing.T) {
 
 	// Run specific MSSQL tool tests
 	tests.RunMSSQLListTablesTest(t, tableNameParam, tableNameAuth)
+
+	tests.RunSearchCatalogToolTest(t, tests.SearchCatalogTestParams{
+		ContainerParamName: "databaseIds",
+		ContainerName:      CloudSQLMSSQLDatabase,
+		ProjectID:          CloudSQLMSSQLProject,
+		TargetName:         tableNameParam,
+		WantKey:            "DisplayName",
+		AllowEmpty:         true,
+		CheckValue:         false,
+	})
 }
 
 // Test connection with different IP type
@@ -197,4 +207,52 @@ func TestCloudSQLMSSQLIpConnection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func addCloudSQLMSSQLSearchCatalogConfig(t *testing.T, config map[string]any) map[string]any {
+	config = tests.AddMSSQLPrebuiltToolConfig(t, config)
+	tools, ok := config["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get tools from config")
+	}
+	sources, ok := config["sources"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get sources from config")
+	}
+	myInstanceConfig, ok := sources["my-instance"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get my-instance from sources")
+	}
+
+	// Create a copy of the source config with client OAuth enabled
+	oauthSourceConfig := make(map[string]any)
+	for k, v := range myInstanceConfig {
+		oauthSourceConfig[k] = v
+	}
+	oauthSourceConfig["useClientOAuth"] = true
+	sources["my-oauth-instance"] = oauthSourceConfig
+
+	// Add tools
+	tools["my-search-catalog-tool"] = map[string]any{
+		"type":        "mssql-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+	}
+	tools["my-auth-search-catalog-tool"] = map[string]any{
+		"type":        "mssql-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+		"authRequired": []string{
+			"my-google-auth",
+		},
+	}
+	tools["my-client-auth-search-catalog-tool"] = map[string]any{
+		"type":        "mssql-search-catalog",
+		"source":      "my-oauth-instance",
+		"description": "Searches for data assets in catalog",
+	}
+
+	config["tools"] = tools
+	config["sources"] = sources
+	return config
 }

--- a/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
+++ b/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
@@ -134,6 +134,7 @@ func TestCloudSQLMySQLToolEndpoints(t *testing.T) {
 	tmplSelectCombined, tmplSelectFilterCombined := tests.GetMySQLTmplToolStatement()
 	toolsFile = tests.AddTemplateParamConfig(t, toolsFile, CloudSQLMySQLToolType, tmplSelectCombined, tmplSelectFilterCombined, "")
 	toolsFile = tests.AddMySQLPrebuiltToolConfig(t, toolsFile)
+	toolsFile = addCloudSQLMySQLSearchCatalogConfig(t, toolsFile)
 
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
@@ -165,6 +166,16 @@ func TestCloudSQLMySQLToolEndpoints(t *testing.T) {
 	tests.RunMySQLListActiveQueriesTest(t, ctx, pool)
 	tests.RunMySQLGetQueryPlanTest(t, ctx, pool, CloudSQLMySQLDatabase, tableNameParam)
 	tests.RunMySQLListTableStatsTest(t, ctx, pool, CloudSQLMySQLDatabase, tableNameParam, tableNameAuth)
+
+	tests.RunSearchCatalogToolTest(t, tests.SearchCatalogTestParams{
+		ContainerParamName: "databaseIds",
+		ContainerName:      CloudSQLMySQLDatabase,
+		ProjectID:          CloudSQLMySQLProject,
+		TargetName:         tableNameParam,
+		WantKey:            "DisplayName",
+		AllowEmpty:         true,
+		CheckValue:         false,
+	})
 }
 
 // Test connection with different IP type
@@ -295,4 +306,51 @@ func TestCloudSQLMySQLIAMConnection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func addCloudSQLMySQLSearchCatalogConfig(t *testing.T, config map[string]any) map[string]any {
+	tools, ok := config["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get tools from config")
+	}
+	sources, ok := config["sources"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get sources from config")
+	}
+	myInstanceConfig, ok := sources["my-instance"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get my-instance from sources")
+	}
+
+	// Create a copy of the source config with client OAuth enabled
+	oauthSourceConfig := make(map[string]any)
+	for k, v := range myInstanceConfig {
+		oauthSourceConfig[k] = v
+	}
+	oauthSourceConfig["useClientOAuth"] = true
+	sources["my-oauth-instance"] = oauthSourceConfig
+
+	// Add tools
+	tools["my-search-catalog-tool"] = map[string]any{
+		"type":        "mysql-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+	}
+	tools["my-auth-search-catalog-tool"] = map[string]any{
+		"type":        "mysql-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+		"authRequired": []string{
+			"my-google-auth",
+		},
+	}
+	tools["my-client-auth-search-catalog-tool"] = map[string]any{
+		"type":        "mysql-search-catalog",
+		"source":      "my-oauth-instance",
+		"description": "Searches for data assets in catalog",
+	}
+
+	config["tools"] = tools
+	config["sources"] = sources
+	return config
 }

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -152,6 +152,7 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 	toolsFile = tests.AddSemanticSearchConfig(t, toolsFile, CloudSQLPostgresToolType, insertStmt, searchStmt)
 
 	toolsFile = tests.AddPostgresPrebuiltConfig(t, toolsFile)
+	toolsFile = addCloudSQLPgSearchCatalogConfig(t, toolsFile)
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
 	if err != nil {
 		t.Fatalf("command initialization returned an error: %s", err)
@@ -200,6 +201,16 @@ func TestCloudSQLPgSimpleToolEndpoints(t *testing.T) {
 	tests.RunPostgresListRolesTest(t, ctx, pool)
 	tests.RunPostgresListStoredProcedureTest(t, ctx, pool)
 	tests.RunSemanticSearchToolInvokeTest(t, "[]", "", "The quick brown fox")
+
+	tests.RunSearchCatalogToolTest(t, tests.SearchCatalogTestParams{
+		ContainerParamName: "databaseIds",
+		ContainerName:      CloudSQLPostgresDatabase,
+		ProjectID:          CloudSQLPostgresProject,
+		TargetName:         tableNameParam,
+		WantKey:            "DisplayName",
+		AllowEmpty:         true,
+		CheckValue:         false,
+	})
 }
 
 // Test connection with different IP type
@@ -295,4 +306,51 @@ func TestCloudSQLPgIAMConnection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func addCloudSQLPgSearchCatalogConfig(t *testing.T, config map[string]any) map[string]any {
+	tools, ok := config["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get tools from config")
+	}
+	sources, ok := config["sources"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get sources from config")
+	}
+	myInstanceConfig, ok := sources["my-instance"].(map[string]any)
+	if !ok {
+		t.Fatalf("unable to get my-instance from sources")
+	}
+
+	// Create a copy of the source config with client OAuth enabled
+	oauthSourceConfig := make(map[string]any)
+	for k, v := range myInstanceConfig {
+		oauthSourceConfig[k] = v
+	}
+	oauthSourceConfig["useClientOAuth"] = true
+	sources["my-oauth-instance"] = oauthSourceConfig
+
+	// Add tools
+	tools["my-search-catalog-tool"] = map[string]any{
+		"type":        "postgres-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+	}
+	tools["my-auth-search-catalog-tool"] = map[string]any{
+		"type":        "postgres-search-catalog",
+		"source":      "my-instance",
+		"description": "Searches for data assets in catalog",
+		"authRequired": []string{
+			"my-google-auth",
+		},
+	}
+	tools["my-client-auth-search-catalog-tool"] = map[string]any{
+		"type":        "postgres-search-catalog",
+		"source":      "my-oauth-instance",
+		"description": "Searches for data assets in catalog",
+	}
+
+	config["tools"] = tools
+	config["sources"] = sources
+	return config
 }


### PR DESCRIPTION
## Description


- Add `cloudsqlsearchcatalog` tool utilizing Dataplex SearchEntries API.
- Integrate search tool into Cloud SQL MSSQL, MySQL, and Postgres sources.
- Update prebuilt configs to include `search_catalog` in the "data" toolset.
- Add documentation and unit tests for the new tool.


## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
