### PR TITLE
docs: clarify mandatory OIDC identity scopes for user identity

### DIFF
--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
@@ -121,7 +121,7 @@ toolset = ToolboxToolset(
 Configures the ADK-native interactive 3-legged OAuth flow to get consent and credentials from the end-user at runtime. This strategy is passed to the `ToolboxToolset` just like any other credential strategy.
 
 {{< notice note >}}
-The `"openid"` scope is **required** for the `user_identity` strategy to generate a valid OIDC ID Token. Only add other scopes (like `"email"`) if explicitly required by your server-side [**Authorized Invocations**](../../../../configuration/tools/_index.md#authorized-invocations) or [**Authenticated Parameters**](../../../../configuration/tools/_index.md#authenticated-parameters) configurations.
+The `"openid"` scope is **required** for the `user_identity` strategy to generate a valid OIDC ID Token. Only add other scopes (like `"email"`) if explicitly required by your server-side [**Authorized Invocations**](../../../../configuration/tools/#authorized-invocations-toolbox-native-authorization) or [**Authenticated Parameters**](../../../../configuration/tools/#authenticated-parameters) configurations.
 {{< /notice >}}
 
 ```python

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
@@ -120,13 +120,21 @@ toolset = ToolboxToolset(
 
 Configures the ADK-native interactive 3-legged OAuth flow to get consent and credentials from the end-user at runtime. This strategy is passed to the `ToolboxToolset` just like any other credential strategy.
 
+{{< notice note >}}
+The `"openid"` scope is **required** for the `user_identity` strategy to generate a valid OIDC ID Token. Only add other scopes (like `"email"`) if explicitly required by your server-side [**Authorized Invocations**](../../../../configuration/tools/_index.md#authorized-invocations) or [**Authenticated Parameters**](../../../../configuration/tools/_index.md#authenticated-parameters) configurations.
+{{< /notice >}}
+
 ```python
 from toolbox_adk import CredentialStrategy, ToolboxToolset
 
 creds = CredentialStrategy.user_identity(
     client_id="YOUR_CLIENT_ID",
     client_secret="YOUR_CLIENT_SECRET",
-    scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    scopes=[
+        "openid",
+        # "email",
+        # "mcp:tools",
+    ]
 )
 
 # The toolset will now initiate OAuth flows when required by tools


### PR DESCRIPTION
### Description

The previous Python ADK `user_identity` code example in the docs recommended a `scopes` array that requested only `"https://www.googleapis.com/auth/cloud-platform"`. 

This omitted the standard `"openid"` protocol scope. In Google's OAuth2 ecosystem, omitting `"openid"` forces Google to issue a standard, opaque **Access Token** instead of a signed **ID Token (JWT)**. Because the self-hosted Toolbox server relies on local JWT validation to cryptographically verify connection handshakes and parameter injections instantly in memory, running this documented example out-of-the-box immediately resulted in immediate connection validation crashes (`401 Unauthorized` or `403 Forbidden`) for developers.

#### Changes
1.  Updated the `user_identity` credentials strategy in the `python-sdk/adk/index.md` code snippet to correctly request `"openid"` and `"email"` to guarantee OIDC JWT token delivery.
2.  Created a warning block to explain the strict cryptographic necessity of `"openid"` for OIDC identity verification, while explaining that further resource scopes are optional depending on tool config.