### PR TITLE
fix: mcpManifest return empty tools list instead of nil

### DIFF
--- a/cmd/internal/skills/generator_test.go
+++ b/cmd/internal/skills/generator_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"go.opentelemetry.io/otel/trace"
@@ -175,12 +175,10 @@ func TestFormatParameters(t *testing.T) {
 
 func TestGenerateSkillMarkdown(t *testing.T) {
 	toolsMap := map[string]tools.Tool{
-		"tool1": server.MockTool{
-			Description: "First tool",
-			Params: []parameters.Parameter{
+		"tool1": testutils.NewMockTool("tool1", "First tool",
+			[]parameters.Parameter{
 				parameters.NewStringParameter("p1", "d1"),
-			},
-		},
+			}, false, false),
 	}
 
 	got, err := generateSkillMarkdown("MySkill", "My Description", "Some extra notes", toolsMap, nil)

--- a/internal/prompts/promptsets.go
+++ b/internal/prompts/promptsets.go
@@ -41,20 +41,21 @@ type PromptsetManifest struct {
 	PromptsManifest map[string]Manifest `json:"prompts"`
 }
 
-func (t PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]Prompt) (Promptset, error) {
+func (p PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]Prompt) (Promptset, error) {
 	// Check each declared prompt name exists
-	var promptset Promptset
-	promptset.Name = t.Name
+	promptset := Promptset{
+		PromptsetConfig: p,
+		Prompts:         make([]*Prompt, 0, len(p.PromptNames)),
+		Manifest: PromptsetManifest{
+			ServerVersion:   serverVersion,
+			PromptsManifest: make(map[string]Manifest, len(p.PromptNames)),
+		},
+		McpManifest: make([]McpManifest, 0, len(p.PromptNames)),
+	}
 	if !tools.IsValidName(promptset.Name) {
 		return promptset, fmt.Errorf("invalid promptset name: %s", promptset.Name)
 	}
-	promptset.Prompts = make([]*Prompt, 0, len(t.PromptNames))
-	promptset.McpManifest = make([]McpManifest, 0, len(t.PromptNames))
-	promptset.Manifest = PromptsetManifest{
-		ServerVersion:   serverVersion,
-		PromptsManifest: make(map[string]Manifest, len(t.PromptNames)),
-	}
-	for _, promptName := range t.PromptNames {
+	for _, promptName := range p.PromptNames {
 		prompt, ok := promptsMap[promptName]
 		if !ok {
 			return promptset, fmt.Errorf("prompt does not exist: %s", promptName)

--- a/internal/prompts/promptsets_test.go
+++ b/internal/prompts/promptsets_test.go
@@ -20,57 +20,20 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
-
-// mockPrompt is a simple mock implementation of prompts.Prompt for testing.
-type mockPrompt struct {
-	name        string
-	desc        string
-	args        prompts.Arguments
-	manifest    prompts.Manifest
-	mcpManifest prompts.McpManifest
-}
-
-func (m mockPrompt) SubstituteParams(parameters.ParamValues) (any, error) { return nil, nil }
-func (m mockPrompt) ParseArgs(map[string]any, map[string]map[string]any) (parameters.ParamValues, error) {
-	return nil, nil
-}
-func (m mockPrompt) Manifest() prompts.Manifest       { return m.manifest }
-func (m mockPrompt) McpManifest() prompts.McpManifest { return m.mcpManifest }
-func (m mockPrompt) ToConfig() prompts.PromptConfig   { return nil }
-
-// newMockPrompt creates a new mock prompt for testing.
-func newMockPrompt(name, desc string) prompts.Prompt {
-	args := prompts.Arguments{
-		{Parameter: parameters.NewStringParameter("arg1", "Test argument")},
-	}
-	return mockPrompt{
-		name: name,
-		desc: desc,
-		args: args,
-		manifest: prompts.Manifest{
-			Description: desc,
-			Arguments: []parameters.ParameterManifest{
-				{Name: "arg1", Type: "string", Required: true, Description: "Test argument", AuthServices: []string{}},
-			},
-		},
-		mcpManifest: prompts.McpManifest{
-			Name:        name,
-			Description: desc,
-			Arguments: []prompts.ArgMcpManifest{
-				{Name: "arg1", Description: "Test argument", Required: true},
-			},
-		},
-	}
-}
 
 func TestPromptsetConfig_Initialize(t *testing.T) {
 	t.Parallel()
 
+	args := prompts.Arguments{
+		{Parameter: parameters.NewStringParameter("arg1", "Test argument")},
+	}
+
 	promptsMap := map[string]prompts.Prompt{
-		"prompt1": newMockPrompt("prompt1", "First test prompt"),
-		"prompt2": newMockPrompt("prompt2", "Second test prompt"),
+		"prompt1": testutils.NewMockPrompt("prompt1", "First test prompt", args),
+		"prompt2": testutils.NewMockPrompt("prompt2", "Second test prompt", args),
 	}
 	serverVersion := "v1.0.0"
 
@@ -93,7 +56,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			},
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "default",
+					Name:        "default",
+					PromptNames: []string{"prompt1", "prompt2"},
 				},
 				Prompts: []*prompts.Prompt{
 					prompt1Ptr,
@@ -121,7 +85,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			},
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "single",
+					Name:        "single",
+					PromptNames: []string{"prompt1"},
 				},
 				Prompts: []*prompts.Prompt{
 					prompt1Ptr,
@@ -144,7 +109,18 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 				Name:        "invalid name", // Contains a space
 				PromptNames: []string{"prompt1"},
 			},
-			want:    prompts.Promptset{PromptsetConfig: prompts.PromptsetConfig{Name: "invalid name"}}, // Expect partial struct
+			want: prompts.Promptset{
+				PromptsetConfig: prompts.PromptsetConfig{
+					Name:        "invalid name",
+					PromptNames: []string{"prompt1"},
+				},
+				Prompts: []*prompts.Prompt{},
+				Manifest: prompts.PromptsetManifest{
+					ServerVersion:   serverVersion,
+					PromptsManifest: map[string]prompts.Manifest{},
+				},
+				McpManifest: []prompts.McpManifest{},
+			},
 			wantErr: "invalid promptset name",
 		},
 		{
@@ -156,7 +132,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			// Expect partial struct with fields populated up to the error
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "missing_prompt",
+					Name:        "missing_prompt",
+					PromptNames: []string{"prompt1", "prompt_does_not_exist"},
 				},
 				Prompts: []*prompts.Prompt{
 					prompt1Ptr,
@@ -181,7 +158,8 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 			},
 			want: prompts.Promptset{
 				PromptsetConfig: prompts.PromptsetConfig{
-					Name: "empty",
+					Name:        "empty",
+					PromptNames: []string{},
 				},
 				Prompts: []*prompts.Prompt{},
 				Manifest: prompts.PromptsetManifest{
@@ -207,15 +185,15 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 					t.Errorf("Initialize() error mismatch:\n  want to contain: %q\n  got: %q", tc.wantErr, err.Error())
 				}
 				// Also check that the partially populated struct matches
-				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(mockPrompt{})); diff != "" {
+				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockPrompt{})); diff != "" {
 					t.Errorf("Initialize() partial result on error mismatch (-want +got):\n%s", diff)
 				}
 			} else {
 				if err != nil {
 					t.Fatalf("Initialize() returned unexpected error: %v", err)
 				}
-				// Using cmp.AllowUnexported because mockPrompt is unexported
-				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(mockPrompt{})); diff != "" {
+				// Using cmp.AllowUnexported because MockPrompt is unexported
+				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockPrompt{})); diff != "" {
 					t.Errorf("Initialize() result mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 )
 
 func TestToolsetEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2}
+	mockTools := []testutils.MockTool{tool1, tool2}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
 	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
 	defer shutdown()
@@ -124,7 +125,7 @@ func TestToolsetEndpoint(t *testing.T) {
 }
 
 func TestToolGetEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2}
+	mockTools := []testutils.MockTool{tool1, tool2}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
 	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
 	defer shutdown()
@@ -212,7 +213,7 @@ func TestToolGetEndpoint(t *testing.T) {
 }
 
 func TestToolInvokeEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool4, tool5}
+	mockTools := []testutils.MockTool{tool1, tool2, tool4, tool5}
 	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
 	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
 	defer shutdown()

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -30,67 +30,49 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
 
 // fakeVersionString is used as a temporary version string in tests
 const fakeVersionString = "0.0.0"
 
 var (
-	_ tools.Tool     = MockTool{}
-	_ prompts.Prompt = MockPrompt{}
+	_ tools.Tool     = testutils.MockTool{}
+	_ prompts.Prompt = testutils.MockPrompt{}
 )
 
-var tool1 = MockTool{
-	Name:   "no_params",
-	Params: []parameters.Parameter{},
-}
+var tool1 = testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
 
-var tool2 = MockTool{
-	Name: "some_params",
-	Params: parameters.Parameters{
+var tool2 = testutils.NewMockTool(
+	"some_params",
+	"",
+	parameters.Parameters{
 		parameters.NewIntParameter("param1", "This is the first parameter."),
 		parameters.NewIntParameter("param2", "This is the second parameter."),
-	},
-}
+	}, false, false)
 
-var tool3 = MockTool{
-	Name:        "array_param",
-	Description: "some description",
-	Params: parameters.Parameters{
+var tool3 = testutils.NewMockTool(
+	"array_param", "some description",
+	parameters.Parameters{
 		parameters.NewArrayParameter("my_array", "this param is an array of strings", parameters.NewStringParameter("my_string", "string item")),
-	},
-}
+	}, false, false)
 
-var tool4 = MockTool{
-	Name:         "unauthorized_tool",
-	Params:       []parameters.Parameter{},
-	unauthorized: true,
-}
+var tool4 = testutils.NewMockTool("unauthorized_tool", "", []parameters.Parameter{}, true, false)
 
-var tool5 = MockTool{
-	Name:                        "require_client_auth_tool",
-	Params:                      []parameters.Parameter{},
-	requiresClientAuthorization: true,
-}
+var tool5 = testutils.NewMockTool("require_client_auth_tool", "", []parameters.Parameter{}, false, true)
 
-var prompt1 = MockPrompt{
-	Name: "prompt1",
-	Args: prompts.Arguments{},
-}
+var prompt1 = testutils.NewMockPrompt("prompt1", "", prompts.Arguments{})
 
-var prompt2 = MockPrompt{
-	Name: "prompt2",
-	Args: prompts.Arguments{
-		{Parameter: parameters.NewStringParameter("arg1", "This is the first argument.")},
-	},
-}
+var prompt2 = testutils.NewMockPrompt("prompt2", "", prompts.Arguments{
+	{Parameter: parameters.NewStringParameter("arg1", "This is the first argument.")},
+})
 
 // setUpResources setups resources to test against
-func setUpResources(t *testing.T, mockTools []MockTool, mockPrompts []MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
+func setUpResources(t *testing.T, mockTools []testutils.MockTool, mockPrompts []testutils.MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
 	toolsMap := make(map[string]tools.Tool)
 	var allTools []string
 	for _, tool := range mockTools {
-		tool.manifest = tool.Manifest()
 		toolsMap[tool.Name] = tool
 		allTools = append(allTools, tool.Name)
 	}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/telemetry"
+
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
 
 const jsonrpcVersion = "2.0"
@@ -76,8 +78,8 @@ var prompt2Args = []any{
 }
 
 func TestMcpEndpointWithoutInitialized(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
 	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
@@ -421,8 +423,8 @@ func runInitializeLifecycle(t *testing.T, ts *httptest.Server, protocolVersion s
 }
 
 func TestMcpEndpoint(t *testing.T) {
-	mockTools := []MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
 	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
@@ -1088,8 +1090,8 @@ func TestStdioSession(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockTools := []MockTool{tool1, tool2, tool3}
-	mockPrompts := []MockPrompt{prompt1, prompt2}
+	mockTools := []testutils.MockTool{tool1, tool2, tool3}
+	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
 	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
 
 	pr, pw, err := os.Pipe()

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package server
+package testutils
 
 import (
 	"context"
@@ -27,12 +27,64 @@ import (
 
 // MockTool is used to mock tools in tests
 type MockTool struct {
-	Name                        string
-	Description                 string
-	Params                      []parameters.Parameter
-	manifest                    tools.Manifest
-	unauthorized                bool
-	requiresClientAuthorization bool
+	Name                       string
+	Description                string
+	Params                     []parameters.Parameter
+	manifest                   tools.Manifest
+	mcpManifest                tools.McpManifest
+	unauthorized               bool
+	requireClientAuthorization bool
+}
+
+// NewMockTool creates a new mock prompt for testing.
+func NewMockTool(name, desc string, params []parameters.Parameter, unauthorized, requireClientAuthorization bool) MockTool {
+	pMs := make([]parameters.ParameterManifest, 0, len(params))
+	for _, p := range params {
+		pMs = append(pMs, p.Manifest())
+	}
+	manifest := tools.Manifest{Description: desc, Parameters: pMs}
+
+	properties := make(map[string]parameters.ParameterMcpManifest)
+	required := make([]string, 0)
+	authParams := make(map[string][]string)
+
+	for _, p := range params {
+		pName := p.GetName()
+		paramManifest, authParamList := p.McpManifest()
+		properties[pName] = paramManifest
+		required = append(required, pName)
+
+		if len(authParamList) > 0 {
+			authParams[pName] = authParamList
+		}
+	}
+
+	toolsSchema := parameters.McpToolsSchema{
+		Type:       "object",
+		Properties: properties,
+		Required:   required,
+	}
+
+	mcpManifest := tools.McpManifest{
+		Name:        name,
+		Description: desc,
+		InputSchema: toolsSchema,
+	}
+
+	if len(authParams) > 0 {
+		mcpManifest.Metadata = map[string]any{
+			"toolbox/authParams": authParams,
+		}
+	}
+	return MockTool{
+		Name:                       name,
+		Description:                desc,
+		Params:                     params,
+		manifest:                   manifest,
+		mcpManifest:                mcpManifest,
+		unauthorized:               unauthorized,
+		requireClientAuthorization: requireClientAuthorization,
+	}
 }
 
 func (t MockTool) Invoke(context.Context, tools.SourceProvider, parameters.ParamValues, tools.AccessToken) (any, util.ToolboxError) {
@@ -54,11 +106,7 @@ func (t MockTool) EmbedParams(ctx context.Context, paramValues parameters.ParamV
 }
 
 func (t MockTool) Manifest() tools.Manifest {
-	pMs := make([]parameters.ParameterManifest, 0, len(t.Params))
-	for _, p := range t.Params {
-		pMs = append(pMs, p.Manifest())
-	}
-	return tools.Manifest{Description: t.Description, Parameters: pMs}
+	return t.manifest
 }
 
 func (t MockTool) Authorized(verifiedAuthServices []string) bool {
@@ -68,7 +116,7 @@ func (t MockTool) Authorized(verifiedAuthServices []string) bool {
 
 func (t MockTool) RequiresClientAuthorization(tools.SourceProvider) (bool, error) {
 	// defaulted to false
-	return t.requiresClientAuthorization, nil
+	return t.requireClientAuthorization, nil
 }
 
 func (t MockTool) GetParameters() parameters.Parameters {
@@ -76,40 +124,7 @@ func (t MockTool) GetParameters() parameters.Parameters {
 }
 
 func (t MockTool) McpManifest() tools.McpManifest {
-	properties := make(map[string]parameters.ParameterMcpManifest)
-	required := make([]string, 0)
-	authParams := make(map[string][]string)
-
-	for _, p := range t.Params {
-		name := p.GetName()
-		paramManifest, authParamList := p.McpManifest()
-		properties[name] = paramManifest
-		required = append(required, name)
-
-		if len(authParamList) > 0 {
-			authParams[name] = authParamList
-		}
-	}
-
-	toolsSchema := parameters.McpToolsSchema{
-		Type:       "object",
-		Properties: properties,
-		Required:   required,
-	}
-
-	mcpManifest := tools.McpManifest{
-		Name:        t.Name,
-		Description: t.Description,
-		InputSchema: toolsSchema,
-	}
-
-	if len(authParams) > 0 {
-		mcpManifest.Metadata = map[string]any{
-			"toolbox/authParams": authParams,
-		}
-	}
-
-	return mcpManifest
+	return t.mcpManifest
 }
 
 func (t MockTool) GetAuthTokenHeaderName(tools.SourceProvider) (string, error) {
@@ -121,6 +136,8 @@ type MockPrompt struct {
 	Name        string
 	Description string
 	Args        prompts.Arguments
+	manifest    prompts.Manifest
+	mcpManifest prompts.McpManifest
 }
 
 func (p MockPrompt) SubstituteParams(vals parameters.ParamValues) (any, error) {
@@ -157,4 +174,24 @@ func (p MockPrompt) McpManifest() prompts.McpManifest {
 
 func (p MockPrompt) ToConfig() prompts.PromptConfig {
 	return nil
+}
+
+// NewMockPrompt creates a new mock prompt for testing.
+func NewMockPrompt(name, desc string, args prompts.Arguments) MockPrompt {
+	var argManifests []parameters.ParameterManifest
+	for _, arg := range args {
+		argManifests = append(argManifests, arg.Manifest())
+	}
+	manifest := prompts.Manifest{
+		Description: desc,
+		Arguments:   argManifests,
+	}
+	mcpManifest := prompts.GetMcpManifest(name, desc, args)
+	return MockPrompt{
+		Name:        name,
+		Description: desc,
+		Args:        args,
+		manifest:    manifest,
+		mcpManifest: mcpManifest,
+	}
 }

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -43,15 +43,17 @@ type ToolsetManifest struct {
 func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool) (Toolset, error) {
 	// finish toolset setup
 	// Check each declared tool name exists
-	var toolset Toolset
-	toolset.Name = t.Name
+	toolset := Toolset{
+		ToolsetConfig: t,
+		Tools:         make([]*Tool, 0, len(t.ToolNames)),
+		Manifest: ToolsetManifest{
+			ServerVersion: serverVersion,
+			ToolsManifest: make(map[string]Manifest),
+		},
+		McpManifest: make([]McpManifest, 0, len(t.ToolNames)),
+	}
 	if !IsValidName(toolset.Name) {
 		return toolset, fmt.Errorf("invalid toolset name: %s", toolset.Name)
-	}
-	toolset.Tools = make([]*Tool, 0, len(t.ToolNames))
-	toolset.Manifest = ToolsetManifest{
-		ServerVersion: serverVersion,
-		ToolsManifest: make(map[string]Manifest),
 	}
 	for _, toolName := range t.ToolNames {
 		tool, ok := toolsMap[toolName]
@@ -62,7 +64,6 @@ func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool
 		toolset.Manifest.ToolsManifest[toolName] = tool.Manifest()
 		toolset.McpManifest = append(toolset.McpManifest, tool.McpManifest())
 	}
-
 	return toolset, nil
 }
 

--- a/internal/tools/toolsets_test.go
+++ b/internal/tools/toolsets_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+func TestToolsetConfig_Initialize(t *testing.T) {
+	t.Parallel()
+
+	var tool1 = testutils.NewMockTool("tool1", "some description", []parameters.Parameter{}, false, false)
+	var tool2 = testutils.NewMockTool(
+		"tool2",
+		"some description",
+		parameters.Parameters{
+			parameters.NewIntParameter("param1", "This is the first parameter."),
+			parameters.NewIntParameter("param2", "This is the second parameter."),
+		}, false, false)
+
+	toolsMap := map[string]tools.Tool{
+		"tool1": tool1,
+		"tool2": tool2,
+	}
+	serverVersion := "test-version"
+
+	t1 := toolsMap["tool1"]
+	t2 := toolsMap["tool2"]
+	tool1Ptr := &t1
+	tool2Ptr := &t2
+
+	testCases := []struct {
+		name    string
+		config  tools.ToolsetConfig
+		want    tools.Toolset
+		wantErr string
+	}{
+		{
+			name: "Success case",
+			config: tools.ToolsetConfig{
+				Name:      "default",
+				ToolNames: []string{"tool1", "tool2"},
+			},
+			want: tools.Toolset{
+				ToolsetConfig: tools.ToolsetConfig{
+					Name:      "default",
+					ToolNames: []string{"tool1", "tool2"},
+				},
+				Tools: []*tools.Tool{
+					tool1Ptr,
+					tool2Ptr,
+				},
+				Manifest: tools.ToolsetManifest{
+					ServerVersion: serverVersion,
+					ToolsManifest: map[string]tools.Manifest{
+						"tool1": toolsMap["tool1"].Manifest(),
+						"tool2": toolsMap["tool2"].Manifest(),
+					},
+				},
+				McpManifest: []tools.McpManifest{
+					toolsMap["tool1"].McpManifest(),
+					toolsMap["tool2"].McpManifest(),
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Success case with one tool",
+			config: tools.ToolsetConfig{
+				Name:      "single",
+				ToolNames: []string{"tool1"},
+			},
+			want: tools.Toolset{
+				ToolsetConfig: tools.ToolsetConfig{
+					Name:      "single",
+					ToolNames: []string{"tool1"},
+				},
+				Tools: []*tools.Tool{
+					tool1Ptr,
+				},
+				Manifest: tools.ToolsetManifest{
+					ServerVersion: serverVersion,
+					ToolsManifest: map[string]tools.Manifest{
+						"tool1": toolsMap["tool1"].Manifest(),
+					},
+				},
+				McpManifest: []tools.McpManifest{
+					toolsMap["tool1"].McpManifest(),
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Failure case - invalid toolset name",
+			config: tools.ToolsetConfig{
+				Name:      "invalid name", // Contains a space
+				ToolNames: []string{"tool1"},
+			},
+			want: tools.Toolset{
+				ToolsetConfig: tools.ToolsetConfig{
+					Name:      "invalid name",
+					ToolNames: []string{"tool1"},
+				},
+				Tools: []*tools.Tool{},
+				Manifest: tools.ToolsetManifest{
+					ServerVersion: serverVersion,
+					ToolsManifest: map[string]tools.Manifest{},
+				},
+				McpManifest: []tools.McpManifest{},
+			},
+			wantErr: "invalid toolset name",
+		},
+		{
+			name: "Failure case - tool not found",
+			config: tools.ToolsetConfig{
+				Name:      "missing_tool",
+				ToolNames: []string{"tool1", "tool_does_not_exist"},
+			},
+			// Expect partial struct with fields populated up to the error
+			want: tools.Toolset{
+				ToolsetConfig: tools.ToolsetConfig{
+					Name:      "missing_tool",
+					ToolNames: []string{"tool1", "tool_does_not_exist"},
+				},
+				Tools: []*tools.Tool{
+					tool1Ptr,
+				},
+				Manifest: tools.ToolsetManifest{
+					ServerVersion: serverVersion,
+					ToolsManifest: map[string]tools.Manifest{
+						"tool1": toolsMap["tool1"].Manifest(),
+					},
+				},
+				McpManifest: []tools.McpManifest{
+					toolsMap["tool1"].McpManifest(),
+				},
+			},
+			wantErr: "tool does not exist",
+		},
+		{
+			name: "Success case - empty tools list",
+			config: tools.ToolsetConfig{
+				Name:      "empty",
+				ToolNames: []string{},
+			},
+			want: tools.Toolset{
+				ToolsetConfig: tools.ToolsetConfig{
+					Name:      "empty",
+					ToolNames: []string{},
+				},
+				Tools: []*tools.Tool{},
+				Manifest: tools.ToolsetManifest{
+					ServerVersion: serverVersion,
+					ToolsManifest: map[string]tools.Manifest{},
+				},
+				McpManifest: []tools.McpManifest{},
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.config.Initialize(serverVersion, toolsMap)
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Initialize() expected error but got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("Initialize() error mismatch:\n  want to contain: %q\n  got: %q", tc.wantErr, err.Error())
+				}
+				// Also check that the partially populated struct matches
+				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockTool{})); diff != "" {
+					t.Errorf("Initialize() partial result on error mismatch (-want +got):\n%s", diff)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Initialize() returned unexpected error: %v", err)
+				}
+				// Using cmp.AllowUnexported because MockTool is unexported
+				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockTool{})); diff != "" {
+					t.Errorf("Initialize() result mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/tests/firebird/firebird_integration_test.go
+++ b/tests/firebird/firebird_integration_test.go
@@ -129,7 +129,7 @@ func TestFirebirdToolEndpoints(t *testing.T) {
 	// Get configs for tests
 	select1Want, mcpMyFailToolWant, createTableStatement, mcpSelect1Want := getFirebirdWants()
 	nullWant := `[{"id":4,"name":null}]`
-	select1Statement := `"SELECT 1 AS \"constant\" FROM RDB$DATABASE;"`
+	select1Statement := `SELECT 1 AS "constant" FROM RDB$DATABASE;`
 	templateParamCreateColArray := `["id INTEGER","name VARCHAR(255)","age INTEGER"]`
 
 	// Run tests


### PR DESCRIPTION
When there are no tools, return an empty list in McpManifest instead of null.

This PR also refactor to move all mocks to `testutils`. And added new `toolset_tests.go` file.

```
curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id": 1,  "method": "tools/list"}' http://127.0.0.1:5000/mcp


{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}
```

Previously UI will response with `Error: Invalid response format from toolset API.`. After the fix, UI will run with `no tools found`

---

Go nil slice vs empty slice --

`var tools []tools.Tool` (Nil Slice):
This creates a slice header where the internal pointer to the underlying array is nil. In Go logic, the length is 0 and the capacity is 0, but the slice itself is technically nil.

`tools := []tools.Tool{}` (Empty Slice):
This initializes the slice header. Even though the length is 0, the internal pointer points to a special "zerobase" memory address. It is not nil.

This is probably due to some memory state of variable between `nil` vs allocated.