### PR TITLE
feat: support SEP-2575 make MCP stateless

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -151,19 +151,20 @@ func (c traceContextCarrier) Keys() []string {
 
 // extractMeta parses params._meta from the request body in a single pass,
 // extracting both W3C Trace Context and client telemetry attributes.
-func extractMeta(ctx context.Context, body []byte) context.Context {
+func extractMeta(ctx context.Context, body []byte) (string, context.Context) {
 	var req struct {
 		Params struct {
 			Meta struct {
-				Traceparent    string            `json:"traceparent,omitempty"`
-				Tracestate     string            `json:"tracestate,omitempty"`
-				TelemetryAttrs map[string]string `json:"dev.mcp-toolbox/telemetry,omitempty"`
+				Traceparent     string            `json:"traceparent,omitempty"`
+				Tracestate      string            `json:"tracestate,omitempty"`
+				TelemetryAttrs  map[string]string `json:"dev.mcp-toolbox/telemetry,omitempty"`
+				ProtocolVersion string            `json:"io.modelcontextprotocol/protocolVersion"`
 			} `json:"_meta,omitempty"`
 		} `json:"params,omitempty"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
-		return ctx
+		return "", ctx
 	}
 
 	// Extract W3C Trace Context
@@ -189,7 +190,7 @@ func extractMeta(ctx context.Context, body []byte) context.Context {
 		ctx = util.WithTelemetryAttributes(ctx, ta)
 	}
 
-	return ctx
+	return req.Params.Meta.ProtocolVersion, ctx
 }
 
 func NewStdioSession(s *Server, stdin io.Reader, stdout io.Writer) *stdioSession {
@@ -257,7 +258,7 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 
 		if err := func() error {
 			// This ensures the transport span becomes a child of the client span
-			msgCtx := extractMeta(ctx, []byte(line))
+			metaProtocolVersion, msgCtx := extractMeta(ctx, []byte(line))
 
 			// Create span for STDIO transport
 			msgCtx, span := s.server.instrumentation.Tracer.Start(msgCtx, "toolbox/server/mcp/stdio",
@@ -265,9 +266,17 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 			)
 			defer span.End()
 
+			protocol := s.protocol
+			// if protocol version was found in meta, it takes precedence
+			// the metaProtocolVersion does not replace existing protocol
+			// version if initialize method took place
+			if metaProtocolVersion != "" {
+				protocol = metaProtocolVersion
+			}
+
 			var v string
 			var res any
-			v, res, err = processMcpMessage(msgCtx, []byte(line), s.server, s.protocol, "", "", nil, "")
+			v, res, err = processMcpMessage(msgCtx, []byte(line), s.server, protocol, "", "", nil, "")
 			if err != nil {
 				// errors during the processing of message will generate a valid MCP Error response.
 				// server can continue to run.
@@ -504,7 +513,8 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// This ensures the transport span becomes a child of the client span
-	ctx = extractMeta(ctx, body)
+	// _meta.ProtocolVersion is not checked here for http transport.
+	_, ctx = extractMeta(ctx, body)
 
 	// Create span for HTTP transport
 	ctx, span := s.instrumentation.Tracer.Start(ctx, "toolbox/server/mcp/http",
@@ -542,11 +552,6 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	// Only supported for v2025-06-18+.
 	headerProtocolVersion := r.Header.Get("Mcp-Protocol-Version")
 	if headerProtocolVersion != "" {
-		if !mcp.VerifyProtocolVersion(headerProtocolVersion) {
-			err := fmt.Errorf("invalid protocol version: %s", headerProtocolVersion)
-			_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
-			return
-		}
 		protocolVersion = headerProtocolVersion
 	}
 
@@ -621,6 +626,10 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
 			}
+		case jsonrpc.METHOD_NOT_FOUND:
+			w.WriteHeader(http.StatusNotFound)
+		case jsonrpc.HEADER_MISMATCH, jsonrpc.UNSUPPORTED_PROTOCOL_VERSION:
+			w.WriteHeader(http.StatusBadRequest)
 		}
 	}
 
@@ -779,11 +788,12 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 		return "", nil, err
 	}
 
-	// Add instrumentation to context for use in method handlers
+	// Add instrumentation and toolbox version to context for use in method handlers
 	ctx = util.WithInstrumentation(ctx, s.instrumentation)
-
+	ctx = util.WithToolboxVersionKey(ctx, s.version)
 	// Process the method
 	switch baseMessage.Method {
+	// This is only used for <v2026
 	case "initialize":
 		var initReq struct {
 			Params struct {
@@ -803,7 +813,6 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			version = mcputil.LATEST_PROTOCOL_VERSION
 		}
 
-		ctx = util.WithToolboxVersionKey(ctx, s.version)
 		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())

--- a/internal/server/mcp/jsonrpc/jsonrpc.go
+++ b/internal/server/mcp/jsonrpc/jsonrpc.go
@@ -14,20 +14,29 @@
 
 package jsonrpc
 
+import (
+	"fmt"
+
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
+)
+
 // JSONRPC_VERSION is the version of JSON-RPC used by MCP.
 const JSONRPC_VERSION = "2.0"
 
 const (
 	// Standard JSON-RPC error codes
-	PARSE_ERROR      = -32700
-	INVALID_REQUEST  = -32600
-	METHOD_NOT_FOUND = -32601
-	INVALID_PARAMS   = -32602
-	INTERNAL_ERROR   = -32603
+	PARSE_ERROR                        = -32700
+	INVALID_REQUEST                    = -32600
+	METHOD_NOT_FOUND                   = -32601
+	INVALID_PARAMS                     = -32602
+	INTERNAL_ERROR                     = -32603
+	HEADER_MISMATCH                    = -32001
+	MISSING_REQUIRED_CLIENT_CAPABILITY = -32003
+	UNSUPPORTED_PROTOCOL_VERSION       = -32004
 
 	// Custom auth error codes
-	UNAUTHORIZED = -32001
-	FORBIDDEN    = -32003
+	UNAUTHORIZED = -401
+	FORBIDDEN    = -403
 )
 
 // ProgressToken is used to associate progress notifications with the original request.
@@ -40,20 +49,16 @@ type RequestId interface{}
 // Request represents a bidirectional message with method and parameters expecting a response.
 type Request struct {
 	Method string `json:"method"`
-	Params struct {
-		Meta struct {
-			// If specified, the caller is requesting out-of-band progress
-			// notifications for this request (as represented by
-			// notifications/progress). The value of this parameter is an
-			// opaque token that will be attached to any subsequent
-			// notifications. The receiver is not obligated to provide these
-			// notifications.
-			ProgressToken ProgressToken `json:"progressToken,omitempty"`
-			// W3C Trace Context fields for distributed tracing
-			Traceparent string `json:"traceparent,omitempty"`
-			Tracestate  string `json:"tracestate,omitempty"`
-		} `json:"_meta,omitempty"`
-	} `json:"params,omitempty"`
+}
+
+type RequestParams struct {
+	Meta *RequestMetaObject `json:"_meta"`
+}
+
+type RequestMetaObject struct {
+	// W3C Trace Context fields for distributed tracing
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
 }
 
 // JSONRPCRequest represents a request that expects a response.
@@ -135,9 +140,10 @@ type JSONRPCError struct {
 
 // Generic baseMessage could either be a JSONRPCNotification or JSONRPCRequest
 type BaseMessage struct {
-	Jsonrpc string    `json:"jsonrpc"`
-	Method  string    `json:"method"`
-	Id      RequestId `json:"id,omitempty"`
+	Jsonrpc string         `json:"jsonrpc"`
+	Method  string         `json:"method"`
+	Id      RequestId      `json:"id,omitempty"`
+	Params  *RequestParams `json:"params,omitempty"`
 }
 
 // NewError is the standard JSONRPC response sent back when an error has been encountered.
@@ -149,6 +155,36 @@ func NewError(id RequestId, code int, message string, data any) JSONRPCError {
 			Code:    code,
 			Message: message,
 			Data:    data,
+		},
+	}
+}
+
+func NewUnsupportedProtocolVersionError(id RequestId, v string) (JSONRPCError, error) {
+	err := fmt.Errorf("unsupported protocol version")
+	return JSONRPCError{
+		Jsonrpc: JSONRPC_VERSION,
+		Id:      id,
+		Error: Error{
+			Code:    UNSUPPORTED_PROTOCOL_VERSION,
+			Message: err.Error(),
+			Data: struct {
+				Supported []string `json:"supported"`
+				Requested string   `json:"requested"`
+			}{
+				Supported: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
+				Requested: v,
+			},
+		},
+	}, err
+}
+
+func NewHeaderMismatchedError(id RequestId, err error) JSONRPCError {
+	return JSONRPCError{
+		Jsonrpc: JSONRPC_VERSION,
+		Id:      id,
+		Error: Error{
+			Code:    HEADER_MISMATCH,
+			Message: err.Error(),
 		},
 	}
 }

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -28,6 +28,7 @@ import (
 	v20250326 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20250326"
 	v20250618 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20250618"
 	v20251125 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20251125"
+	vdraft "github.com/googleapis/mcp-toolbox/internal/server/mcp/vdraft"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 )
@@ -46,14 +47,18 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 // This is the Operation phase of the lifecycle for MCP client-server connections.
 func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch mcpVersion {
-	case v20251125.PROTOCOL_VERSION:
+	case mcputil.VERSION_DRAFT:
+		return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+	case mcputil.VERSION_20251125:
 		return v20251125.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	case v20250618.PROTOCOL_VERSION:
+	case mcputil.VERSION_20250618:
 		return v20250618.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	case v20250326.PROTOCOL_VERSION:
+	case mcputil.VERSION_20250326:
 		return v20250326.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	default:
+	case "", mcputil.VERSION_20241105:
 		return v20241105.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+	default:
+		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion)
 	}
 }
 

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -39,44 +40,83 @@ import (
 
 // ProcessMethod returns a response for the request.
 func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+	stdio := header == nil
 	switch method {
-	case INITIALIZE:
-		return initializeHandler(ctx, id, body)
-	case PING:
-		return pingHandler(id)
+	case SERVER_DISCOVER:
+		return serverDiscoverHandler(ctx, id, body, stdio)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body)
+		return toolsListHandler(id, resourceMgr, toolset, body, stdio)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
-		return promptsListHandler(ctx, id, resourceMgr, promptset, body)
+		return promptsListHandler(ctx, id, resourceMgr, promptset, body, stdio)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, promptset, resourceMgr, body)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body, stdio)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
 	}
 }
 
-// InitializeResponse runs capability negotiation and protocol version agreement.
-// This is the Initialization phase of the lifecycle for MCP client-server connections.
-// Always start with the latest protocol version supported.
-func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+// validateMetadata checks the metadata of every requests
+func validateMetadata(id jsonrpc.RequestId, params RequestParams, stdio bool) (any, error) {
+	// Check _meta field for protocol version
+	if params.Meta != nil {
+		// check for protocol version metadata
+		v := params.Meta.ProtocolVersion
+		if v == "" {
+			metaErr := fmt.Errorf("missing io.modelcontextprotocol/protocolVersion")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// do not have to verify header for stdio; already verified during stdio
+		// message processing
+		if !stdio {
+			if PROTOCOL_VERSION != v {
+				metaErr := fmt.Errorf("header mismatch: MCP-Protocol-Version header value '%s' does not match body value '%s'", PROTOCOL_VERSION, v)
+				return jsonrpc.NewHeaderMismatchedError(id, metaErr), metaErr
+			}
+		}
+
+		// check for clientInfo
+		clientInfo := params.Meta.ClientInfo
+		if clientInfo.Version == "" || clientInfo.Name == "" {
+			metaErr := fmt.Errorf("missing field from io.modelcontextprotocol/clientInfo")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// check for clientCapabilities
+		clientCapabilities := params.Meta.MetaClientCapabilities
+		if clientCapabilities == nil {
+			metaErr := fmt.Errorf("missing field from io.modelcontextprotocol/clientCapabilities")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// skip checking clientCapabilities since Toolbox do not utilize any of those
+	} else {
+		metaErr := fmt.Errorf("missing required fields in request metadata")
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+	}
+	return nil, nil
+}
+
+func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, stdio bool) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
 
-	var req InitializeRequest
+	var req DiscoverRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		err = fmt.Errorf("invalid mcp initialize request: %w", err)
+		err = fmt.Errorf("invalid server discover request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	toolsListChanged := false
 	promptsListChanged := false
-	result := InitializeResult{
-		ProtocolVersion: PROTOCOL_VERSION,
+	result := DiscoverResult{
+		SupportedVersions: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
 		Capabilities: ServerCapabilities{
 			Tools: &ListChanged{
 				ListChanged: &toolsListChanged,
@@ -97,24 +137,18 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 		Id:      id,
 		Result:  result,
 	}
-
 	return res, nil
 }
 
-// pingHandler handles the "ping" method by returning an empty response.
-func pingHandler(id jsonrpc.RequestId) (any, error) {
-	return jsonrpc.JSONRPCResponse{
-		Jsonrpc: jsonrpc.JSONRPC_VERSION,
-		Id:      id,
-		Result:  struct{}{},
-	}, nil
-}
-
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
+func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, stdio bool) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	toolsMap := resourceMgr.GetToolsMap()
@@ -144,6 +178,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	if err = json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools call request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
+	if err != nil {
+		return validateErr, err
 	}
 
 	toolName := req.Params.Name
@@ -407,7 +445,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 }
 
 // promptsListHandler handles the "prompts/list" method.
-func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte) (any, error) {
+func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte, stdio bool) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -419,6 +457,10 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp prompts list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	promptsMap := resourceMgr.GetPromptsMap()
@@ -436,7 +478,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, stdio bool) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -448,6 +490,10 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prom
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp prompts/get request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	promptName := req.Params.Name

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdraft
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+)
+
+func TestValidateMetadata(t *testing.T) {
+	var dummyId jsonrpc.RequestId
+	clientCapabilities := &ClientCapabilities{}
+
+	tests := []struct {
+		name        string
+		params      RequestParams
+		stdio       bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "Missing Meta entirely",
+			params: RequestParams{
+				Meta: nil,
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing required fields in request metadata",
+		},
+		{
+			name: "Missing Protocol Version",
+			params: RequestParams{
+				Meta: &RequestMetaObject{}, // ProtocolVersion defaults to ""
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing io.modelcontextprotocol/protocolVersion",
+		},
+		{
+			name: "Protocol Version Mismatch (non-stdio)",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: "invalid-version-999",
+				},
+			},
+			stdio:       false,
+			wantErr:     true,
+			errContains: "header mismatch",
+		},
+		{
+			name: "Missing ClientInfo Name",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION,
+					ClientInfo: Implementation{
+						Version:      "1.0",
+						BaseMetadata: BaseMetadata{Name: ""}, // Missing name
+					},
+				},
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing field from io.modelcontextprotocol/clientInfo",
+		},
+		{
+			name: "Missing ClientInfo Version",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION,
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "", // Missing version
+					},
+				},
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing field from io.modelcontextprotocol/clientInfo",
+		},
+		{
+			name: "Missing Client Capabilities",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION,
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "1.0",
+					},
+					MetaClientCapabilities: nil, // Missing capabilities
+				},
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing field from io.modelcontextprotocol/clientCapabilities",
+		},
+		{
+			name: "stdio transport",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					// ProtocolVersion can be anything if stdio is true
+					// Technically it will be valid and would already be
+					// verified during message processing
+					ProtocolVersion: "any-version",
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "1.0",
+					},
+					MetaClientCapabilities: clientCapabilities,
+				},
+			},
+			stdio:   true,
+			wantErr: false,
+		},
+		{
+			name: "Success request metadata",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION, // Must match exactly when stdio=false
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "1.0",
+					},
+					MetaClientCapabilities: clientCapabilities,
+				},
+			},
+			stdio:   false,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := validateMetadata(dummyId, tt.params, tt.stdio)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateMetadata() expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("validateMetadata() error = %v, want error containing %q", err, tt.errContains)
+				}
+				if res == nil {
+					t.Errorf("validateMetadata() expected jsonrpc error response, got nil res")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateMetadata() expected no error, got %v", err)
+				}
+				if res != nil {
+					t.Errorf("validateMetadata() expected nil res on success, got %v", res)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/mcp/vdraft/types.go
+++ b/internal/server/mcp/vdraft/types.go
@@ -28,59 +28,67 @@ const PROTOCOL_VERSION = util.VERSION_DRAFT
 
 // methods that are supported.
 const (
-	INITIALIZE   = "initialize"
-	PING         = "ping"
-	TOOLS_LIST   = "tools/list"
-	TOOLS_CALL   = "tools/call"
-	PROMPTS_LIST = "prompts/list"
-	PROMPTS_GET  = "prompts/get"
+	SERVER_DISCOVER = "server/discover"
+	TOOLS_LIST      = "tools/list"
+	TOOLS_CALL      = "tools/call"
+	PROMPTS_LIST    = "prompts/list"
+	PROMPTS_GET     = "prompts/get"
 )
 
-/* Initialization */
-
-// Params to define MCP Client during initialize request.
-type InitializeParams struct {
-	// The latest version of the Model Context Protocol that the client supports.
-	// The client MAY decide to support older versions as well.
-	ProtocolVersion string             `json:"protocolVersion"`
-	Capabilities    ClientCapabilities `json:"capabilities"`
-	ClientInfo      Implementation     `json:"clientInfo"`
+/* Request Params */
+type RequestParams struct {
+	Meta *RequestMetaObject `json:"_meta"`
 }
 
-// InitializeRequest is sent from the client to the server when it first
-// connects, asking it to begin initialization.
-type InitializeRequest struct {
-	jsonrpc.Request
-	Params InitializeParams `json:"params"`
-}
-
-// InitializeResult is sent after receiving an initialize request from the
-// client.
-type InitializeResult struct {
-	jsonrpc.Result
-	// The version of the Model Context Protocol that the server wants to use.
-	// This may not match the version that the client requested. If the client cannot
-	// support this version, it MUST disconnect.
-	ProtocolVersion string             `json:"protocolVersion"`
-	Capabilities    ServerCapabilities `json:"capabilities"`
-	ServerInfo      Implementation     `json:"serverInfo"`
-	// Instructions describing how to use the server and its features.
-	//
-	// This can be used by clients to improve the LLM's understanding of
-	// available tools, resources, etc. It can be thought of like a "hint" to the model.
-	// For example, this information MAY be added to the system prompt.
-	Instructions string `json:"instructions,omitempty"`
-}
-
-// InitializedNotification is sent from the client to the server after
-// initialization has finished.
-type InitializedNotification struct {
-	jsonrpc.Notification
-}
-
-// ListChange represents whether the server supports notification for changes to the capabilities.
-type ListChanged struct {
-	ListChanged *bool `json:"listChanged,omitempty"`
+/**
+ * Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.
+ *
+ * Certain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.
+ *
+ * Valid keys have two segments:
+ *
+ * **Prefix:**
+ * - Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).
+ * - Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).
+ * - Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).
+ * - Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.
+ *
+ * **Name:**
+ * - Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).
+ * - Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).
+ */
+type RequestMetaObject struct {
+	// If specified, the caller is requesting out-of-band progress
+	// notifications for this request (as represented by
+	// notifications/progress). The value of this parameter is an
+	// opaque token that will be attached to any subsequent
+	// notifications. The receiver is not obligated to provide these
+	// notifications.
+	ProgressToken jsonrpc.ProgressToken `json:"progressToken,omitempty"`
+	/**
+	 * The MCP Protocol Version being used for this request. Required.
+	 *
+	 * For the HTTP transport, this value MUST match the `MCP-Protocol-Version`
+	 * header; otherwise the server MUST return a `400 Bad Request`. If the
+	 * server does not support the requested version, it MUST return an
+	 * UnsupportedProtocolVersionError.
+	 */
+	ProtocolVersion string `json:"io.modelcontextprotocol/protocolVersion"`
+	/**
+	 * Identifies the client software making the request. Required.
+	 *
+	 * The Implementation schema requires `name` and `version`; other
+	 * fields are optional.
+	 */
+	ClientInfo Implementation `json:"io.modelcontextprotocol/clientInfo"`
+	/**
+	 * The client's capabilities for this specific request. Required.
+	 *
+	 * Capabilities are declared per-request rather than once at initialization;
+	 * an empty object means the client supports no optional capabilities.
+	 * Servers MUST NOT infer capabilities from prior requests.
+	 */
+	MetaClientCapabilities *ClientCapabilities `json:"io.modelcontextprotocol/clientCapabilities"`
 }
 
 // ClientCapabilities represents capabilities a client may support. Known
@@ -95,12 +103,44 @@ type ClientCapabilities struct {
 	Sampling struct{} `json:"sampling,omitempty"`
 }
 
-// ServerCapabilities represents capabilities that a server may support. Known
-// capabilities are defined here, in this schema, but this is not a closed set: any
-// server can define its own, additional capabilities.
-type ServerCapabilities struct {
-	Tools   *ListChanged `json:"tools,omitempty"`
-	Prompts *ListChanged `json:"prompts,omitempty"`
+/* Discovery */
+
+/**
+ * A request from the client asking the server to advertise its supported
+ * protocol versions, capabilities, and other metadata. Servers **MUST**
+ * implement `server/discover`. Clients **MAY** call it but are not required
+ * to — version negotiation can also happen inline via per-request `_meta`.
+ */
+type DiscoverRequest struct {
+	jsonrpc.Request
+	Params RequestParams `json:"params,omitempty"`
+}
+
+// The result returned by the server for a {@link DiscoverRequest | server/discover} request.
+type DiscoverResult struct {
+	jsonrpc.Result
+	/**
+	 * MCP Protocol Versions this server supports. The client should choose a
+	 * version from this list for use in subsequent requests.
+	 */
+	SupportedVersions []string `json:"supportedVersions"`
+	/**
+	 * The capabilities of the server.
+	 */
+	Capabilities ServerCapabilities `json:"capabilities"`
+	/**
+	 * Information about the server software implementation.
+	 */
+	ServerInfo Implementation `json:"serverInfo"`
+	/**
+	 * Natural-language guidance describing the server and its features.
+	 *
+	 * This can be used by clients to improve an LLM's understanding of
+	 * available tools (e.g., by including it in a system prompt). It should
+	 * focus on information that helps the model use the server effectively
+	 * and should not duplicate information already in tool descriptions.
+	 */
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // Base interface for metadata with name (identifier) and title (display name) properties.
@@ -123,6 +163,19 @@ type Implementation struct {
 	Version string `json:"version"`
 }
 
+// ServerCapabilities represents capabilities that a server may support. Known
+// capabilities are defined here, in this schema, but this is not a closed set: any
+// server can define its own, additional capabilities.
+type ServerCapabilities struct {
+	Tools   *ListChanged `json:"tools,omitempty"`
+	Prompts *ListChanged `json:"prompts,omitempty"`
+}
+
+// ListChange represents whether the server supports notification for changes to the capabilities.
+type ListChanged struct {
+	ListChanged *bool `json:"listChanged,omitempty"`
+}
+
 /* Empty result */
 
 // EmptyResult represents a response that indicates success but carries no data.
@@ -133,13 +186,17 @@ type EmptyResult jsonrpc.Result
 // Cursor is an opaque token used to represent a cursor for pagination.
 type Cursor string
 
+// Common params for paginated requests.
 type PaginatedRequest struct {
 	jsonrpc.Request
-	Params struct {
-		// An opaque token representing the current pagination position.
-		// If provided, the server should return results starting after this cursor.
-		Cursor Cursor `json:"cursor,omitempty"`
-	} `json:"params,omitempty"`
+	Params PaginatedRequestParams `json:"params,omitempty"`
+}
+
+type PaginatedRequestParams struct {
+	RequestParams
+	// An opaque token representing the current pagination position.
+	// If provided, the server should return results starting after this cursor.
+	Cursor Cursor `json:"cursor,omitempty"`
 }
 
 type PaginatedResult struct {
@@ -187,10 +244,20 @@ type InputSchema struct {
 // Used by the client to invoke a tool provided by the server.
 type CallToolRequest struct {
 	jsonrpc.Request
-	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
-	} `json:"params,omitempty"`
+	Params CallToolRequestParams `json:"params,omitempty"`
+}
+
+// Parameters for a `tools/call` request.
+type CallToolRequestParams struct {
+	RequestParams
+	/**
+	 * The name of the tool.
+	 */
+	Name string `json:"name"`
+	/**
+	 * Arguments to use for the tool call.
+	 */
+	Arguments map[string]any `json:"arguments,omitempty"`
 }
 
 // The sender or recipient of messages and data in a conversation.
@@ -309,10 +376,14 @@ type ListPromptsResult struct {
 // Used by the client to get a prompt provided by the server.
 type GetPromptRequest struct {
 	jsonrpc.Request
-	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
-	} `json:"params"`
+	Params GetPromptRequestParams `json:"params"`
+}
+
+// Parameters for a `prompts/get` request.
+type GetPromptRequestParams struct {
+	RequestParams
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
 }
 
 // The server's response to a prompts/get request from the client.

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -44,6 +45,7 @@ const protocolVersion20241105 = "2024-11-05"
 const protocolVersion20250326 = "2025-03-26"
 const protocolVersion20250618 = "2025-06-18"
 const protocolVersion20251125 = "2025-11-25"
+const protocolVersionDraft = "DRAFT-2026-v1"
 const serverName = "Toolbox"
 
 var basicInputSchema = map[string]any{
@@ -436,10 +438,12 @@ func TestMcpEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	versTestCases := []struct {
-		name     string
-		protocol string
-		idHeader bool
-		initWant map[string]any
+		name           string
+		protocol       string
+		idHeader       bool
+		initWant       map[string]any
+		invalidMethods []string
+		meta           map[string]any
 	}{
 		{
 			name:     "version 2024-11-05",
@@ -457,6 +461,8 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+
+			invalidMethods: []string{"server/discover"},
 		},
 		{
 			name:     "version 2025-03-26",
@@ -474,6 +480,7 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+			invalidMethods: []string{"server/discover"},
 		},
 		{
 			name:     "version 2025-06-18",
@@ -491,6 +498,7 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+			invalidMethods: []string{"server/discover"},
 		},
 		{
 			name:     "version 2025-11-25",
@@ -508,11 +516,29 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+			invalidMethods: []string{"server/discover"},
+		},
+		{
+			name:           "version DRAFT",
+			protocol:       protocolVersionDraft,
+			idHeader:       false,
+			invalidMethods: []string{"ping"},
+			meta: map[string]any{
+				"io.modelcontextprotocol/protocolVersion": protocolVersionDraft,
+				"io.modelcontextprotocol/clientInfo": map[string]any{
+					"version": "client-temp-version",
+					"name":    "client-name",
+				},
+				"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+			},
 		},
 	}
 	for _, vtc := range versTestCases {
 		t.Run(vtc.name, func(t *testing.T) {
-			sessionId := runInitializeLifecycle(t, ts, vtc.protocol, vtc.initWant, vtc.idHeader)
+			sessionId := ""
+			if len(vtc.initWant) != 0 {
+				sessionId = runInitializeLifecycle(t, ts, vtc.protocol, vtc.initWant, vtc.idHeader)
+			}
 
 			header := map[string]string{}
 			if sessionId != "" {
@@ -522,11 +548,12 @@ func TestMcpEndpoint(t *testing.T) {
 				header["MCP-Protocol-Version"] = vtc.protocol
 			}
 
-			testCases := []struct {
+			testCases := []*struct {
 				name           string
 				url            string
 				isErr          bool
 				body           any
+				methodName     string
 				wantStatusCode int
 				want           map[string]any
 			}{
@@ -539,6 +566,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "notification",
 						},
 					},
+					methodName:     "notification",
 					wantStatusCode: http.StatusAccepted,
 				},
 				{
@@ -551,11 +579,37 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "ping",
 						},
 					},
+					methodName:     "ping",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "ping-test-123",
 						"result":  map[string]any{},
+					},
+				},
+				{
+					name: "server/discover",
+					url:  "/",
+					body: jsonrpc.JSONRPCRequest{
+						Jsonrpc: jsonrpcVersion,
+						Id:      "server-discover",
+						Request: jsonrpc.Request{
+							Method: "server/discover",
+						},
+					},
+					methodName:     "server/discover",
+					wantStatusCode: http.StatusOK,
+					want: map[string]any{
+						"jsonrpc": "2.0",
+						"id":      "server-discover",
+						"result": map[string]any{
+							"supportedVersions": []any{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25", "DRAFT-2026-v1"},
+							"capabilities": map[string]any{
+								"tools":   map[string]any{"listChanged": false},
+								"prompts": map[string]any{"listChanged": false},
+							},
+							"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+						},
 					},
 				},
 				{
@@ -568,6 +622,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "tools/list",
 						},
 					},
+					methodName:     "tools/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -609,6 +664,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "prompts/list",
 						},
 					},
+					methodName:     "prompts/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -642,6 +698,7 @@ func TestMcpEndpoint(t *testing.T) {
 							},
 						},
 					},
+					methodName:     "prompts/get",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -669,6 +726,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "tools/list",
 						},
 					},
+					methodName:     "tools/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -694,6 +752,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "tools/list",
 						},
 					},
+					methodName:     "tools/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -713,7 +772,8 @@ func TestMcpEndpoint(t *testing.T) {
 						Id:      "missing-method",
 						Request: jsonrpc.Request{},
 					},
-					wantStatusCode: http.StatusOK,
+					methodName:     "",
+					wantStatusCode: http.StatusNotFound,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "missing-method",
@@ -734,7 +794,8 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "foo",
 						},
 					},
-					wantStatusCode: http.StatusOK,
+					methodName:     "foo",
+					wantStatusCode: http.StatusNotFound,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "invalid-method",
@@ -755,6 +816,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "foo",
 						},
 					},
+					methodName:     "foo",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -808,6 +870,7 @@ func TestMcpEndpoint(t *testing.T) {
 							"name": "no_params",
 						},
 					},
+					methodName:     "tools/call",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -835,6 +898,7 @@ func TestMcpEndpoint(t *testing.T) {
 							"name": "unauthorized_tool",
 						},
 					},
+					methodName:     "tools/call",
 					wantStatusCode: http.StatusUnauthorized,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -858,6 +922,7 @@ func TestMcpEndpoint(t *testing.T) {
 							"name": "require_client_auth_tool",
 						},
 					},
+					methodName:     "tools/call",
 					wantStatusCode: http.StatusUnauthorized,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -869,8 +934,22 @@ func TestMcpEndpoint(t *testing.T) {
 					},
 				},
 			}
-			for _, tc := range testCases {
+			for i := range testCases {
+				tc := *testCases[i]
 				t.Run(tc.name, func(t *testing.T) {
+					if vtc.meta != nil {
+						switch v := tc.body.(type) {
+						case jsonrpc.JSONRPCRequest:
+							if v.Params != nil {
+								v.Params.(map[string]any)["_meta"] = vtc.meta
+							} else {
+								v.Params = map[string]any{
+									"_meta": vtc.meta,
+								}
+							}
+							tc.body = v
+						}
+					}
 					reqMarshal, err := json.Marshal(tc.body)
 					if err != nil {
 						t.Fatalf("unexpected error during marshaling of body")
@@ -881,6 +960,10 @@ func TestMcpEndpoint(t *testing.T) {
 					}
 
 					resp, body, err := runRequest(ts, http.MethodPost, tc.url, bytes.NewBuffer(reqMarshal), header)
+
+					if slices.Contains(vtc.invalidMethods, tc.methodName) {
+						return
+					}
 
 					if err != nil {
 						t.Fatalf("unexpected error during request: %s", err)
@@ -901,7 +984,7 @@ func TestMcpEndpoint(t *testing.T) {
 							t.Fatalf("unexpected error unmarshalling body: %s", err)
 						}
 						if !reflect.DeepEqual(got, tc.want) {
-							t.Fatalf("unexpected response: got %+v, want %+v", got, tc.want)
+							t.Fatalf("unexpected response: got %#v, want %#v", got, tc.want)
 						}
 					}
 				})
@@ -911,24 +994,46 @@ func TestMcpEndpoint(t *testing.T) {
 }
 
 func TestInvalidProtocolVersionHeader(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3, testutils.MockTool4, testutils.MockTool5}
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, mockPrompts)
+	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
 
+	reqBody := jsonrpc.JSONRPCRequest{
+		Jsonrpc: jsonrpcVersion,
+		Id:      "tools-list",
+		Request: jsonrpc.Request{
+			Method: "tools/list",
+		},
+	}
+	reqMarshal, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("unexpected error during marshaling of body")
+	}
 	header := map[string]string{}
 	header["MCP-Protocol-Version"] = "foo"
 
-	resp, body, err := runRequest(ts, http.MethodPost, "/", nil, header)
+	resp, body, err := runRequest(ts, http.MethodPost, "/", bytes.NewBuffer(reqMarshal), header)
 	if resp.Status != "400 Bad Request" {
-		t.Fatalf("unexpected status: %s", resp.Status)
+		t.Fatalf("unexpected status: %s; %s", resp.Status, body)
 	}
 	var got map[string]any
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("unexpected error unmarshalling body: %s", err)
 	}
-	want := "invalid protocol version: foo"
-	if got["error"] != want {
+	errMap, ok := got["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'error' field to be a map, got %T", got["error"])
+	}
+	msg, ok := errMap["message"].(string)
+	if !ok {
+		t.Fatalf("expected 'message' field to be a string, got %T", errMap["message"])
+	}
+	want := "unsupported protocol version"
+	if msg != want {
 		t.Fatalf("unexpected error message: got %s, want %s", got["error"], want)
 	}
 	if err != nil {
@@ -1200,85 +1305,121 @@ func TestSseManagerGetNilSessionValue(t *testing.T) {
 	}
 }
 
-// withTraceContextPropagator registers the W3C trace-context propagator globally
-// for the duration of the test. extractMeta delegates to otel.GetTextMapPropagator,
-// and the default global propagator is a no-op — so without this helper the
-// "extracted" trace context would always be invalid.
-func withTraceContextPropagator(t *testing.T) {
+func TestExtractMeta(t *testing.T) {
+	// withTraceContextPropagator registers the W3C trace-context propagator globally
+	// for the duration of the test. extractMeta delegates to otel.GetTextMapPropagator,
+	// and the default global propagator is a no-op — so without this helper the
+	// "extracted" trace context would always be invalid.
 	t.Helper()
 	prev := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
-}
 
-func TestExtractMeta_EmptyOrInvalidBody(t *testing.T) {
-	cases := map[string][]byte{
-		"empty":      []byte(""),
-		"not json":   []byte("not json"),
-		"no _meta":   []byte(`{"params":{}}`),
-		"no params":  []byte(`{"method":"tools/call"}`),
-		"empty meta": []byte(`{"params":{"_meta":{}}}`),
+	testCases := []struct {
+		name                 string
+		body                 []byte
+		wantEmptyCtx         bool
+		wantValidSpanContext bool
+		wantTraceId          string
+		wantProtocolVersion  string
+		wantTelemetryAttr    *util.TelemetryAttributes
+		wantClientName       string
+		wantClientVersion    string
+	}{
+		{
+			name:         "empty meta",
+			body:         []byte(""),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "not json meta",
+			body:         []byte("not json"),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "no _meta",
+			body:         []byte(`{"params":{}}`),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "no params",
+			body:         []byte(`{"method":"tools/call"}`),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "empty meta",
+			body:         []byte(`{"params":{"_meta":{}}}`),
+			wantEmptyCtx: true,
+		},
+		{
+			name:                 "traceparent only",
+			body:                 []byte(`{"params":{"_meta":{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}}}`),
+			wantValidSpanContext: true,
+			wantEmptyCtx:         true,
+		},
+		{
+			name: "telemetry attributes only",
+			body: []byte(`{"params":{"_meta":{"dev.mcp-toolbox/telemetry":{` +
+				`"client.name":"toolbox-langchain-python",` +
+				`"client.version":"v0.1.0",` +
+				`"client.model":"gemini-2.5-flash",` +
+				`"client.user.id":"user-123",` +
+				`"client.agent.id":"agent-456"}}}}`),
+			wantTelemetryAttr: &util.TelemetryAttributes{
+				ClientName: "toolbox-langchain-python", ClientVersion: "v0.1.0",
+				ClientModel: "gemini-2.5-flash", ClientUserID: "user-123", ClientAgentID: "agent-456",
+			},
+		},
+		{
+			name: "traceparent, telemetry and protocol version",
+			body: []byte(`{"params":{"_meta":{` +
+				`"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",` +
+				`"dev.mcp-toolbox/telemetry":{"client.name":"foo","client.version":"v1"},` +
+				`"io.modelcontextprotocol/protocolVersion":"v999"}}}`),
+			wantTelemetryAttr: &util.TelemetryAttributes{
+				ClientName: "foo", ClientVersion: "v1",
+				ClientModel: "", ClientUserID: "", ClientAgentID: "",
+			},
+			wantValidSpanContext: true,
+			wantClientName:       "foo",
+			wantClientVersion:    "v1",
+			wantProtocolVersion:  "v999",
+		},
 	}
-	for name, body := range cases {
-		t.Run(name, func(t *testing.T) {
-			ctx := extractMeta(context.Background(), body)
-			if util.TelemetryAttributesFromContext(ctx) != nil {
-				t.Error("expected no telemetry attributes")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metaProtocolVersion, ctx := extractMeta(context.Background(), tc.body)
+			ta := util.TelemetryAttributesFromContext(ctx)
+			if tc.wantEmptyCtx {
+				if ta != nil {
+					t.Fatalf("expected no telemetry attributes")
+				}
+			}
+
+			if !reflect.DeepEqual(ta, tc.wantTelemetryAttr) {
+				t.Fatalf("got %#v, want %#v", ta, tc.wantTelemetryAttr)
+				if tc.wantClientName != "" && ta.ClientName != tc.wantClientName {
+					t.Fatalf("invalid telemetry attr client name: got %s, want %s", ta.ClientName, tc.wantClientName)
+				}
+				if tc.wantClientVersion != "" && ta.ClientVersion != tc.wantClientVersion {
+					t.Fatalf("invalid telemetry attr client version: got %s, want %s", ta.ClientVersion, tc.wantClientVersion)
+				}
+			}
+
+			if tc.wantValidSpanContext {
+				sc := trace.SpanContextFromContext(ctx)
+				if !sc.IsValid() {
+					t.Fatal("expected valid span context")
+				}
+				if got := sc.TraceID().String(); got != "0af7651916cd43dd8448eb211c80319c" {
+					t.Errorf("trace id mismatch: got %s", got)
+				}
+			}
+
+			if tc.wantProtocolVersion != metaProtocolVersion {
+				t.Fatalf("meta protocol version mismatch: got %s, want %s", metaProtocolVersion, tc.wantProtocolVersion)
 			}
 		})
-	}
-}
-
-func TestExtractMeta_TraceparentOnly(t *testing.T) {
-	withTraceContextPropagator(t)
-	body := []byte(`{"params":{"_meta":{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}}}`)
-	ctx := extractMeta(context.Background(), body)
-
-	sc := trace.SpanContextFromContext(ctx)
-	if !sc.IsValid() {
-		t.Fatal("expected valid span context from extracted traceparent")
-	}
-	if got := sc.TraceID().String(); got != "0af7651916cd43dd8448eb211c80319c" {
-		t.Errorf("trace id mismatch: got %s", got)
-	}
-	if util.TelemetryAttributesFromContext(ctx) != nil {
-		t.Error("expected no telemetry attributes when only traceparent is sent")
-	}
-}
-
-func TestExtractMeta_TelemetryAttrsOnly(t *testing.T) {
-	body := []byte(`{"params":{"_meta":{"dev.mcp-toolbox/telemetry":{` +
-		`"client.name":"toolbox-langchain-python",` +
-		`"client.version":"v0.1.0",` +
-		`"client.model":"gemini-2.5-flash",` +
-		`"client.user.id":"user-123",` +
-		`"client.agent.id":"agent-456"}}}}`)
-
-	ta := util.TelemetryAttributesFromContext(extractMeta(context.Background(), body))
-	if ta == nil {
-		t.Fatal("expected TelemetryAttributes in context")
-	}
-	want := util.TelemetryAttributes{
-		ClientName: "toolbox-langchain-python", ClientVersion: "v0.1.0",
-		ClientModel: "gemini-2.5-flash", ClientUserID: "user-123", ClientAgentID: "agent-456",
-	}
-	if *ta != want {
-		t.Errorf("got %+v, want %+v", *ta, want)
-	}
-}
-
-func TestExtractMeta_TraceparentAndTelemetryBoth(t *testing.T) {
-	withTraceContextPropagator(t)
-	body := []byte(`{"params":{"_meta":{` +
-		`"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",` +
-		`"dev.mcp-toolbox/telemetry":{"client.name":"foo","client.version":"v1"}}}}`)
-	ctx := extractMeta(context.Background(), body)
-
-	if !trace.SpanContextFromContext(ctx).IsValid() {
-		t.Error("expected valid span context")
-	}
-	ta := util.TelemetryAttributesFromContext(ctx)
-	if ta == nil || ta.ClientName != "foo" || ta.ClientVersion != "v1" {
-		t.Errorf("expected telemetry attrs alongside traceparent, got %+v", ta)
 	}
 }


### PR DESCRIPTION
Support [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575)

This PR also updates our custom auth error code since it contradicts with some new errors added in this SEP.:
```
// Custom auth error codes
UNAUTHORIZED = -401
FORBIDDEN    = -403
```


For stdio transport:
* If `_meta.io.modelcontextprotocol/protocolVersion` was provided, it will use the protocol version specified (take precedence over existing version).
* Else, it will use the version during initialization method.
* If no initialization method was called, it will default to `v2024-11-05` similar to Toolbox's HTTP transport. Toolbox had a custom transport on v2024-11-05 --> "regular" HTTP POST (without SSE), that does not enforce the initialize method

For HTTP transport:
* Use the version that was specified in header as protocol version.
* If it specified the DRAFT version, it will check against `_meta.io.modelcontextprotocol/protocolVersion` to validate.