### PR TITLE
chore: update security settings in hugo config

### DIFF
--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -24,8 +24,9 @@ enableRobotsTXT = true
 
 ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quickstart/go"]
 
-[security.exec.node]
-  disable = true
+[security.node]
+  [security.node.permissions]
+    disable = true
 
 [languages]
   [languages.en]

--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -24,7 +24,7 @@ enableRobotsTXT = true
 
 ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quickstart/go"]
 
-[security.node]
+[security.exec.node]
   disable = true
 
 [languages]


### PR DESCRIPTION
fix for #3182

Missing `[security.node.permissions]` according to https://gohugo.io/configuration/security/