### PR TITLE
fix(tools/looker): return a 401 error to MCP client when Looker returns a 401

### DIFF
--- a/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
+++ b/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -180,6 +181,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	qresp, err := sdk.CreateQuery(*wq, "id", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
+++ b/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -221,6 +222,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.CreateDashboardFilter(req, "name", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	logger.DebugContext(ctx, "resp = %v", resp)

--- a/internal/tools/looker/lookercreateagent/lookercreateagent.go
+++ b/internal/tools/looker/lookercreateagent/lookercreateagent.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -198,7 +199,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.CreateAgent(body, "", source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making create_agent request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 

--- a/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
+++ b/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -139,7 +140,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.CreateGitBranch(projectId, body, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making create_git_branch request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 }

--- a/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
+++ b/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -136,6 +137,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	err = lookercommon.CreateProjectDirectory(sdk, projectId, directoryPath, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
+++ b/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -146,6 +147,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	err = lookercommon.CreateProjectFile(sdk, projectId, req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
+++ b/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -228,7 +229,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	err = lookercommon.CreateViewsFromTables(ctx, sdk, projectId, queryParams, reqBody, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error generating views: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	return map[string]string{

--- a/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
+++ b/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -140,7 +141,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.DeleteAgent(agentId, "", source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making delete_agent request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 

--- a/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
+++ b/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -133,7 +134,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	_, err = sdk.DeleteGitBranch(projectId, branch, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making delete_git_branch request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return fmt.Sprintf("Deleted branch %s", branch), nil
 }

--- a/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
+++ b/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -138,6 +139,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	err = lookercommon.DeleteProjectDirectory(sdk, projectId, directoryPath, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
+++ b/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -138,6 +139,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	err = lookercommon.DeleteProjectFile(sdk, projectId, filePath, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerdevmode/lookerdevmode.go
+++ b/internal/tools/looker/lookerdevmode/lookerdevmode.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -139,6 +140,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.UpdateSession(req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	logger.DebugContext(ctx, "result = ", resp)

--- a/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
+++ b/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -154,6 +155,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	logger.ErrorContext(ctx, "Making request %v", req)
 	resp, err := sdk.CreateEmbedUrlAsMe(req, nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	logger.ErrorContext(ctx, "Got response %v", resp)

--- a/internal/tools/looker/lookergetagent/lookergetagent.go
+++ b/internal/tools/looker/lookergetagent/lookergetagent.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -138,7 +139,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.GetAgent(agentId, "", source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_agent request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 

--- a/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
+++ b/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -129,6 +130,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.ConnectionDatabases(conn, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookergetconnections/lookergetconnections.go
+++ b/internal/tools/looker/lookergetconnections/lookergetconnections.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -127,6 +128,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.AllConnections("name, dialect(name), database, schema", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
+++ b/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -137,6 +138,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.ConnectionSchemas(req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil

--- a/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
+++ b/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -153,6 +154,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.ConnectionColumns(req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	var data []any

--- a/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
+++ b/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -147,6 +148,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.ConnectionTables(req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	var data []any

--- a/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
+++ b/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -156,6 +157,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	logger.ErrorContext(ctx, "Making request %v", req)
 	resp, err := sdk.SearchDashboards(req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	logger.ErrorContext(ctx, "Got response %v", resp)

--- a/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
+++ b/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -139,6 +140,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.LookmlModelExplore(req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookergetexplores/lookergetexplores.go
+++ b/internal/tools/looker/lookergetexplores/lookergetexplores.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -134,6 +135,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.LookmlModel(model, "explores(name,description,label,group_label,hidden)", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookergetfilters/lookergetfilters.go
+++ b/internal/tools/looker/lookergetfilters/lookergetfilters.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -139,7 +140,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.LookmlModelExplore(req, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_filters request: %v", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	if err := lookercommon.CheckLookerExploreFields(&resp); err != nil {

--- a/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
+++ b/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -127,7 +128,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.GitBranch(projectId, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_git_branch request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 }

--- a/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
+++ b/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -137,7 +138,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.AllLookmlTests(projectId, fileId, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error retrieving lookml tests: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	return resp, nil

--- a/internal/tools/looker/lookergetlooks/lookergetlooks.go
+++ b/internal/tools/looker/lookergetlooks/lookergetlooks.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -161,7 +162,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.SearchLooks(req, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_looks request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	var data []any

--- a/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
+++ b/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -139,7 +140,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.LookmlModelExplore(req, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_measures request: %v", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	if err := lookercommon.CheckLookerExploreFields(&resp); err != nil {

--- a/internal/tools/looker/lookergetmodels/lookergetmodels.go
+++ b/internal/tools/looker/lookergetmodels/lookergetmodels.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -137,7 +138,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.AllLookmlModels(req, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_models request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	var data []any

--- a/internal/tools/looker/lookergetparameters/lookergetparameters.go
+++ b/internal/tools/looker/lookergetparameters/lookergetparameters.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -139,7 +140,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.LookmlModelExplore(req, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_parameters request: %v", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	if err := lookercommon.CheckLookerExploreFields(&resp); err != nil {

--- a/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
+++ b/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -131,6 +132,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := lookercommon.GetProjectDirectories(sdk, projectId, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
+++ b/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -141,7 +142,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := lookercommon.GetProjectFileContent(sdk, projectId, filePath, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_project_file request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	logger.DebugContext(ctx, "Got response of %v\n", resp)

--- a/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
+++ b/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -135,7 +136,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.AllProjectFiles(projectId, "", source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_project_files request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	var data []any

--- a/internal/tools/looker/lookergetprojects/lookergetprojects.go
+++ b/internal/tools/looker/lookergetprojects/lookergetprojects.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -128,7 +129,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.AllProjects("id,name", source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making get_models request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	var data []any

--- a/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
+++ b/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
@@ -170,7 +170,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		projectId, _ := paramsMap["project"].(string)
 		result, err := analyzeTool.projects(ctx, projectId)
 		if err != nil {
-			return nil, util.NewClientServerError(fmt.Sprintf("error analyzing projects: %v", err), http.StatusInternalServerError, err)
+			if strings.Contains(err.Error(), "status=401") {
+				return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+			}
+			return nil, util.ProcessGeneralError(err)
 		}
 		logger.DebugContext(ctx, "result = ", result)
 		return result, nil
@@ -179,7 +182,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		modelName, _ := paramsMap["model"].(string)
 		result, err := analyzeTool.models(ctx, projectName, modelName)
 		if err != nil {
-			return nil, util.NewClientServerError(fmt.Sprintf("error analyzing models: %v", err), http.StatusInternalServerError, err)
+			if strings.Contains(err.Error(), "status=401") {
+				return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+			}
+			return nil, util.ProcessGeneralError(err)
 		}
 		logger.DebugContext(ctx, "result = ", result)
 		return result, nil
@@ -188,7 +194,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		exploreName, _ := paramsMap["explore"].(string)
 		result, err := analyzeTool.explores(ctx, modelName, exploreName)
 		if err != nil {
-			return nil, util.NewClientServerError(fmt.Sprintf("error analyzing explores: %v", err), http.StatusInternalServerError, err)
+			if strings.Contains(err.Error(), "status=401") {
+				return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+			}
+			return nil, util.ProcessGeneralError(err)
 		}
 		logger.DebugContext(ctx, "result = ", result)
 		return result, nil

--- a/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
+++ b/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
@@ -152,6 +152,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	result, err := pulseTool.RunPulse(ctx, source, pulseParams)
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
+++ b/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
@@ -176,6 +176,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerlistagents/lookerlistagents.go
+++ b/internal/tools/looker/lookerlistagents/lookerlistagents.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -129,7 +130,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.SearchAgents(v4.RequestSearchAgents{}, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making search_agents request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 

--- a/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
+++ b/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -127,7 +128,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.AllGitBranches(projectId, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making list_git_branches request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 }

--- a/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
+++ b/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -144,6 +145,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	mrespFields := "id,personal_folder_id"
 	mresp, err := sdk.Me(mrespFields, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookermakelook/lookermakelook.go
+++ b/internal/tools/looker/lookermakelook/lookermakelook.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -155,6 +156,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	mrespFields := "id,personal_folder_id"
 	mresp, err := sdk.Me(mrespFields, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerquery/lookerquery.go
+++ b/internal/tools/looker/lookerquery/lookerquery.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -132,6 +133,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := lookercommon.RunInlineQuery(ctx, sdk, wq, "json", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerquerysql/lookerquerysql.go
+++ b/internal/tools/looker/lookerquerysql/lookerquerysql.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -131,6 +132,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := lookercommon.RunInlineQuery(ctx, sdk, wq, "sql", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	logger.DebugContext(ctx, "resp = ", resp)

--- a/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
+++ b/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -148,6 +149,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	respFields := "id,slug,share_url,expanded_share_url"
 	resp, err := sdk.CreateQuery(*wq, respFields, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 	logger.DebugContext(ctx, "resp = ", resp)

--- a/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
+++ b/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	yaml "github.com/goccy/go-yaml"
@@ -138,6 +139,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	dashboard, err := sdk.Dashboard(dashboard_id, "", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerrunlook/lookerrunlook.go
+++ b/internal/tools/looker/lookerrunlook/lookerrunlook.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -142,6 +143,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	look, err := sdk.Look(look_id, "", source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
+++ b/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -155,7 +156,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.RunLookmlTest(req, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error running lookml tests: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	// Filter out pointer fields for better JSON marshaling in basic map if needed,

--- a/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
+++ b/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -141,7 +142,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.UpdateGitBranch(projectId, body, source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making update_git_branch request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 }

--- a/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
+++ b/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -205,7 +206,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 	resp, err := sdk.UpdateAgent(agentId, body, "", source.LookerApiSettings())
 	if err != nil {
-		return nil, util.NewClientServerError(fmt.Sprintf("error making update_agent request: %s", err), http.StatusInternalServerError, err)
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 	return resp, nil
 

--- a/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
+++ b/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -147,6 +148,9 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	err = lookercommon.UpdateProjectFile(sdk, projectId, req, source.LookerApiSettings())
 	if err != nil {
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
 		return nil, util.ProcessGeneralError(err)
 	}
 

--- a/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
+++ b/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
@@ -135,7 +136,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 
 	resp, err := sdk.ValidateProject(projectId, "", source.LookerApiSettings())
 	if err != nil {
-		return nil, util.ProcessGeneralError(fmt.Errorf("error making validate_project request: %w", err))
+		if strings.Contains(err.Error(), "status=401") {
+			return nil, util.NewClientServerError("unauthorized error", http.StatusUnauthorized, err)
+		}
+		return nil, util.ProcessGeneralError(err)
 	}
 
 	logger.DebugContext(ctx, "Got response of %v\n", resp)

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -118,7 +118,7 @@ func ProcessGeneralError(err error) ToolboxError {
 	errStr := err.Error()
 
 	// Check for Unauthorized
-	if strings.Contains(errStr, "Error 401") || strings.Contains(errStr, "status 401") {
+	if strings.Contains(errStr, "Error 401") || strings.Contains(errStr, "status 401") || strings.Contains(errStr, "status=401") {
 		return NewClientServerError(
 			"failed to access resource",
 			http.StatusUnauthorized,
@@ -127,10 +127,19 @@ func ProcessGeneralError(err error) ToolboxError {
 	}
 
 	// Check for Forbidden
-	if strings.Contains(errStr, "Error 403") || strings.Contains(errStr, "status 403") {
+	if strings.Contains(errStr, "Error 403") || strings.Contains(errStr, "status 403") || strings.Contains(errStr, "status=403") {
 		return NewClientServerError(
 			"failed to access resource",
 			http.StatusForbidden,
+			err,
+		)
+	}
+
+	// Check for StatusTooManyRequests
+	if strings.Contains(errStr, "Error 429") || strings.Contains(errStr, "status 429") || strings.Contains(errStr, "status=429") {
+		return NewClientServerError(
+			"rate limited - too many requests",
+			http.StatusTooManyRequests,
 			err,
 		)
 	}


### PR DESCRIPTION
…ns a 401.

## Description

When Looker returns a 401 to MCP Toolbox, this will propagate the error back to the client.
This is so the client knows to refresh the OAuth token.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change


