### PR TITLE
ci(conformance): fix issue causing go version mismatch in presubmits

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
           
       - name: Start MCP Toolbox Server
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25"
+          go-version-file: 'go.mod'
           
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,13 +35,13 @@ jobs:
     permissions:
       contents: 'read'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
-          
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: >
           Verify go mod tidy. If you're reading this and the check has

--- a/.github/workflows/nightly_tier_report.yml
+++ b/.github/workflows/nightly_tier_report.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
 
       - name: Start MCP Toolbox Server
         run: |


### PR DESCRIPTION
## Description

The `go.mod` file requires `Go >= 1.25.7`, but several CI workflows including `conformance.yml` and `nightly_tier_report.yml` hardcoded `go-version: '1.23'`. This caused presubmit compilation failures due to a toolchain [version mismatch](https://github.com/googleapis/mcp-toolbox/actions/runs/26557469339/job/78232320545?pr=3239) (eg. in #3239).

## Changes

This PR standardizes the CI setups to dynamically resolve the Go version using `go-version-file: 'go.mod'`.