### PR TITLE
feat(firestore): add vector embedding support for document writes

### DIFF
--- a/docs/en/integrations/firestore/source.md
+++ b/docs/en/integrations/firestore/source.md
@@ -82,3 +82,27 @@ project: "my-project-id"
 | type      |  string  |     true     | Must be "firestore".                                                                                     |
 | project   |  string  |     true     | Id of the GCP project that contains the Firestore database (e.g. "my-project-id").                       |
 | database  |  string  |     false    | Name of the Firestore database to connect to. Defaults to "(default)" if not specified.                  |
+
+## Advanced Usage
+
+### Vector Embedding Support
+
+Firestore source supports native vector embeddings when used with the `vectorFields` configuration in supported tools. This enables automatic ingestion of embeddings and native vector similarity search.
+
+#### Automatic Ingestion
+When adding or updating documents, you can configure `vectorFields` to automatically generate embeddings for text fields using an `embeddingModel`. The resulting vectors are stored as native Firestore arrays of doubles.
+
+#### Vector Similarity Search
+You can perform semantic searches using natural language prompts. The system automatically embeds the search prompt and executes a Firestore native `findNearest` query.
+
+#### Requirements
+To use vector search, you must create a **Vector Index** for the specific field in your Firestore database.
+
+```bash
+gcloud firestore indexes composite create \
+  --project=PROJECT_ID \
+  --collection-group=COLLECTION_GROUP \
+  --query-scope=COLLECTION \
+  --field-config=vector-config='{"dimension":"DIMENSIONS","flat": "{}"}',field-path=FIELD_PATH
+```
+

--- a/docs/en/integrations/firestore/tools/firestore-add-documents.md
+++ b/docs/en/integrations/firestore/tools/firestore-add-documents.md
@@ -23,6 +23,8 @@ each new document.
 | `collectionPath` | string  | Yes      | The path of the collection where the document will be added                                                                                                                                                   |
 | `documentData`   | map     | Yes      | The data to be added as a document to the given collection. Must use [Firestore's native JSON format](https://cloud.google.com/firestore/docs/reference/rest/Shared.Types/ArrayValue#Value) with typed values |
 | `returnData`     | boolean | No       | If set to true, the output will include the data of the created document. Defaults to false to help avoid overloading the context                                                                             |
+| `vectorFields`   | list    | No       | Configuration for automatic vector embedding. See [Vector Embedding Support](#vector-embedding-support)                                                                                                       |
+
 
 ### Data Type Format
 
@@ -232,6 +234,36 @@ Usage:
   }
 }
 ```
+
+### With Vector Embedding
+
+Automatically generate embeddings for a text field and store them in the document.
+
+```yaml
+kind: tool
+name: add-embedded-doc
+type: firestore-add-documents
+source: my-firestore
+vectorFields:
+  - name: description
+    fieldPath: description_embedding
+    embeddedBy: my-text-embedding-model
+```
+
+Usage:
+
+```json
+{
+  "collectionPath": "products",
+  "documentData": {
+    "title": { "stringValue": "Wireless Headphones" },
+    "description": { "stringValue": "High-quality noise-cancelling wireless headphones with 30-hour battery life." }
+  }
+}
+```
+
+The tool will automatically call `my-text-embedding-model` with the value of the `description` field and store the resulting vector in the `description_embedding` field of the document.
+
 
 ## Output Format
 

--- a/docs/en/integrations/firestore/tools/firestore-query-collection.md
+++ b/docs/en/integrations/firestore/tools/firestore-query-collection.md
@@ -24,6 +24,8 @@ with filters, ordering, and limit capabilities.
 | `orderBy`        |    string    |     false    |      -      | JSON string specifying field and direction to order results           |
 | `limit`          |    integer   |     false    |     100     | Maximum number of documents to return                                 |
 | `analyzeQuery`   |    boolean   |     false    |    false    | If true, returns query explain metrics including execution statistics |
+| `vectorFields`   |    list      |     false    |      -      | Configuration for vector similarity search.                           |
+
 
 ## Example
 
@@ -149,6 +151,32 @@ Direction values:
   "analyzeQuery": true
 }
 ```
+
+### Vector Search
+
+You can perform semantic searches on a collection by configuring `vectorFields`.
+
+```yaml
+kind: tool
+name: find_similar_profiles
+type: firestore-query-collection
+source: my-firestore
+vectorFields:
+  - name: search_query
+    fieldPath: profile_embedding
+    embeddedBy: text-embedding-model
+    distanceMeasure: COSINE
+```
+
+Usage:
+
+```json
+{
+  "collectionPath": "users",
+  "search_query": "AI researcher with experience in Python"
+}
+```
+
 
 ## Output Format
 

--- a/docs/en/integrations/firestore/tools/firestore-query.md
+++ b/docs/en/integrations/firestore/tools/firestore-query.md
@@ -50,7 +50,9 @@ developers can use to create custom tools with specific query patterns.
 | `orderBy`        | object  | No       | Ordering configuration with `field` and `direction`(supports templates for the value of field or direction) |
 | `limit`          | integer | No       | Maximum number of documents to return (default: 100) (supports templates)                                   |
 | `analyzeQuery`   | boolean | No       | Whether to analyze query performance (default: false)                                                       |
+| `vectorFields`   | list    | No       | Configuration for vector similarity search. See [Vector Search](#vector-search)                             |
 | `parameters`     | array   | Yes      | Parameter definitions for template substitution                                                             |
+
 
 ### Runtime Parameters
 
@@ -352,6 +354,54 @@ parameters:
     description: End time in RFC3339 format
     required: true
 ```
+
+## Vector Search
+
+The `firestore-query` tool supports native Firestore vector similarity search using the `findNearest` operation. This allows you to perform semantic searches using natural language prompts.
+
+### Configuration
+
+To enable vector search, add the `vectorFields` configuration to your tool:
+
+```yaml
+vectorFields:
+  - name: search_query
+    fieldPath: description_embedding
+    embeddedBy: my-text-embedding-model
+    distanceMeasure: COSINE
+```
+
+| Field             | Type   | Description                                                                 |
+|-------------------|--------|-----------------------------------------------------------------------------|
+| `name`            | string | The name of the runtime parameter that will hold the search prompt.         |
+| `fieldPath`       | string | The path to the vector field in your Firestore documents.                   |
+| `embeddedBy`      | string | The name of the `embeddingModel` to use for embedding the search prompt.    |
+| `distanceMeasure` | string | The distance metric to use: `EUCLIDEAN`, `COSINE`, or `DOT_PRODUCT`.        |
+
+### Example: Semantic Product Search
+
+```yaml
+kind: tool
+name: search_products
+type: firestore-query
+source: my-firestore
+description: Search for products using natural language
+collectionPath: "products"
+vectorFields:
+  - name: query
+    fieldPath: description_embedding
+    embeddedBy: my-text-embedding-model
+    distanceMeasure: COSINE
+parameters:
+  - name: query
+    type: string
+    description: Semantic search query (e.g. "portable audio gear")
+    required: true
+```
+
+### Technical Note on Limits
+When performing a vector search, Firestore uses the `limit` parameter to determine the number of nearest neighbors to return. Standard query filters can still be applied, but they act as a pre-filter for the vector search.
+
 
 ## Advanced Usage
 

--- a/docs/en/integrations/firestore/tools/firestore-update-document.md
+++ b/docs/en/integrations/firestore/tools/firestore-update-document.md
@@ -26,6 +26,8 @@ deleted from the document, following Firestore's native behavior.
 | `documentData` | map     | Yes      | The data to update in the document. Must use [Firestore's native JSON format](https://cloud.google.com/firestore/docs/reference/rest/Shared.Types/ArrayValue#Value) with typed values                                                                  |
 | `updateMask`   | array   | No       | The selective fields to update. If not provided, all fields in documentData will be updated. When provided, only the specified fields will be updated. Fields referenced in the mask but not present in documentData will be deleted from the document |
 | `returnData`   | boolean | No       | If set to true, the output will include the data of the updated document. Defaults to false to help avoid overloading the context                                                                                                                      |
+| `vectorFields` | list    | No       | Configuration for automatic vector embedding. See [Vector Embedding Support](#vector-embedding-support)                                                                                                                                               |
+
 
 ### Data Type Format
 
@@ -278,6 +280,36 @@ In this example:
   "returnData": true
 }
 ```
+
+### With Vector Embedding
+
+Automatically update embeddings when document text changes.
+
+```yaml
+kind: tool
+name: update-embedded-doc
+type: firestore-update-document
+source: my-firestore
+vectorFields:
+  - name: bio
+    fieldPath: bio_embedding
+    embeddedBy: my-text-embedding-model
+```
+
+Usage:
+
+```json
+{
+  "documentPath": "users/user123",
+  "documentData": {
+    "bio": { "stringValue": "AI Engineer specializing in vector databases and MCP." }
+  },
+  "updateMask": ["bio"]
+}
+```
+
+The tool will automatically re-embed the updated `bio` text and store the new vector in the `bio_embedding` field.
+
 
 ## Output Format
 

--- a/internal/sources/firestore/firestore.go
+++ b/internal/sources/firestore/firestore.go
@@ -168,7 +168,9 @@ func (s *Source) BuildQuery(collectionPath string, filter firestore.EntityFilter
 	if field != "" {
 		query = query.OrderBy(field, direction)
 	}
-	query = query.Limit(limit)
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
 
 	// Apply analyze options if enabled
 	if analyzeQuery {
@@ -196,9 +198,17 @@ type QueryResponse struct {
 	ExplainMetrics map[string]any `json:"explainMetrics,omitempty"`
 }
 
+// DocumentQuery is an interface for queries that can return documents
+type DocumentQuery interface {
+	Documents(ctx context.Context) *firestore.DocumentIterator
+}
+
 // ExecuteQuery runs the query and formats the results
-func (s *Source) ExecuteQuery(ctx context.Context, query *firestore.Query, analyzeQuery bool) (any, error) {
-	docIterator := query.Documents(ctx)
+func (s *Source) ExecuteQuery(ctx context.Context, query DocumentQuery, analyzeQuery bool) (any, error) {
+	return s.executeIterator(query.Documents(ctx), analyzeQuery)
+}
+
+func (s *Source) executeIterator(docIterator *firestore.DocumentIterator, analyzeQuery bool) (any, error) {
 	docs, err := docIterator.GetAll()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)

--- a/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
+++ b/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
@@ -53,9 +53,10 @@ type compatibleSource interface {
 
 type Config struct {
 	tools.ConfigBase `yaml:",inline"`
-	Type             string                 `yaml:"type" validate:"required"`
-	Source           string                 `yaml:"source" validate:"required"`
-	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Type             string                     `yaml:"type" validate:"required"`
+	Source           string                     `yaml:"source" validate:"required"`
+	Annotations      *tools.ToolAnnotations     `yaml:"annotations,omitempty"`
+	VectorFields     []fsUtil.VectorFieldConfig `yaml:"vectorFields"`
 }
 
 // validate interface
@@ -105,6 +106,16 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 		returnDataParameter,
 	}
 
+	vectorFields := make([]fsUtil.VectorFieldRuntime, 0, len(cfg.VectorFields))
+	for _, vfCfg := range cfg.VectorFields {
+		param, runtime, err := fsUtil.BuildVectorFieldParameter(vfCfg)
+		if err != nil {
+			return nil, err
+		}
+		params = append(params, param)
+		vectorFields = append(vectorFields, runtime)
+	}
+
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
@@ -112,6 +123,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 			tools.Manifest{Description: cfg.Description, Parameters: params.Manifest(), AuthRequired: cfg.AuthRequired},
 			params,
 		),
+		vectorFields: vectorFields,
 	}, nil
 }
 
@@ -120,6 +132,7 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	tools.BaseTool[Config]
+	vectorFields []fsUtil.VectorFieldRuntime
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -152,6 +165,20 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	documentData, err := fsUtil.JSONToFirestoreValue(documentDataRaw, source.FirestoreClient())
 	if err != nil {
 		return nil, util.NewAgentError(fmt.Sprintf("failed to convert document data: %v", err), err)
+	}
+
+	vectorValues, err := fsUtil.ExtractVectorFieldValues(mapParams, t.vectorFields)
+	if err != nil {
+		return nil, util.NewAgentError(fmt.Sprintf("invalid vector field: %v", err), err)
+	}
+	if len(vectorValues) > 0 {
+		dataMap, ok := documentData.(map[string]any)
+		if !ok {
+			return nil, util.NewAgentError("documentData must be an object when vector fields are provided", nil)
+		}
+		if err := fsUtil.UpsertVectorValues(dataMap, vectorValues); err != nil {
+			return nil, util.NewAgentError(fmt.Sprintf("failed to apply vector fields: %v", err), err)
+		}
 	}
 
 	// Get return document data flag

--- a/internal/tools/firestore/firestorequery/firestorequery.go
+++ b/internal/tools/firestore/firestorequery/firestorequery.go
@@ -24,6 +24,8 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+
+	firestoreSource "github.com/googleapis/mcp-toolbox/internal/sources/firestore"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -54,7 +56,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 type compatibleSource interface {
 	FirestoreClient() *firestoreapi.Client
 	BuildQuery(string, firestoreapi.EntityFilter, []string, string, firestoreapi.Direction, int, bool) (*firestoreapi.Query, error)
-	ExecuteQuery(context.Context, *firestoreapi.Query, bool) (any, error)
+	ExecuteQuery(context.Context, firestoreSource.DocumentQuery, bool) (any, error)
 }
 
 // Config represents the configuration for the Firestore query tool
@@ -64,12 +66,13 @@ type Config struct {
 	Source           string `yaml:"source" validate:"required"`
 
 	// Template fields
-	CollectionPath string         `yaml:"collectionPath" validate:"required"`
-	Filters        string         `yaml:"filters"`      // JSON string template
-	Select         []string       `yaml:"select"`       // Fields to select
-	OrderBy        map[string]any `yaml:"orderBy"`      // Order by configuration
-	Limit          string         `yaml:"limit"`        // Limit template (can be a number or template)
-	AnalyzeQuery   bool           `yaml:"analyzeQuery"` // Analyze query (boolean, not parameterizable)
+	CollectionPath string                    `yaml:"collectionPath" validate:"required"`
+	Filters        string                    `yaml:"filters"`      // JSON string template
+	Select         []string                  `yaml:"select"`       // Fields to select
+	OrderBy        map[string]any            `yaml:"orderBy"`      // Order by configuration
+	Limit          string                    `yaml:"limit"`        // Limit template (can be a number or template)
+	AnalyzeQuery   bool                      `yaml:"analyzeQuery"` // Analyze query (boolean, not parameterizable)
+	VectorQuery    *fsUtil.VectorQueryConfig `yaml:"vectorQuery"`
 
 	// Parameters for template substitution
 	Parameters  parameters.Parameters  `yaml:"parameters"`
@@ -95,6 +98,18 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 		cfg.Limit = fmt.Sprintf("%d", defaultLimit)
 	}
 
+	var vectorQueryRuntime *fsUtil.VectorQueryRuntime
+	if cfg.VectorQuery != nil {
+		param, runtime, err := fsUtil.BuildVectorQueryRuntime(cfg.VectorQuery)
+		if err != nil {
+			return nil, err
+		}
+		if param != nil {
+			cfg.Parameters = append(cfg.Parameters, param)
+		}
+		vectorQueryRuntime = runtime
+	}
+
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
@@ -102,6 +117,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 			tools.Manifest{Description: cfg.Description, Parameters: cfg.Parameters.Manifest(), AuthRequired: cfg.AuthRequired},
 			cfg.Parameters,
 		),
+		vectorQuery: vectorQueryRuntime,
 	}, nil
 }
 
@@ -111,6 +127,7 @@ var _ tools.Tool = Tool{}
 // Tool represents the Firestore query tool
 type Tool struct {
 	tools.BaseTool[Config]
+	vectorQuery *fsUtil.VectorQueryRuntime
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -209,11 +226,32 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		orderByDirection = orderBy.GetDirection()
 	}
 
+	if t.vectorQuery != nil {
+		vectorValues, ok, extractErr := fsUtil.ExtractVectorQueryValue(paramsMap, t.vectorQuery)
+		if extractErr != nil {
+			return nil, util.NewAgentError(fmt.Sprintf("invalid vector query: %v", extractErr), extractErr)
+		}
+		if ok {
+			// Build the query WITHOUT limit for vector search
+			query, err := source.BuildQuery(collectionPath, filter, selectFields, orderByField, orderByDirection, 0, t.Cfg.AnalyzeQuery)
+			if err != nil {
+				return nil, util.ProcessGcpError(err)
+			}
+			nearestQuery := query.FindNearest(t.vectorQuery.FieldPath, firestoreapi.Vector64(vectorValues), limit, t.vectorQuery.Measure, fsUtil.BuildFindNearestOptions(t.vectorQuery))
+			resp, err := source.ExecuteQuery(ctx, nearestQuery, t.Cfg.AnalyzeQuery)
+			if err != nil {
+				return nil, util.ProcessGcpError(err)
+			}
+			return resp, nil
+		}
+	}
+
 	// Build the query
 	query, err := source.BuildQuery(collectionPath, filter, selectFields, orderByField, orderByDirection, limit, t.Cfg.AnalyzeQuery)
 	if err != nil {
 		return nil, util.ProcessGcpError(err)
 	}
+
 	// Execute the query and return results
 	resp, err := source.ExecuteQuery(ctx, query, t.Cfg.AnalyzeQuery)
 	if err != nil {

--- a/internal/tools/firestore/firestorequery/firestorequery_test.go
+++ b/internal/tools/firestore/firestorequery/firestorequery_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/firestore/firestorequery"
+	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
@@ -310,6 +311,58 @@ func TestParseFromYamlFirestoreQuery(t *testing.T) {
 						parameters.NewFloatParameterWithRequired("minGdp", "Minimum GDP value", true),
 						parameters.NewBooleanParameterWithRequired("isActive", "Filter by active status", true),
 						parameters.NewStringParameterWithRequired("startDate", "Start date in RFC3339 format", true),
+					},
+				},
+			},
+		},
+		{
+			desc: "with vector query configuration",
+			in: `
+            kind: tool
+            name: query_with_vector
+            type: firestore-query
+            source: vec-firestore
+            description: Query with vector search
+            collectionPath: "documents"
+            limit: 25
+            vectorQuery:
+                name: search_prompt
+                description: Natural language description
+                fieldPath: embedding
+                embeddedBy: gemini-model
+                distanceMeasure: COSINE
+                distanceResultField: distance
+                distanceThreshold: 0.5
+                required: false
+            parameters:
+                - name: base
+                  type: string
+                  description: Base filter
+                  required: true
+			`,
+			want: server.ToolConfigs{
+				"query_with_vector": firestorequery.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "query_with_vector",
+						Description:  "Query with vector search",
+						AuthRequired: []string{},
+					},
+					Type:           "firestore-query",
+					Source:         "vec-firestore",
+					CollectionPath: "documents",
+					Limit:          "25",
+					VectorQuery: &fsUtil.VectorQueryConfig{
+						Name:                "search_prompt",
+						Description:         "Natural language description",
+						FieldPath:           "embedding",
+						EmbeddedBy:          "gemini-model",
+						DistanceMeasure:     "COSINE",
+						DistanceResultField: "distance",
+						DistanceThreshold:   func() *float64 { v := 0.5; return &v }(),
+						Required:            false,
+					},
+					Parameters: parameters.Parameters{
+						parameters.NewStringParameterWithRequired("base", "Base filter", true),
 					},
 				},
 			},

--- a/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
+++ b/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
@@ -23,6 +23,8 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+
+	firestoreSource "github.com/googleapis/mcp-toolbox/internal/sources/firestore"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -90,15 +92,16 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 type compatibleSource interface {
 	FirestoreClient() *firestoreapi.Client
 	BuildQuery(string, firestoreapi.EntityFilter, []string, string, firestoreapi.Direction, int, bool) (*firestoreapi.Query, error)
-	ExecuteQuery(context.Context, *firestoreapi.Query, bool) (any, error)
+	ExecuteQuery(context.Context, firestoreSource.DocumentQuery, bool) (any, error)
 }
 
 // Config represents the configuration for the Firestore query collection tool
 type Config struct {
 	tools.ConfigBase `yaml:",inline"`
-	Type             string                 `yaml:"type" validate:"required"`
-	Source           string                 `yaml:"source" validate:"required"`
-	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Type             string                    `yaml:"type" validate:"required"`
+	Source           string                    `yaml:"source" validate:"required"`
+	Annotations      *tools.ToolAnnotations    `yaml:"annotations,omitempty"`
+	VectorQuery      *fsUtil.VectorQueryConfig `yaml:"vectorQuery"`
 }
 
 // validate interface
@@ -118,6 +121,18 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	// Create parameters
 	params := createParameters()
 
+	var vectorQueryRuntime *fsUtil.VectorQueryRuntime
+	if cfg.VectorQuery != nil {
+		param, runtime, err := fsUtil.BuildVectorQueryRuntime(cfg.VectorQuery)
+		if err != nil {
+			return nil, err
+		}
+		if param != nil {
+			params = append(params, param)
+		}
+		vectorQueryRuntime = runtime
+	}
+
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
@@ -125,6 +140,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 			tools.Manifest{Description: cfg.Description, Parameters: params.Manifest(), AuthRequired: cfg.AuthRequired},
 			params,
 		),
+		vectorQuery: vectorQueryRuntime,
 	}, nil
 }
 
@@ -183,6 +199,7 @@ var _ tools.Tool = Tool{}
 // Tool represents the Firestore query collection tool
 type Tool struct {
 	tools.BaseTool[Config]
+	vectorQuery *fsUtil.VectorQueryRuntime
 }
 
 // FilterConfig represents a filter for the query
@@ -235,7 +252,8 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	// Parse parameters
-	queryParams, err := t.parseQueryParameters(params)
+	mapParams := params.AsMap()
+	queryParams, err := t.parseQueryParameters(mapParams)
 	if err != nil {
 		return nil, util.NewAgentError(fmt.Sprintf("failed to parse query parameters: %v", err), err)
 	}
@@ -265,11 +283,32 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		orderByDirection = queryParams.OrderBy.GetDirection()
 	}
 
-	// Build the query
+	if t.vectorQuery != nil {
+		vectorValues, ok, extractErr := fsUtil.ExtractVectorQueryValue(mapParams, t.vectorQuery)
+		if extractErr != nil {
+			return nil, util.NewAgentError(fmt.Sprintf("invalid vector query: %v", extractErr), extractErr)
+		}
+		if ok {
+			// Build the query WITHOUT limit for vector search
+			query, err := source.BuildQuery(queryParams.CollectionPath, filter, nil, orderByField, orderByDirection, 0, queryParams.AnalyzeQuery)
+			if err != nil {
+				return nil, util.ProcessGcpError(err)
+			}
+			nearestQuery := query.FindNearest(t.vectorQuery.FieldPath, firestoreapi.Vector64(vectorValues), queryParams.Limit, t.vectorQuery.Measure, fsUtil.BuildFindNearestOptions(t.vectorQuery))
+			resp, err := source.ExecuteQuery(ctx, nearestQuery, queryParams.AnalyzeQuery)
+			if err != nil {
+				return nil, util.ProcessGcpError(err)
+			}
+			return resp, nil
+		}
+	}
+
+	// Build the regular query with limit
 	query, err := source.BuildQuery(queryParams.CollectionPath, filter, nil, orderByField, orderByDirection, queryParams.Limit, queryParams.AnalyzeQuery)
 	if err != nil {
 		return nil, util.ProcessGcpError(err)
 	}
+
 	resp, err := source.ExecuteQuery(ctx, query, queryParams.AnalyzeQuery)
 	if err != nil {
 		return nil, util.ProcessGcpError(err)
@@ -287,9 +326,7 @@ type queryParameters struct {
 }
 
 // parseQueryParameters extracts and validates parameters from the input
-func (t Tool) parseQueryParameters(params parameters.ParamValues) (*queryParameters, error) {
-	mapParams := params.AsMap()
-
+func (t Tool) parseQueryParameters(mapParams map[string]any) (*queryParameters, error) {
 	// Get collection path
 	collectionPath, ok := mapParams[collectionPathKey].(string)
 	if !ok || collectionPath == "" {

--- a/internal/tools/firestore/firestorequerycollection/firestorequerycollection_test.go
+++ b/internal/tools/firestore/firestorequerycollection/firestorequerycollection_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/firestore/firestorequerycollection"
+	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 )
 
 func TestParseFromYamlFirestoreQueryCollection(t *testing.T) {
@@ -76,6 +77,46 @@ func TestParseFromYamlFirestoreQueryCollection(t *testing.T) {
 					},
 					Type:   "firestore-query-collection",
 					Source: "prod-firestore",
+				},
+			},
+		},
+		{
+			desc: "with vector query config",
+			in: `
+            kind: tool
+            name: query_vector
+            type: firestore-query-collection
+            source: vec-firestore
+            description: Query with vector search
+            vectorQuery:
+                name: search_prompt
+                description: Search prompt
+                fieldPath: embedding
+                embeddedBy: gemini-model
+                distanceMeasure: COSINE
+                distanceResultField: distance
+                distanceThreshold: 0.6
+                required: false
+			`,
+			want: server.ToolConfigs{
+				"query_vector": firestorequerycollection.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "query_vector",
+						Description:  "Query with vector search",
+						AuthRequired: []string{},
+					},
+					Type:         "firestore-query-collection",
+					Source:       "vec-firestore",
+					VectorQuery: &fsUtil.VectorQueryConfig{
+						Name:                "search_prompt",
+						Description:         "Search prompt",
+						FieldPath:           "embedding",
+						EmbeddedBy:          "gemini-model",
+						DistanceMeasure:     "COSINE",
+						DistanceResultField: "distance",
+						DistanceThreshold:   func() *float64 { v := 0.6; return &v }(),
+						Required:            false,
+					},
 				},
 			},
 		},

--- a/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
+++ b/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
@@ -55,9 +55,10 @@ type compatibleSource interface {
 
 type Config struct {
 	tools.ConfigBase `yaml:",inline"`
-	Type             string                 `yaml:"type" validate:"required"`
-	Source           string                 `yaml:"source" validate:"required"`
-	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Type             string                     `yaml:"type" validate:"required"`
+	Source           string                     `yaml:"source" validate:"required"`
+	Annotations      *tools.ToolAnnotations     `yaml:"annotations,omitempty"`
+	VectorFields     []fsUtil.VectorFieldConfig `yaml:"vectorFields"`
 }
 
 // validate interface
@@ -115,6 +116,16 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 		returnDataParameter,
 	}
 
+	vectorFields := make([]fsUtil.VectorFieldRuntime, 0, len(cfg.VectorFields))
+	for _, vfCfg := range cfg.VectorFields {
+		param, runtime, err := fsUtil.BuildVectorFieldParameter(vfCfg)
+		if err != nil {
+			return nil, err
+		}
+		params = append(params, param)
+		vectorFields = append(vectorFields, runtime)
+	}
+
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
@@ -122,6 +133,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 			tools.Manifest{Description: cfg.Description, Parameters: params.Manifest(), AuthRequired: cfg.AuthRequired},
 			params,
 		),
+		vectorFields: vectorFields,
 	}, nil
 }
 
@@ -130,6 +142,7 @@ var _ tools.Tool = Tool{}
 
 type Tool struct {
 	tools.BaseTool[Config]
+	vectorFields []fsUtil.VectorFieldRuntime
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -161,6 +174,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter", documentDataKey), nil)
 	}
 
+	vectorValues, err := fsUtil.ExtractVectorFieldValues(mapParams, t.vectorFields)
+	if err != nil {
+		return nil, util.NewAgentError(fmt.Sprintf("invalid vector field: %v", err), err)
+	}
+
 	// Get update mask if provided
 	var updatePaths []string
 	if updateMaskRaw, ok := mapParams[updateMaskKey]; ok && updateMaskRaw != nil {
@@ -188,9 +206,16 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		}
 
 		// Ensure it's a map
-		dataMapTyped, ok := dataMap.(map[string]interface{})
+		dataMapTyped, ok := dataMap.(map[string]any)
 		if !ok {
 			return nil, util.NewAgentError("document data must be a map", nil)
+		}
+
+		if len(vectorValues) > 0 {
+			if err := fsUtil.UpsertVectorValues(dataMapTyped, vectorValues); err != nil {
+				return nil, util.NewAgentError(fmt.Sprintf("failed to apply vector fields: %v", err), err)
+			}
+			updatePaths = fsUtil.EnsureFieldPaths(updatePaths, vectorValues)
 		}
 
 		for _, path := range updatePaths {
@@ -211,6 +236,15 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		documentData, err = fsUtil.JSONToFirestoreValue(documentDataRaw, source.FirestoreClient())
 		if err != nil {
 			return nil, util.NewAgentError(fmt.Sprintf("failed to convert document data: %v", err), err)
+		}
+		if len(vectorValues) > 0 {
+			dataMap, ok := documentData.(map[string]any)
+			if !ok {
+				return nil, util.NewAgentError("documentData must be an object when vector fields are provided", nil)
+			}
+			if err := fsUtil.UpsertVectorValues(dataMap, vectorValues); err != nil {
+				return nil, util.NewAgentError(fmt.Sprintf("failed to apply vector fields: %v", err), err)
+			}
 		}
 	}
 

--- a/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument_test.go
+++ b/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument_test.go
@@ -19,12 +19,14 @@ import (
 	"strings"
 	"testing"
 
+	firestoreapi "cloud.google.com/go/firestore"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	firestoreds "github.com/googleapis/mcp-toolbox/internal/sources/firestore"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
+	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
@@ -440,5 +442,172 @@ func TestGetFieldValue(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+type mockFirestoreSource struct {
+	sources.Source
+	lastDocumentPath string
+	lastUpdates      []firestoreapi.Update
+	lastDocumentData any
+	lastReturnData   bool
+}
+
+func (m *mockFirestoreSource) SourceType() string {
+	return "firestore"
+}
+
+func (m *mockFirestoreSource) ToConfig() sources.SourceConfig {
+	return nil
+}
+
+func (m *mockFirestoreSource) FirestoreClient() *firestoreapi.Client {
+	return nil
+}
+
+func (m *mockFirestoreSource) UpdateDocument(_ context.Context, documentPath string, updates []firestoreapi.Update, documentData any, returnData bool) (map[string]any, error) {
+	m.lastDocumentPath = documentPath
+	m.lastUpdates = updates
+	m.lastDocumentData = documentData
+	m.lastReturnData = returnData
+	return map[string]any{"status": "ok"}, nil
+}
+
+type mockSourceProvider struct {
+	sourceName string
+	source     sources.Source
+}
+
+func (m mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	if name == m.sourceName {
+		return m.source, true
+	}
+	return nil, false
+}
+
+func TestToolInvoke_AppliesVectorFieldsWithoutMask(t *testing.T) {
+	cfg := Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "update-docs",
+			Description: "Update doc",
+		},
+		Type:        resourceType,
+		Source:      "firestore-source",
+		VectorFields: []fsUtil.VectorFieldConfig{
+			{
+				Name:        "content_to_embed",
+				Description: "text",
+				FieldPath:   "embedding",
+				EmbeddedBy:  "gemini",
+			},
+		},
+	}
+
+	toolIface, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	tool := toolIface.(Tool)
+
+	firestoreSource := &mockFirestoreSource{}
+	provider := mockSourceProvider{sourceName: cfg.Source, source: firestoreSource}
+
+	params := parameters.ParamValues{
+		{Name: documentPathKey, Value: "users/user1"},
+		{Name: documentDataKey, Value: map[string]any{
+			"mapValue": map[string]any{
+				"fields": map[string]any{
+					"title": map[string]any{"stringValue": "hello"},
+				},
+			},
+		}},
+		{Name: returnDocumentDataKey, Value: false},
+		{Name: cfg.VectorFields[0].Name, Value: []float32{0.25, -0.25}},
+	}
+
+	if _, err := tool.Invoke(context.Background(), provider, params, ""); err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+
+	dataMap, ok := firestoreSource.lastDocumentData.(map[string]any)
+	if !ok {
+		t.Fatalf("expected document data map, got %T", firestoreSource.lastDocumentData)
+	}
+	vector, ok := dataMap["embedding"].([]float64)
+	if !ok {
+		t.Fatalf("expected embedding field to be present")
+	}
+	if diff := cmp.Diff([]float64{0.25, -0.25}, vector); diff != "" {
+		t.Fatalf("embedding mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestToolInvoke_AppliesVectorFieldsWithUpdateMask(t *testing.T) {
+	cfg := Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "update-docs",
+			Description: "Update doc",
+		},
+		Type:        resourceType,
+		Source:      "firestore-source",
+		VectorFields: []fsUtil.VectorFieldConfig{
+			{
+				Name:        "content_to_embed",
+				Description: "text",
+				FieldPath:   "embedding",
+				EmbeddedBy:  "gemini",
+			},
+		},
+	}
+
+	toolIface, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	tool := toolIface.(Tool)
+
+	firestoreSource := &mockFirestoreSource{}
+	provider := mockSourceProvider{sourceName: cfg.Source, source: firestoreSource}
+
+	params := parameters.ParamValues{
+		{Name: documentPathKey, Value: "users/user1"},
+		{Name: documentDataKey, Value: map[string]any{
+			"mapValue": map[string]any{
+				"fields": map[string]any{
+					"title": map[string]any{"stringValue": "hello"},
+				},
+			},
+		}},
+		{Name: updateMaskKey, Value: []any{"title"}},
+		{Name: returnDocumentDataKey, Value: false},
+		{Name: cfg.VectorFields[0].Name, Value: []float64{0.5, 0.75}},
+	}
+
+	if _, err := tool.Invoke(context.Background(), provider, params, ""); err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+
+	if firestoreSource.lastDocumentData != nil {
+		t.Fatalf("expected document data to be nil for masked update")
+	}
+	if len(firestoreSource.lastUpdates) != 2 {
+		t.Fatalf("expected two updates (scalar + vector), got %d", len(firestoreSource.lastUpdates))
+	}
+
+	foundVector := false
+	for _, update := range firestoreSource.lastUpdates {
+		if update.Path == "embedding" {
+			vector, ok := update.Value.([]float64)
+			if !ok {
+				t.Fatalf("vector update has unexpected type %T", update.Value)
+			}
+			if diff := cmp.Diff([]float64{0.5, 0.75}, vector); diff != "" {
+				t.Fatalf("vector update mismatch (-want +got):\n%s", diff)
+			}
+			foundVector = true
+		}
+	}
+	if !foundVector {
+		t.Fatalf("expected embedding field to be added to update mask")
 	}
 }

--- a/internal/tools/firestore/util/vector.go
+++ b/internal/tools/firestore/util/vector.go
@@ -1,0 +1,294 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/firestore"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+// VectorFieldConfig defines a plain-text input that should be embedded and stored
+// at the specified Firestore field path during writes.
+type VectorFieldConfig struct {
+	Name           string `yaml:"name" validate:"required"`
+	Description    string `yaml:"description"`
+	FieldPath      string `yaml:"fieldPath" validate:"required"`
+	EmbeddedBy     string `yaml:"embeddedBy" validate:"required"`
+	Required       bool   `yaml:"required"`
+	ValueFromParam string `yaml:"valueFromParam"`
+}
+
+// VectorFieldRuntime captures the runtime metadata required to process vector inputs.
+type VectorFieldRuntime struct {
+	ParameterName string
+	FieldPath     string
+}
+
+// BuildVectorFieldParameter converts the config into a string parameter definition and runtime metadata.
+func BuildVectorFieldParameter(cfg VectorFieldConfig) (*parameters.StringParameter, VectorFieldRuntime, error) {
+	if cfg.Name == "" {
+		return nil, VectorFieldRuntime{}, fmt.Errorf("vector field parameter requires a name")
+	}
+	if cfg.Description == "" && cfg.ValueFromParam == "" {
+		return nil, VectorFieldRuntime{}, fmt.Errorf("vector field %q must specify description", cfg.Name)
+	}
+	if cfg.FieldPath == "" {
+		return nil, VectorFieldRuntime{}, fmt.Errorf("vector field %q must specify fieldPath", cfg.Name)
+	}
+	if cfg.EmbeddedBy == "" {
+		return nil, VectorFieldRuntime{}, fmt.Errorf("vector field %q must specify embeddedBy", cfg.Name)
+	}
+
+	param := parameters.NewStringParameterWithRequired(cfg.Name, cfg.Description, cfg.Required)
+	param.EmbeddedBy = cfg.EmbeddedBy
+	param.ValueFromParam = cfg.ValueFromParam
+
+	runtime := VectorFieldRuntime{
+		ParameterName: cfg.Name,
+		FieldPath:     cfg.FieldPath,
+	}
+
+	return param, runtime, nil
+}
+
+// ExtractVectorFieldValues renders vector field parameter values into float64 slices keyed by field path.
+func ExtractVectorFieldValues(paramMap map[string]any, fields []VectorFieldRuntime) (map[string][]float64, error) {
+	if len(fields) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string][]float64, len(fields))
+	for _, field := range fields {
+		value, ok := paramMap[field.ParameterName]
+		if !ok || value == nil {
+			continue
+		}
+
+		vectorValues, err := ConvertVectorValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("parameter %q: %w", field.ParameterName, err)
+		}
+		if len(vectorValues) == 0 {
+			continue
+		}
+		result[field.FieldPath] = vectorValues
+	}
+
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+// ConvertVectorValue casts embedding outputs into a []float64 slice that Firestore accepts.
+func ConvertVectorValue(val any) ([]float64, error) {
+	switch v := val.(type) {
+	case []float32:
+		out := make([]float64, len(v))
+		for i, item := range v {
+			out[i] = float64(item)
+		}
+		return out, nil
+	case []float64:
+		return v, nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("expected embedding result to be []float32 or []float64, got %T", val)
+	}
+}
+
+// UpsertVectorValues mutates the provided map to include the given vectors at their field paths.
+func UpsertVectorValues(target map[string]any, vectors map[string][]float64) error {
+	if len(vectors) == 0 {
+		return nil
+	}
+
+	for fieldPath, vector := range vectors {
+		if err := setNestedField(target, fieldPath, vector); err != nil {
+			return fmt.Errorf("failed to set field %q: %w", fieldPath, err)
+		}
+	}
+	return nil
+}
+
+// EnsureFieldPaths appends any missing vector field paths to the provided mask slice.
+func EnsureFieldPaths(mask []string, vectors map[string][]float64) []string {
+	if len(vectors) == 0 {
+		return mask
+	}
+
+	existing := make(map[string]struct{}, len(mask))
+	for _, path := range mask {
+		existing[path] = struct{}{}
+	}
+
+	for fieldPath := range vectors {
+		if _, ok := existing[fieldPath]; ok {
+			continue
+		}
+		mask = append(mask, fieldPath)
+	}
+	return mask
+}
+
+// setNestedField assigns the provided value within a map according to a dot-delimited field path.
+func setNestedField(target map[string]any, fieldPath string, value any) error {
+	if target == nil {
+		return fmt.Errorf("target map cannot be nil")
+	}
+	segments := strings.Split(fieldPath, ".")
+	if len(segments) == 0 {
+		return fmt.Errorf("invalid field path: %q", fieldPath)
+	}
+
+	current := target
+	for idx, segment := range segments {
+		if segment == "" {
+			return fmt.Errorf("field path %q contains an empty segment", fieldPath)
+		}
+
+		if idx == len(segments)-1 {
+			current[segment] = value
+			return nil
+		}
+
+		next, ok := current[segment]
+		if !ok || next == nil {
+			child := make(map[string]any)
+			current[segment] = child
+			current = child
+			continue
+		}
+
+		nextMap, ok := next.(map[string]any)
+		if !ok {
+			return fmt.Errorf("field %q is not a map; cannot create child field %q", strings.Join(segments[:idx+1], "."), segments[idx+1])
+		}
+		current = nextMap
+	}
+
+	return nil
+}
+
+// VectorQueryConfig describes a similarity search input.
+type VectorQueryConfig struct {
+	Name                string   `yaml:"name" validate:"required"`
+	Description         string   `yaml:"description"`
+	FieldPath           string   `yaml:"fieldPath" validate:"required"`
+	EmbeddedBy          string   `yaml:"embeddedBy" validate:"required"`
+	DistanceMeasure     string   `yaml:"distanceMeasure" validate:"required"`
+	DistanceResultField string   `yaml:"distanceResultField"`
+	DistanceThreshold   *float64 `yaml:"distanceThreshold"`
+	Required            bool     `yaml:"required"`
+}
+
+// VectorQueryRuntime stores the computed runtime settings for vector search.
+type VectorQueryRuntime struct {
+	ParameterName       string
+	FieldPath           string
+	Measure             firestore.DistanceMeasure
+	DistanceResultField string
+	DistanceThreshold   *float64
+}
+
+// ExtractVectorQueryValue ensures the embedded vector parameter exists and returns its values.
+func ExtractVectorQueryValue(paramMap map[string]any, runtime *VectorQueryRuntime) ([]float64, bool, error) {
+	if runtime == nil {
+		return nil, false, nil
+	}
+	value, ok := paramMap[runtime.ParameterName]
+	if !ok || value == nil {
+		return nil, false, nil
+	}
+	vectorValues, err := ConvertVectorValue(value)
+	if err != nil {
+		return nil, false, fmt.Errorf("parameter %q: %w", runtime.ParameterName, err)
+	}
+	if len(vectorValues) == 0 {
+		return nil, false, fmt.Errorf("parameter %q: embedding result is empty", runtime.ParameterName)
+	}
+	return vectorValues, true, nil
+}
+
+// BuildVectorQueryRuntime creates parameter and runtime config for a vector query.
+func BuildVectorQueryRuntime(cfg *VectorQueryConfig) (*parameters.StringParameter, *VectorQueryRuntime, error) {
+	if cfg == nil {
+		return nil, nil, nil
+	}
+	if cfg.Name == "" {
+		return nil, nil, fmt.Errorf("vector query parameter requires a name")
+	}
+	if cfg.Description == "" {
+		return nil, nil, fmt.Errorf("vector query %q must specify description", cfg.Name)
+	}
+	if cfg.FieldPath == "" {
+		return nil, nil, fmt.Errorf("vector query %q must specify fieldPath", cfg.Name)
+	}
+	if cfg.EmbeddedBy == "" {
+		return nil, nil, fmt.Errorf("vector query %q must specify embeddedBy", cfg.Name)
+	}
+	measure, err := parseDistanceMeasure(cfg.DistanceMeasure)
+	if err != nil {
+		return nil, nil, fmt.Errorf("vector query %q: %w", cfg.Name, err)
+	}
+
+	param := parameters.NewStringParameterWithRequired(cfg.Name, cfg.Description, cfg.Required)
+	param.EmbeddedBy = cfg.EmbeddedBy
+
+	runtime := &VectorQueryRuntime{
+		ParameterName:       cfg.Name,
+		FieldPath:           cfg.FieldPath,
+		Measure:             measure,
+		DistanceResultField: cfg.DistanceResultField,
+		DistanceThreshold:   cfg.DistanceThreshold,
+	}
+	return param, runtime, nil
+}
+
+func parseDistanceMeasure(value string) (firestore.DistanceMeasure, error) {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "EUCLIDEAN":
+		return firestore.DistanceMeasureEuclidean, nil
+	case "COSINE":
+		return firestore.DistanceMeasureCosine, nil
+	case "DOT_PRODUCT":
+		return firestore.DistanceMeasureDotProduct, nil
+	default:
+		return 0, fmt.Errorf("unsupported distanceMeasure %q (supported: EUCLIDEAN, COSINE, DOT_PRODUCT)", value)
+	}
+}
+
+// BuildFindNearestOptions converts the runtime settings into Firestore options.
+func BuildFindNearestOptions(runtime *VectorQueryRuntime) *firestore.FindNearestOptions {
+	if runtime == nil {
+		return nil
+	}
+
+	opts := &firestore.FindNearestOptions{}
+	if runtime.DistanceThreshold != nil {
+		opts.DistanceThreshold = runtime.DistanceThreshold
+	}
+	if runtime.DistanceResultField != "" {
+		opts.DistanceResultField = runtime.DistanceResultField
+	}
+	if opts.DistanceThreshold == nil && opts.DistanceResultField == "" {
+		return nil
+	}
+	return opts
+}

--- a/internal/tools/firestore/util/vector_test.go
+++ b/internal/tools/firestore/util/vector_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBuildVectorFieldParameter(t *testing.T) {
+	cfg := VectorFieldConfig{
+		Name:        "content",
+		Description: "text to embed",
+		FieldPath:   "embedding",
+		EmbeddedBy:  "gemini",
+		Required:    true,
+	}
+
+	param, runtime, err := BuildVectorFieldParameter(cfg)
+	if err != nil {
+		t.Fatalf("BuildVectorFieldParameter() error = %v", err)
+	}
+	if param == nil {
+		t.Fatalf("expected parameter to be non-nil")
+	}
+	if param.EmbeddedBy != "gemini" {
+		t.Fatalf("EmbeddedBy = %q, want %q", param.EmbeddedBy, "gemini")
+	}
+	if !param.GetRequired() {
+		t.Fatalf("expected parameter to be required")
+	}
+	if runtime.ParameterName != "content" || runtime.FieldPath != "embedding" {
+		t.Fatalf("unexpected runtime: %+v", runtime)
+	}
+}
+
+func TestBuildVectorFieldParameterRequiresDescription(t *testing.T) {
+	cfg := VectorFieldConfig{
+		Name:       "content",
+		FieldPath:  "embedding",
+		EmbeddedBy: "model",
+	}
+	if _, _, err := BuildVectorFieldParameter(cfg); err == nil {
+		t.Fatalf("expected error when description missing")
+	}
+}
+
+func TestExtractVectorFieldValues(t *testing.T) {
+	params := map[string]any{
+		"content": []float32{0.1, 0.2},
+	}
+	runtime := []VectorFieldRuntime{{ParameterName: "content", FieldPath: "embedding"}}
+	got, err := ExtractVectorFieldValues(params, runtime)
+	if err != nil {
+		t.Fatalf("ExtractVectorFieldValues() error = %v", err)
+	}
+	embedding, ok := got["embedding"]
+	if !ok {
+		t.Fatalf("expected embedding field to be present")
+	}
+	if len(embedding) != 2 {
+		t.Fatalf("expected 2 vector values, got %d", len(embedding))
+	}
+	if math.Abs(embedding[0]-0.1) > 1e-6 || math.Abs(embedding[1]-0.2) > 1e-6 {
+		t.Fatalf("unexpected vector values: %v", embedding)
+	}
+}
+
+func TestUpsertVectorValuesNested(t *testing.T) {
+	target := map[string]any{
+		"existing": "value",
+	}
+	vectors := map[string][]float64{
+		"metadata.embedding": []float64{0.5, -0.5},
+	}
+	if err := UpsertVectorValues(target, vectors); err != nil {
+		t.Fatalf("UpsertVectorValues() error = %v", err)
+	}
+	nested, ok := target["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested map to exist")
+	}
+	if diff := cmp.Diff([]float64{0.5, -0.5}, nested["embedding"]); diff != "" {
+		t.Fatalf("embedding mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEnsureFieldPaths(t *testing.T) {
+	mask := []string{"title"}
+	vectors := map[string][]float64{"embedding": []float64{1, 2}}
+	got := EnsureFieldPaths(mask, vectors)
+	want := []string{"title", "embedding"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("EnsureFieldPaths mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBuildVectorQueryRuntimeRequiresDescription(t *testing.T) {
+	cfg := &VectorQueryConfig{
+		Name:            "query",
+		FieldPath:       "embedding",
+		EmbeddedBy:      "model",
+		DistanceMeasure: "COSINE",
+	}
+	if _, _, err := BuildVectorQueryRuntime(cfg); err == nil {
+		t.Fatalf("expected error when description missing")
+	}
+}
+
+func TestExtractVectorQueryValue(t *testing.T) {
+	runtime := &VectorQueryRuntime{
+		ParameterName: "query",
+	}
+	params := map[string]any{
+		"query": []float32{0.1, -0.2},
+	}
+	values, ok, err := ExtractVectorQueryValue(params, runtime)
+	if err != nil {
+		t.Fatalf("ExtractVectorQueryValue() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected vector query to be detected")
+	}
+	if len(values) != 2 || math.Abs(values[0]-0.1) > 1e-6 || math.Abs(values[1]+0.2) > 1e-6 {
+		t.Fatalf("unexpected vector values: %v", values)
+	}
+}
+
+func TestExtractVectorQueryValueMissing(t *testing.T) {
+	values, ok, err := ExtractVectorQueryValue(map[string]any{}, &VectorQueryRuntime{ParameterName: "query"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when parameter missing, got true with %v", values)
+	}
+}
+
+func TestBuildFindNearestOptions(t *testing.T) {
+	threshold := 0.42
+	runtime := &VectorQueryRuntime{
+		DistanceResultField: "score",
+		DistanceThreshold:   &threshold,
+	}
+	got := BuildFindNearestOptions(runtime)
+	if got == nil {
+		t.Fatalf("expected options to be created")
+	}
+	if got.DistanceResultField != "score" {
+		t.Fatalf("DistanceResultField = %q, want %q", got.DistanceResultField, "score")
+	}
+	if got.DistanceThreshold == nil || math.Abs(*got.DistanceThreshold-threshold) > 1e-9 {
+		t.Fatalf("DistanceThreshold mismatch: got %v want %v", got.DistanceThreshold, threshold)
+	}
+
+	nilOpts := BuildFindNearestOptions(&VectorQueryRuntime{})
+	if nilOpts != nil {
+		t.Fatalf("expected nil options when no fields set")
+	}
+}

--- a/internal/util/parameters/parameters.go
+++ b/internal/util/parameters/parameters.go
@@ -139,7 +139,20 @@ func ParseParams(ps Parameters, data map[string]any, claimsMap map[string]map[st
 		sourceParamName := p.GetValueFromParam()
 		if sourceParamName != "" {
 			v = data[sourceParamName]
-
+			if v == nil && strings.Contains(sourceParamName, ".") {
+				// Fallback to dot notation lookup
+				parts := strings.Split(sourceParamName, ".")
+				var current any = data
+				for _, part := range parts {
+					if currentMap, ok := current.(map[string]any); ok {
+						current = currentMap[part]
+					} else {
+						current = nil
+						break
+					}
+				}
+				v = current
+			}
 		} else if len(paramAuthServices) == 0 {
 			// parse non auth-required parameter
 			var ok bool


### PR DESCRIPTION
## Description

This PR implements Toolbox native vector embedding support for Firestore, enabling automatic vector embedding for document write operations and vector similarity search capabilities.

### Vector Embedding for Document Writes

Firestore tools now support automatic vector embedding when writing documents:

**Tools Updated:**
- `firestore-add-documents` - Add new documents with automatic text-to-vector embedding
- `firestore-update-document` - Update documents with automatic text-to-vector embedding

**Features:**
- Accepts plain text strings via `vectorFields` configuration
- Automatically embeds text using configured embedding models
- Stores vectors as Firestore native array objects of doubles
- Seamless integration with Toolbox's `embeddingModel` framework

**Example Configuration:**
```yaml
tools:
  firestore-add-documents:
    type: firestore-add-documents
    source: my-instance
    vectorFields:
      - name: embedding_text
        fieldPath: document_embedding
        embeddedBy: text-embedding-model
        required: false
```

### Vector Search & Similarity Queries

Vector similarity search capabilities for Firestore queries:

**Tools to Support:**
- `firestore-query` - Support vector similarity search with `findNearest`
- `firestore-query-collection` - Support collection-level vector similarity queries

**Features:**
- Accept natural language prompts via `vectorFields` in search queries
- Automatically embed search queries using configured embedding models
- Execute Firestore native vector similarity queries using `findNearest`
- Return semantically similar documents based on vector distance

**Testing:**
- Comprehensive integration tests for vector embedding in add/update operations
- Vectors successfully embedded and stored in Firestore with correct dimensions

## Related Issue

Fixes #3159