### PR TITLE
docs: update titles for knowledge catalog tools

### DIFF
--- a/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-lookup-context.md
+++ b/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-lookup-context.md
@@ -1,5 +1,5 @@
 ---
-title: "dataplex-lookup-context"
+title: "lookup-context"
 type: docs
 weight: 1
 description: > 

--- a/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-lookup-entry.md
+++ b/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-lookup-entry.md
@@ -1,9 +1,9 @@
 ---
-title: "dataplex-lookup-entry"
+title: "lookup-entry"
 type: docs
 weight: 1
 description: >
-  A "dataplex-lookup-entry" tool returns details of a particular entry in Knowledge Catalog.
+  A "lookup-entry" tool returns details of a particular entry in Knowledge Catalog.
 ---
 
 ## About

--- a/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-search-aspect-types.md
+++ b/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-search-aspect-types.md
@@ -1,9 +1,9 @@
 ---
-title: "dataplex-search-aspect-types"
+title: "search-aspect-types"
 type: docs
 weight: 1
 description: >
-  A "dataplex-search-aspect-types" tool allows to to find aspect types relevant to the query.
+  A "search-aspect-types" tool allows to to find aspect types relevant to the query.
 ---
 
 ## About

--- a/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-search-dq-scans.md
+++ b/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-search-dq-scans.md
@@ -1,9 +1,9 @@
 ---
-title: "dataplex-search-dq-scans"
+title: "search-dq-scans"
 type: docs
 weight: 1
 description: >
-  A "dataplex-search-dq-scans" tool allows to search for data quality scans based on the provided parameters.
+  A "search-dq-scans" tool allows to search for data quality scans based on the provided parameters.
 aliases:
 - /resources/tools/dataplex-search-dq-scans
 ---

--- a/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-search-entries.md
+++ b/docs/en/integrations/knowledge-catalog/tools/knowledge-catalog-search-entries.md
@@ -1,9 +1,9 @@
 ---
-title: "dataplex-search-entries"
+title: "search-entries"
 type: docs
 weight: 1
 description: >
-  A "dataplex-search-entries" tool allows to search for entries based on the provided query.
+  A "search-entries" tool allows to search for entries based on the provided query.
 ---
 
 ## About


### PR DESCRIPTION
## Description
Updates the documentation for Knowledge Catalog tools to remove the legacy "dataplex-" prefix from the titles and descriptions in the markdown frontmatter. This aligns the documentation with the updated, more concise tool naming convention.
## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
