### PR TITLE
docs(looker): Add redirectUri to Looker samples for Gemini-CLI

### DIFF
--- a/docs/en/integrations/looker/samples/looker_gemini_oauth/_index.md
+++ b/docs/en/integrations/looker/samples/looker_gemini_oauth/_index.md
@@ -102,6 +102,7 @@ In this section, we will download Toolbox and run the Toolbox server.
             "oauth": {
                 "enabled": true,
                 "clientId": "gemini-cli",
+                "redirectUri": "http://localhost:7777/oauth/callback",
                 "authorizationUrl": "https://looker.example.com/auth",
                 "tokenUrl": "https://looker.example.com/api/token",
                 "scopes": ["cors_api"]
@@ -163,7 +164,8 @@ Skip **Step 2** and use the following in the `~/.gemini/settings.json` file in
     "looker": {
         "httpUrl": "https://<your mcp server url>/mcp",
         "oauth": {
-            "clientId": "gemini-cli"
+            "clientId": "gemini-cli",
+            "redirectUri": "http://localhost:7777/oauth/callback"
         }
     }
 }


### PR DESCRIPTION
The Gemini-CLI sometimes uses a random port for the fowarding redirect in the OAuth process. This makes that port fixed, which is required by Looker's OAuth config.