### PR TITLE
fix(tools/http): prevent path traversal and base path scope escape

### DIFF
--- a/docs/en/integrations/http/tools/http-tool.md
+++ b/docs/en/integrations/http/tools/http-tool.md
@@ -217,6 +217,26 @@ will send the following output:
 }
 ```
 
+##### Path Escape
+
+The `pathescape` keyword escapes strings so they can be safely placed inside a URL path segment, replacing special characters like slashes `/` with `%2F`.
+
+Example:
+
+```yaml
+path: /users/{{pathescape .username}}/records
+```
+
+##### Query Escape
+
+The `queryescape` keyword escapes strings to be safely placed inside a URL query string, encoding spaces into `+` and special characters into percent-encoded values.
+
+Example:
+
+```yaml
+path: /search?q={{queryescape .query}}
+```
+
 ## Example
 
 ```yaml

--- a/docs/en/integrations/http/tools/http-tool.md
+++ b/docs/en/integrations/http/tools/http-tool.md
@@ -219,22 +219,22 @@ will send the following output:
 
 ##### Path Escape
 
-The `pathescape` keyword escapes strings so they can be safely placed inside a URL path segment, replacing special characters like slashes `/` with `%2F`.
+The `pathEscape` keyword escapes strings so they can be safely placed inside a URL path segment, replacing special characters like slashes `/` with `%2F`.
 
 Example:
 
 ```yaml
-path: /users/{{pathescape .username}}/records
+path: /users/{{pathEscape .username}}/records
 ```
 
 ##### Query Escape
 
-The `queryescape` keyword escapes strings to be safely placed inside a URL query string, encoding spaces into `+` and special characters into percent-encoded values.
+The `queryEscape` keyword escapes strings to be safely placed inside a URL query string, encoding spaces into `+` and special characters into percent-encoded values.
 
 Example:
 
 ```yaml
-path: /search?q={{queryescape .query}}
+path: /search?q={{queryEscape .query}}
 ```
 
 ## Example

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -170,7 +170,7 @@ func getURL(baseURL, path string, pathParams, queryParams parameters.Parameters,
 	pathParamsMap := pathParamValues.AsMap()
 
 	funcMap := template.FuncMap{
-		"pathescape": func(v any) string {
+		"pathEscape": func(v any) string {
 			if s, ok := v.(string); ok {
 				return url.PathEscape(s)
 			}
@@ -179,7 +179,7 @@ func getURL(baseURL, path string, pathParams, queryParams parameters.Parameters,
 			}
 			return url.PathEscape(fmt.Sprintf("%v", v))
 		},
-		"queryescape": func(v any) string {
+		"queryEscape": func(v any) string {
 			if s, ok := v.(string); ok {
 				return url.QueryEscape(s)
 			}

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -196,9 +196,24 @@ func getURL(baseURL, path string, pathParams, queryParams parameters.Parameters,
 		return "", fmt.Errorf("path must be relative and cannot override base host")
 	}
 
+	// Reject dot segments before resolution
+	if strings.Contains(relativePath, "..") || strings.Contains(relParsedURL.Path, "..") {
+		return "", fmt.Errorf("path cannot contain dot segments (..)")
+	}
+
 	// Create URL based on BaseURL and Path
 	// Attach query parameters
 	parsedURL := baseParsedURL.ResolveReference(relParsedURL)
+
+	// Verify final path stays within base path scope
+	basePath := baseParsedURL.Path
+	finalPath := parsedURL.Path
+	if basePath != "/" {
+		requiredPrefix := strings.TrimSuffix(basePath, "/") + "/"
+		if finalPath != basePath && !strings.HasPrefix(finalPath, requiredPrefix) {
+			return "", fmt.Errorf("resolved path %q escapes base path %q", finalPath, basePath)
+		}
+	}
 
 	// Get existing query parameters from the URL
 	queryParameters := parsedURL.Query()

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -169,7 +169,28 @@ func getURL(baseURL, path string, pathParams, queryParams parameters.Parameters,
 	}
 	pathParamsMap := pathParamValues.AsMap()
 
-	templ, err := template.New("url").Parse(path)
+	funcMap := template.FuncMap{
+		"pathescape": func(v any) string {
+			if s, ok := v.(string); ok {
+				return url.PathEscape(s)
+			}
+			if v == nil {
+				return ""
+			}
+			return url.PathEscape(fmt.Sprintf("%v", v))
+		},
+		"queryescape": func(v any) string {
+			if s, ok := v.(string); ok {
+				return url.QueryEscape(s)
+			}
+			if v == nil {
+				return ""
+			}
+			return url.QueryEscape(fmt.Sprintf("%v", v))
+		},
+	}
+
+	templ, err := template.New("url").Funcs(funcMap).Parse(path)
 	if err != nil {
 		return "", fmt.Errorf("error parsing URL: %s", err)
 	}

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -197,8 +197,10 @@ func getURL(baseURL, path string, pathParams, queryParams parameters.Parameters,
 	}
 
 	// Reject dot segments before resolution
-	if strings.Contains(relativePath, "..") || strings.Contains(relParsedURL.Path, "..") {
-		return "", fmt.Errorf("path cannot contain dot segments (..)")
+	for _, segment := range strings.Split(relParsedURL.Path, "/") {
+		if segment == ".." {
+			return "", fmt.Errorf("path cannot contain dot segments (..)")
+		}
 	}
 
 	// Create URL based on BaseURL and Path

--- a/internal/tools/http/http_url_test.go
+++ b/internal/tools/http/http_url_test.go
@@ -178,7 +178,7 @@ func TestGetURLPathValidation(t *testing.T) {
 
 func TestGetURLCustomFuncs(t *testing.T) {
 	baseURL := "https://api.good.com/v1/"
-	path := "users/{{pathescape .name}}/details?q={{queryescape .query}}"
+	path := "users/{{pathEscape .name}}/details?q={{queryEscape .query}}"
 	pathParams := parameters.Parameters{
 		parameters.NewStringParameter("name", "user name"),
 		parameters.NewStringParameter("query", "search query"),

--- a/internal/tools/http/http_url_test.go
+++ b/internal/tools/http/http_url_test.go
@@ -175,3 +175,27 @@ func TestGetURLPathValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetURLCustomFuncs(t *testing.T) {
+	baseURL := "https://api.good.com/v1/"
+	path := "users/{{pathescape .name}}/details?q={{queryescape .query}}"
+	pathParams := parameters.Parameters{
+		parameters.NewStringParameter("name", "user name"),
+		parameters.NewStringParameter("query", "search query"),
+	}
+
+	paramsMap := map[string]any{
+		"name":  "john/doe",
+		"query": "hello world",
+	}
+
+	urlString, err := getURL(baseURL, path, pathParams, nil, nil, paramsMap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "https://api.good.com/v1/users/john%2Fdoe/details?q=hello+world"
+	if urlString != expected {
+		t.Fatalf("expected %q, got %q", expected, urlString)
+	}
+}

--- a/internal/tools/http/http_url_test.go
+++ b/internal/tools/http/http_url_test.go
@@ -130,6 +130,20 @@ func TestGetURLPathValidation(t *testing.T) {
 			expectError:  false,
 			expectedPath: "/base",
 		},
+		{
+			name:         "double dots in query parameters are allowed",
+			baseURL:      "https://api.good.com/base/",
+			pathParam:    "v1?date=2023-01-01..2023-01-31",
+			expectError:  false,
+			expectedPath: "/base/v1",
+		},
+		{
+			name:         "double dots in non-dot segments are allowed",
+			baseURL:      "https://api.good.com/base/",
+			pathParam:    "file..txt",
+			expectError:  false,
+			expectedPath: "/base/file..txt",
+		},
 	}
 
 	path := "{{.pathParam}}"

--- a/internal/tools/http/http_url_test.go
+++ b/internal/tools/http/http_url_test.go
@@ -76,3 +76,88 @@ func TestGetURLHostOverride(t *testing.T) {
 		})
 	}
 }
+
+func TestGetURLPathValidation(t *testing.T) {
+	testCases := []struct {
+		name         string
+		baseURL      string
+		pathParam    string
+		expectError  bool
+		expectedPath string
+	}{
+		{
+			name:         "valid subpath stays within base path",
+			baseURL:      "https://api.good.com/base/",
+			pathParam:    "v1",
+			expectError:  false,
+			expectedPath: "/base/v1",
+		},
+		{
+			name:        "path with dot segments is rejected",
+			baseURL:     "https://api.good.com/base/",
+			pathParam:   "../v1",
+			expectError: true,
+		},
+		{
+			name:        "absolute path escaping base path scope is rejected",
+			baseURL:     "https://api.good.com/base/",
+			pathParam:   "/v1",
+			expectError: true,
+		},
+		{
+			name:         "absolute path for root base path is allowed",
+			baseURL:      "https://api.good.com/",
+			pathParam:    "/v1",
+			expectError:  false,
+			expectedPath: "/v1",
+		},
+		{
+			name:        "path with url-encoded dot segments is rejected",
+			baseURL:     "https://api.good.com/base/",
+			pathParam:   "%2e%2e/v1",
+			expectError: true,
+		},
+		{
+			name:        "sibling path traversal via simple prefix matching is rejected",
+			baseURL:     "https://api.good.com/base",
+			pathParam:   "/base-private",
+			expectError: true,
+		},
+		{
+			name:         "exact match of base path without trailing slash is allowed",
+			baseURL:      "https://api.good.com/base",
+			pathParam:    "",
+			expectError:  false,
+			expectedPath: "/base",
+		},
+	}
+
+	path := "{{.pathParam}}"
+	pathParams := parameters.Parameters{parameters.NewStringParameter("pathParam", "path")}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			paramsMap := map[string]any{"pathParam": tc.pathParam}
+
+			urlString, err := getURL(tc.baseURL, path, pathParams, nil, nil, paramsMap)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			parsed, err := url.Parse(urlString)
+			if err != nil {
+				t.Fatalf("failed to parse URL: %v", err)
+			}
+
+			if parsed.Path != tc.expectedPath {
+				t.Fatalf("expected path to be %q, got %q", tc.expectedPath, parsed.Path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Rejects relative or URL-encoded dot segments (`..`, `%2e%2e`) to prevent directory traversal.
- Enforces verification to ensure resolved paths do not escape the intended base path scope or allow unauthorized access to sibling paths sharing a simple string prefix.
- Add `pathEscape` and `queryEscape` template functions to prevent path tempering.