### PR TITLE
feat(server): add support for toolset filtering in prebuilt CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can use the Toolbox in any MCP-compatible IDE or client (e.g., Gemini CLI, G
 
 2. Set the appropriate environment variables to connect, see the [Prebuilt Tools Reference](https://mcp-toolbox.dev/documentation/configuration/prebuilt-configs/).
 
-When you run Toolbox with a `--prebuilt=<database>` flag, you instantly get access to standard tools to interact with that database. You can also specify a specific toolset using the `--prebuilt=<database>/<toolset>` syntax (e.g., `--prebuilt=postgres/sql` to only load SQL tools). 
+When you run Toolbox with a `--prebuilt=<database>` flag, you instantly get access to standard tools to interact with that database. You can also specify a specific toolset using the `--prebuilt=<database>/<toolset>` syntax (e.g., `--prebuilt=postgres/data` to only load SQL tools). 
 
 Supported databases currently include:
 - **Google Cloud:** AlloyDB, BigQuery, Cloud SQL (PostgreSQL, MySQL, SQL Server), Spanner, Firestore, Knowledge Catalog (formerly known as Dataplex).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can use the Toolbox in any MCP-compatible IDE or client (e.g., Gemini CLI, G
 
 2. Set the appropriate environment variables to connect, see the [Prebuilt Tools Reference](https://mcp-toolbox.dev/documentation/configuration/prebuilt-configs/).
 
-When you run Toolbox with a `--prebuilt=<database>` flag, you instantly get access to standard tools to interact with that database. 
+When you run Toolbox with a `--prebuilt=<database>` flag, you instantly get access to standard tools to interact with that database. You can also specify a specific toolset using the `--prebuilt=<database>/<toolset>` syntax (e.g., `--prebuilt=postgres/sql` to only load SQL tools). 
 
 Supported databases currently include:
 - **Google Cloud:** AlloyDB, BigQuery, Cloud SQL (PostgreSQL, MySQL, SQL Server), Spanner, Firestore, Knowledge Catalog (formerly known as Dataplex).

--- a/cmd/internal/options.go
+++ b/cmd/internal/options.go
@@ -206,13 +206,20 @@ func (opts *ToolboxOptions) LoadConfig(ctx context.Context, parser *ConfigParser
 		logger.InfoContext(ctx, logMsg)
 
 		for _, configName := range opts.PrebuiltConfigs {
-			sourceName := configName
-			toolsetName := ""
-			if strings.Contains(configName, "/") {
-				parts := strings.SplitN(configName, "/", 2)
-				sourceName = parts[0]
-				toolsetName = parts[1]
+			if !strings.Contains(configName, "/") {
+				for _, sep := range []string{".", ":", "@"} {
+					if strings.Contains(configName, sep) {
+						parts := strings.SplitN(configName, sep, 2)
+						if slices.Contains(prebuiltconfigs.GetPrebuiltSources(), parts[0]) {
+							errMsg := fmt.Errorf("invalid prebuilt config format '%s'. Did you mean '%s/%s'? Use '/' to specify a toolset", configName, parts[0], parts[1])
+							logger.ErrorContext(ctx, errMsg.Error())
+							return isCustomConfigured, errMsg
+						}
+					}
+				}
 			}
+
+			sourceName, toolsetName, _ := strings.Cut(configName, "/")
 
 			buf, err := prebuiltconfigs.Get(sourceName)
 			if err != nil {
@@ -231,7 +238,12 @@ func (opts *ToolboxOptions) LoadConfig(ctx context.Context, parser *ConfigParser
 			if toolsetName != "" {
 				targetToolset, exists := parsed.Toolsets[toolsetName]
 				if !exists {
-					errMsg := fmt.Errorf("toolset '%s' not found in prebuilt configuration '%s'", toolsetName, sourceName)
+					var available []string
+					for k := range parsed.Toolsets {
+						available = append(available, k)
+					}
+					slices.Sort(available)
+					errMsg := fmt.Errorf("toolset '%s' not found in prebuilt configuration '%s'. Available toolsets: %s", toolsetName, sourceName, strings.Join(available, ", "))
 					logger.ErrorContext(ctx, errMsg.Error())
 					return isCustomConfigured, errMsg
 				}
@@ -273,7 +285,8 @@ func (opts *ToolboxOptions) LoadConfig(ctx context.Context, parser *ConfigParser
 		}
 		// prebuiltConfigs is already sorted above
 		for _, configName := range opts.PrebuiltConfigs {
-			opts.Cfg.Version += fmt.Sprintf("+%s.%s", tag, configName)
+			sanitizedConfigName := strings.ReplaceAll(configName, "/", ".")
+			opts.Cfg.Version += fmt.Sprintf("+%s.%s", tag, sanitizedConfigName)
 		}
 	}
 

--- a/cmd/internal/options.go
+++ b/cmd/internal/options.go
@@ -206,7 +206,15 @@ func (opts *ToolboxOptions) LoadConfig(ctx context.Context, parser *ConfigParser
 		logger.InfoContext(ctx, logMsg)
 
 		for _, configName := range opts.PrebuiltConfigs {
-			buf, err := prebuiltconfigs.Get(configName)
+			sourceName := configName
+			toolsetName := ""
+			if strings.Contains(configName, "/") {
+				parts := strings.SplitN(configName, "/", 2)
+				sourceName = parts[0]
+				toolsetName = parts[1]
+			}
+
+			buf, err := prebuiltconfigs.Get(sourceName)
 			if err != nil {
 				logger.ErrorContext(ctx, err.Error())
 				return isCustomConfigured, err
@@ -219,6 +227,30 @@ func (opts *ToolboxOptions) LoadConfig(ctx context.Context, parser *ConfigParser
 				logger.ErrorContext(ctx, errMsg.Error())
 				return isCustomConfigured, errMsg
 			}
+
+			if toolsetName != "" {
+				targetToolset, exists := parsed.Toolsets[toolsetName]
+				if !exists {
+					errMsg := fmt.Errorf("toolset '%s' not found in prebuilt configuration '%s'", toolsetName, sourceName)
+					logger.ErrorContext(ctx, errMsg.Error())
+					return isCustomConfigured, errMsg
+				}
+
+				// Filter tools to only include those in the target toolset
+				filteredTools := make(server.ToolConfigs)
+				for _, tName := range targetToolset.ToolNames {
+					if tCfg, tExists := parsed.Tools[tName]; tExists {
+						filteredTools[tName] = tCfg
+					}
+				}
+				parsed.Tools = filteredTools
+
+				// Filter toolsets to only include the target toolset
+				filteredToolsets := make(server.ToolsetConfigs)
+				filteredToolsets[toolsetName] = targetToolset
+				parsed.Toolsets = filteredToolsets
+			}
+
 			allConfigs = append(allConfigs, parsed)
 		}
 	}

--- a/cmd/internal/options_test.go
+++ b/cmd/internal/options_test.go
@@ -17,7 +17,11 @@ package internal
 import (
 	"errors"
 	"io"
+	"strings"
 	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
 
 func TestToolboxOptions(t *testing.T) {
@@ -43,6 +47,103 @@ func TestToolboxOptions(t *testing.T) {
 			got := NewToolboxOptions(tc.option)
 			if err := tc.isValid(got); err != nil {
 				t.Errorf("option did not initialize command correctly: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Setenv("CLOUD_HEALTHCARE_PROJECT", "mock")
+	t.Setenv("CLOUD_HEALTHCARE_REGION", "mock")
+	t.Setenv("CLOUD_HEALTHCARE_DATASET", "mock")
+	t.Setenv("BIGQUERY_PROJECT", "mock")
+	t.Setenv("POSTGRES_HOST", "localhost")
+	t.Setenv("POSTGRES_PORT", "5432")
+	t.Setenv("POSTGRES_DATABASE", "mock")
+	t.Setenv("POSTGRES_USER", "mock")
+	t.Setenv("POSTGRES_PASSWORD", "mock")
+
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	tcs := []struct {
+		desc            string
+		prebuiltConfigs []string
+		initialVersion  string
+		wantVersion     string
+		wantErr         string
+		matchPrefix     bool
+	}{
+		{
+			desc:            "version sanitization with multiple configs",
+			prebuiltConfigs: []string{"cloud-healthcare/cloud_healthcare_fhir_tools", "bigquery"},
+			initialVersion:  "v1.0.0",
+			wantVersion:     "v1.0.0+prebuilt.bigquery+prebuilt.cloud-healthcare.cloud_healthcare_fhir_tools",
+		},
+		{
+			desc:            "toolset not found in prebuilt config",
+			prebuiltConfigs: []string{"postgres/invalid-toolset"},
+			wantErr:         "toolset 'invalid-toolset' not found in prebuilt configuration 'postgres'. Available toolsets: data, health, monitor, replication, view-config",
+		},
+		{
+			desc:            "invalid separator - dot",
+			prebuiltConfigs: []string{"postgres.sql"},
+			wantErr:         "invalid prebuilt config format 'postgres.sql'. Did you mean 'postgres/sql'? Use '/' to specify a toolset",
+		},
+		{
+			desc:            "invalid separator - colon",
+			prebuiltConfigs: []string{"postgres:sql"},
+			wantErr:         "invalid prebuilt config format 'postgres:sql'. Did you mean 'postgres/sql'? Use '/' to specify a toolset",
+		},
+		{
+			desc:            "invalid separator - at",
+			prebuiltConfigs: []string{"postgres@sql"},
+			wantErr:         "invalid prebuilt config format 'postgres@sql'. Did you mean 'postgres/sql'? Use '/' to specify a toolset",
+		},
+		{
+			desc:            "no warning on unrelated dots",
+			prebuiltConfigs: []string{"invalid-source.sql"},
+			wantErr:         "prebuilt source tool for 'invalid-source.sql' not found",
+			matchPrefix:     true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := &ToolboxOptions{
+				PrebuiltConfigs: tc.prebuiltConfigs,
+				Cfg: server.ServerConfig{
+					Version: tc.initialVersion,
+				},
+			}
+
+			parser := &ConfigParser{}
+			_, err = opts.LoadConfig(ctx, parser)
+
+			if tc.wantVersion != "" {
+				// Success case
+				if err != nil {
+					t.Fatalf("unexpected error loading config: %v", err)
+				}
+				if opts.Cfg.Version != tc.wantVersion {
+					t.Errorf("unexpected version: got %q, want %q", opts.Cfg.Version, tc.wantVersion)
+				}
+			} else {
+				// Failure case
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.matchPrefix {
+					if !strings.HasPrefix(err.Error(), tc.wantErr) {
+						t.Errorf("unexpected error message:\ngot:  %q\nwant prefix: %q", err.Error(), tc.wantErr)
+					}
+				} else {
+					if err.Error() != tc.wantErr {
+						t.Errorf("unexpected error message:\ngot:  %q\nwant: %q", err.Error(), tc.wantErr)
+					}
+				}
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -879,8 +879,15 @@ tools:
 				if _, ok := cfg.ToolsetConfigs["sqlite_database_tools"]; !ok {
 					return fmt.Errorf("expected toolset 'sqlite_database_tools' not found")
 				}
-				if len(cfg.ToolsetConfigs) != 1 {
-					return fmt.Errorf("expected exactly 1 toolset, got %d", len(cfg.ToolsetConfigs))
+				if len(cfg.ToolsetConfigs) != 2 {
+					var names []string
+					for k := range cfg.ToolsetConfigs {
+						names = append(names, k)
+					}
+					return fmt.Errorf("expected exactly 2 toolsets (including default), got %d: %v", len(cfg.ToolsetConfigs), names)
+				}
+				if _, ok := cfg.ToolsetConfigs[""]; !ok {
+					return fmt.Errorf("expected default toolset '' not found")
 				}
 				return nil
 			},
@@ -916,7 +923,7 @@ tools:
 				}
 				if tc.cfgCheck != nil {
 					if err := tc.cfgCheck(opts.Cfg); err != nil {
-						t.Errorf("config check failed: %v", err)
+						t.Errorf("config check failed: %v. Output:\n%s", err, output)
 					}
 				}
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -412,6 +412,11 @@ func TestPrebuiltFlag(t *testing.T) {
 			args: []string{"--prebuilt", "alloydb,bigquery"},
 			want: []string{"alloydb", "bigquery"},
 		},
+		{
+			desc: "prebuilt toolset flag",
+			args: []string{"--prebuilt", "alloydb-postgres/monitor"},
+			want: []string{"alloydb-postgres/monitor"},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -856,6 +861,35 @@ tools:
 			args:      []string{"--prebuilt", "sqlite", "--config", toolsetConflictFile},
 			wantErr:   true,
 			errString: "resource conflicts detected",
+		},
+		{
+			desc:    "success toolset filtering",
+			args:    []string{"--prebuilt", "sqlite/sqlite_database_tools"},
+			wantErr: false,
+			cfgCheck: func(cfg server.ServerConfig) error {
+				if _, ok := cfg.ToolConfigs["execute_sql"]; !ok {
+					return fmt.Errorf("expected tool 'execute_sql' not found")
+				}
+				if _, ok := cfg.ToolConfigs["list_tables"]; !ok {
+					return fmt.Errorf("expected tool 'list_tables' not found")
+				}
+				if len(cfg.ToolConfigs) != 2 {
+					return fmt.Errorf("expected exactly 2 tools, got %d", len(cfg.ToolConfigs))
+				}
+				if _, ok := cfg.ToolsetConfigs["sqlite_database_tools"]; !ok {
+					return fmt.Errorf("expected toolset 'sqlite_database_tools' not found")
+				}
+				if len(cfg.ToolsetConfigs) != 1 {
+					return fmt.Errorf("expected exactly 1 toolset, got %d", len(cfg.ToolsetConfigs))
+				}
+				return nil
+			},
+		},
+		{
+			desc:      "toolset not found error",
+			args:      []string{"--prebuilt", "sqlite/nonexistent"},
+			wantErr:   true,
+			errString: "toolset 'nonexistent' not found in prebuilt configuration 'sqlite'",
 		},
 	}
 

--- a/docs/en/documentation/configuration/prebuilt-configs/_index.md
+++ b/docs/en/documentation/configuration/prebuilt-configs/_index.md
@@ -20,7 +20,7 @@ You can now use `--prebuilt` along `--config`, `--configs`, or
 You can also combine multiple prebuilt configs.
 
 **Filtering Toolsets:**
-You can load a specific toolset from a prebuilt configuration by appending a `/` and the toolset name, for example: `--prebuilt=postgres/sql` to only load the SQL tools.
+You can load a specific toolset from a prebuilt configuration by appending a `/` and the toolset name, for example: `--prebuilt=postgres/data` to only load the SQL tools.
 
 See [Usage Examples](../../../reference/cli.md#usage-examples).
 {{< /notice >}}

--- a/docs/en/documentation/configuration/prebuilt-configs/_index.md
+++ b/docs/en/documentation/configuration/prebuilt-configs/_index.md
@@ -19,6 +19,9 @@ You can now use `--prebuilt` along `--config`, `--configs`, or
 
 You can also combine multiple prebuilt configs.
 
+**Filtering Toolsets:**
+You can load a specific toolset from a prebuilt configuration by appending a `/` and the toolset name, for example: `--prebuilt=postgres/sql` to only load the SQL tools.
+
 See [Usage Examples](../../../reference/cli.md#usage-examples).
 {{< /notice >}}
 

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -21,7 +21,7 @@ description: >
 | `-p`         | `--port`                   | Port the server will listen on.                                                                                                                                           | `5000`      |
 |              | `--tls-cert`               | Path to the PEM-encoded TLS certificate file.                                                                                                                             |             |
 |              | `--tls-key`                | Path to the PEM-encoded TLS private key file.                                                                                                                             |             |
-|              | `--prebuilt`               | Use one or more prebuilt tool configuration by source type. See [Prebuilt Tools Reference](../documentation/configuration/prebuilt-configs/_index.md) for allowed values. |             |
+|              | `--prebuilt`               | Use one or more prebuilt tool configuration by source type. Optionally specify a toolset suffix (e.g., `<source>/<toolset>`) to load only that toolset. See [Prebuilt Tools Reference](../documentation/configuration/prebuilt-configs/_index.md) for allowed values. |             |
 |              | `--stdio`                  | Listens via MCP STDIO instead of acting as a remote HTTP server.                                                                                                          |             |
 |              | `--telemetry-gcp`          | Enable exporting directly to Google Cloud Monitoring.                                                                                                                     |             |
 |              | `--telemetry-gcp-project`  | Google Cloud project ID used for `--telemetry-gcp`; defaults to `GOOGLE_CLOUD_PROJECT` if not set.                                                                        |             |
@@ -161,6 +161,9 @@ By default, traffic is unencrypted (HTTP). In production or shared networks, you
 ./toolbox --prebuilt alloydb-postgres,alloydb-postgres-admin
 # OR
 ./toolbox --prebuilt alloydb-postgres --prebuilt alloydb-postgres-admin
+
+# Server filtering a prebuilt configuration to load only a specific toolset
+./toolbox --prebuilt alloydb-postgres/monitor
 ```
 
 ### Tool Configuration Sources
@@ -182,7 +185,7 @@ The CLI supports multiple mutually exclusive ways to specify tool configurations
 **Prebuilt Configurations:**
 
 - `--prebuilt`: Use one or more predefined configurations for specific database types (e.g.,
-  'bigquery', 'postgres', 'spanner'). See [Prebuilt Tools 
+  'bigquery', 'postgres', 'spanner'), optionally appending a toolset name to filter the loaded tools (e.g., `alloydb-postgres/monitor`). See [Prebuilt Tools 
   Reference](../documentation/configuration/prebuilt-configs/_index.md) for allowed values.
 
 {{< notice tip >}}


### PR DESCRIPTION
Toolset Filtering for Prebuilt Configs: Enabled loading specific toolsets from a prebuilt configuration by appending a / suffix (e.g., --prebuilt sqlite/sqlite_database_tools), allowing users to load only a subset of tools rather than the entire configuration.