### PR TITLE
fix: align stateless protocol version rejection error with SEP-2575 spec

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -541,11 +541,6 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	// Only supported for v2025-06-18+.
 	headerProtocolVersion := r.Header.Get("MCP-Protocol-Version")
 	if headerProtocolVersion != "" {
-		if !mcp.VerifyProtocolVersion(headerProtocolVersion) {
-			err := fmt.Errorf("invalid protocol version: %s", headerProtocolVersion)
-			_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
-			return
-		}
 		protocolVersion = headerProtocolVersion
 	}
 
@@ -619,6 +614,14 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s"%s`, s.toolboxUrl+"/.well-known/oauth-protected-resource", scopesArg))
 					w.WriteHeader(http.StatusUnauthorized)
 				}
+			}
+		case jsonrpc.METHOD_NOT_FOUND:
+			w.WriteHeader(http.StatusNotFound)
+		case jsonrpc.HEADER_MISMATCH:
+			w.WriteHeader(http.StatusBadRequest)
+		case jsonrpc.INVALID_PARAMS:
+			if strings.Contains(rpcResponse.Error.Message, "unsupported protocol version") {
+				w.WriteHeader(http.StatusBadRequest)
 			}
 		}
 	}
@@ -777,11 +780,12 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 		return "", nil, err
 	}
 
-	// Add instrumentation to context for use in method handlers
+	// Add instrumentation and toolbox version to context for use in method handlers
 	ctx = util.WithInstrumentation(ctx, s.instrumentation)
-
+	ctx = util.WithToolboxVersionKey(ctx, s.version)
 	// Process the method
 	switch baseMessage.Method {
+	// This is only used for <v2026
 	case "initialize":
 		var initReq struct {
 			Params struct {
@@ -801,7 +805,6 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			version = mcputil.LATEST_PROTOCOL_VERSION
 		}
 
-		ctx = util.WithToolboxVersionKey(ctx, s.version)
 		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -621,10 +621,6 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 		case jsonrpc.UNSUPPORTED_PROTOCOL_VERSION:
 			w.WriteHeader(http.StatusBadRequest)
-		case jsonrpc.INVALID_PARAMS:
-			if strings.Contains(rpcResponse.Error.Message, "unsupported protocol version") {
-				w.WriteHeader(http.StatusBadRequest)
-			}
 		}
 	}
 

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -619,6 +619,8 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		case jsonrpc.HEADER_MISMATCH:
 			w.WriteHeader(http.StatusBadRequest)
+		case jsonrpc.UNSUPPORTED_PROTOCOL_VERSION:
+			w.WriteHeader(http.StatusBadRequest)
 		case jsonrpc.INVALID_PARAMS:
 			if strings.Contains(rpcResponse.Error.Message, "unsupported protocol version") {
 				w.WriteHeader(http.StatusBadRequest)

--- a/internal/server/mcp/jsonrpc/jsonrpc.go
+++ b/internal/server/mcp/jsonrpc/jsonrpc.go
@@ -14,20 +14,28 @@
 
 package jsonrpc
 
+import (
+	"fmt"
+
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
+)
+
 // JSONRPC_VERSION is the version of JSON-RPC used by MCP.
 const JSONRPC_VERSION = "2.0"
 
 const (
 	// Standard JSON-RPC error codes
-	PARSE_ERROR      = -32700
-	INVALID_REQUEST  = -32600
-	METHOD_NOT_FOUND = -32601
-	INVALID_PARAMS   = -32602
-	INTERNAL_ERROR   = -32603
+	PARSE_ERROR                        = -32700
+	INVALID_REQUEST                    = -32600
+	METHOD_NOT_FOUND                   = -32601
+	INVALID_PARAMS                     = -32602
+	INTERNAL_ERROR                     = -32603
+	HEADER_MISMATCH                    = -32001
+	MISSING_REQUIRED_CLIENT_CAPABILITY = -32003
 
 	// Custom auth error codes
-	UNAUTHORIZED = -32001
-	FORBIDDEN    = -32003
+	UNAUTHORIZED = -401
+	FORBIDDEN    = -403
 )
 
 // ProgressToken is used to associate progress notifications with the original request.
@@ -40,20 +48,16 @@ type RequestId interface{}
 // Request represents a bidirectional message with method and parameters expecting a response.
 type Request struct {
 	Method string `json:"method"`
-	Params struct {
-		Meta struct {
-			// If specified, the caller is requesting out-of-band progress
-			// notifications for this request (as represented by
-			// notifications/progress). The value of this parameter is an
-			// opaque token that will be attached to any subsequent
-			// notifications. The receiver is not obligated to provide these
-			// notifications.
-			ProgressToken ProgressToken `json:"progressToken,omitempty"`
-			// W3C Trace Context fields for distributed tracing
-			Traceparent string `json:"traceparent,omitempty"`
-			Tracestate  string `json:"tracestate,omitempty"`
-		} `json:"_meta,omitempty"`
-	} `json:"params,omitempty"`
+}
+
+type RequestParams struct {
+	Meta *RequestMetaObject `json:"_meta"`
+}
+
+type RequestMetaObject struct {
+	// W3C Trace Context fields for distributed tracing
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
 }
 
 // JSONRPCRequest represents a request that expects a response.
@@ -135,9 +139,10 @@ type JSONRPCError struct {
 
 // Generic baseMessage could either be a JSONRPCNotification or JSONRPCRequest
 type BaseMessage struct {
-	Jsonrpc string    `json:"jsonrpc"`
-	Method  string    `json:"method"`
-	Id      RequestId `json:"id,omitempty"`
+	Jsonrpc string         `json:"jsonrpc"`
+	Method  string         `json:"method"`
+	Id      RequestId      `json:"id,omitempty"`
+	Params  *RequestParams `json:"params,omitempty"`
 }
 
 // NewError is the standard JSONRPC response sent back when an error has been encountered.
@@ -149,6 +154,36 @@ func NewError(id RequestId, code int, message string, data any) JSONRPCError {
 			Code:    code,
 			Message: message,
 			Data:    data,
+		},
+	}
+}
+
+func NewUnsupportedProtocolVersionError(id RequestId, v string) (JSONRPCError, error) {
+	err := fmt.Errorf("unsupported protocol version")
+	return JSONRPCError{
+		Jsonrpc: JSONRPC_VERSION,
+		Id:      id,
+		Error: Error{
+			Code:    INVALID_PARAMS,
+			Message: err.Error(),
+			Data: struct {
+				Supported []string `json:"supported"`
+				Requested string   `json:"requested"`
+			}{
+				Supported: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
+				Requested: v,
+			},
+		},
+	}, err
+}
+
+func NewHeaderMismatchedError(id RequestId, err error) JSONRPCError {
+	return JSONRPCError{
+		Jsonrpc: JSONRPC_VERSION,
+		Id:      id,
+		Error: Error{
+			Code:    HEADER_MISMATCH,
+			Message: err.Error(),
 		},
 	}
 }

--- a/internal/server/mcp/jsonrpc/jsonrpc.go
+++ b/internal/server/mcp/jsonrpc/jsonrpc.go
@@ -32,6 +32,7 @@ const (
 	INTERNAL_ERROR                     = -32603
 	HEADER_MISMATCH                    = -32001
 	MISSING_REQUIRED_CLIENT_CAPABILITY = -32003
+	UNSUPPORTED_PROTOCOL_VERSION       = -32004
 
 	// Custom auth error codes
 	UNAUTHORIZED = -401
@@ -164,7 +165,7 @@ func NewUnsupportedProtocolVersionError(id RequestId, v string) (JSONRPCError, e
 		Jsonrpc: JSONRPC_VERSION,
 		Id:      id,
 		Error: Error{
-			Code:    INVALID_PARAMS,
+			Code:    UNSUPPORTED_PROTOCOL_VERSION,
 			Message: err.Error(),
 			Data: struct {
 				Supported []string `json:"supported"`

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -28,6 +28,7 @@ import (
 	v20250326 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20250326"
 	v20250618 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20250618"
 	v20251125 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20251125"
+	vdraft "github.com/googleapis/mcp-toolbox/internal/server/mcp/vdraft"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 )
@@ -46,14 +47,18 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 // This is the Operation phase of the lifecycle for MCP client-server connections.
 func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch mcpVersion {
-	case v20251125.PROTOCOL_VERSION:
+	case mcputil.VERSION_DRAFT:
+		return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+	case mcputil.VERSION_20251125:
 		return v20251125.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	case v20250618.PROTOCOL_VERSION:
+	case mcputil.VERSION_20250618:
 		return v20250618.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	case v20250326.PROTOCOL_VERSION:
+	case mcputil.VERSION_20250326:
 		return v20250326.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	default:
+	case "", mcputil.VERSION_20241105:
 		return v20241105.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+	default:
+		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion)
 	}
 }
 

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -39,11 +40,48 @@ import (
 
 // ProcessMethod returns a response for the request.
 func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+	var req GenericRequestParam
+	if err := json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("missing params field from request: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	// Check _meta field for protocol version
+	if req.Params.Meta != nil {
+		// check for protocol version metadata
+		v := req.Params.Meta.ProtocolVersion
+		if v == "" {
+			metaErr := fmt.Errorf("missing io.modelcontextprotocol/protocolVersion")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// do not have to verify header for stdio. stdio header will be nil.
+		if header != nil {
+			if PROTOCOL_VERSION != v {
+				metaErr := fmt.Errorf("header mismatch: MCP-Protocol-Version header value '%s' does not match body value '%s'", PROTOCOL_VERSION, v)
+				return jsonrpc.NewHeaderMismatchedError(id, metaErr), metaErr
+			}
+		}
+
+		// check for clientInfo
+		clientInfo := req.Params.Meta.ClientInfo
+		if clientInfo.Version == "" || clientInfo.Name == "" {
+			metaErr := fmt.Errorf("missing field from io.modelcontextprotocol/clientInfo")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// check for clientCapabilities
+		clientCapabilities := req.Params.Meta.MetaClientCapabilities
+		if clientCapabilities == nil {
+			metaErr := fmt.Errorf("missing field from io.modelcontextprotocol/clientCapabilities")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// skip checking clientCapabilities since Toolbox do not utilize any of those
+	} else {
+		metaErr := fmt.Errorf("missing required fields in request metadata")
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+	}
+
 	switch method {
-	case INITIALIZE:
-		return initializeHandler(ctx, id, body)
-	case PING:
-		return pingHandler(id)
+	case SERVER_DISCOVER:
+		return serverDiscoverHandler(ctx, id, body)
 	case TOOLS_LIST:
 		return toolsListHandler(id, resourceMgr, toolset, body)
 	case TOOLS_CALL:
@@ -58,25 +96,22 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	}
 }
 
-// InitializeResponse runs capability negotiation and protocol version agreement.
-// This is the Initialization phase of the lifecycle for MCP client-server connections.
-// Always start with the latest protocol version supported.
-func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
 
-	var req InitializeRequest
+	var req DiscoverRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		err = fmt.Errorf("invalid mcp initialize request: %w", err)
+		err = fmt.Errorf("invalid server discover request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
 	toolsListChanged := false
 	promptsListChanged := false
-	result := InitializeResult{
-		ProtocolVersion: PROTOCOL_VERSION,
+	result := DiscoverResult{
+		SupportedVersions: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
 		Capabilities: ServerCapabilities{
 			Tools: &ListChanged{
 				ListChanged: &toolsListChanged,
@@ -97,17 +132,7 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 		Id:      id,
 		Result:  result,
 	}
-
 	return res, nil
-}
-
-// pingHandler handles the "ping" method by returning an empty response.
-func pingHandler(id jsonrpc.RequestId) (any, error) {
-	return jsonrpc.JSONRPCResponse{
-		Jsonrpc: jsonrpc.JSONRPC_VERSION,
-		Id:      id,
-		Result:  struct{}{},
-	}, nil
 }
 
 func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {

--- a/internal/server/mcp/vdraft/types.go
+++ b/internal/server/mcp/vdraft/types.go
@@ -28,59 +28,56 @@ const PROTOCOL_VERSION = util.VERSION_DRAFT
 
 // methods that are supported.
 const (
-	INITIALIZE   = "initialize"
-	PING         = "ping"
-	TOOLS_LIST   = "tools/list"
-	TOOLS_CALL   = "tools/call"
-	PROMPTS_LIST = "prompts/list"
-	PROMPTS_GET  = "prompts/get"
+	SERVER_DISCOVER = "server/discover"
+	TOOLS_LIST      = "tools/list"
+	TOOLS_CALL      = "tools/call"
+	PROMPTS_LIST    = "prompts/list"
+	PROMPTS_GET     = "prompts/get"
 )
 
-/* Initialization */
+/* Request Metadata */
 
-// Params to define MCP Client during initialize request.
-type InitializeParams struct {
-	// The latest version of the Model Context Protocol that the client supports.
-	// The client MAY decide to support older versions as well.
-	ProtocolVersion string             `json:"protocolVersion"`
-	Capabilities    ClientCapabilities `json:"capabilities"`
-	ClientInfo      Implementation     `json:"clientInfo"`
+// Generic request to validate header value against _meta
+type GenericRequestParam struct {
+	Params RequestParams `json:"params"`
 }
 
-// InitializeRequest is sent from the client to the server when it first
-// connects, asking it to begin initialization.
-type InitializeRequest struct {
-	jsonrpc.Request
-	Params InitializeParams `json:"params"`
+type RequestParams struct {
+	Meta *RequestMetaObject `json:"_meta"`
 }
 
-// InitializeResult is sent after receiving an initialize request from the
-// client.
-type InitializeResult struct {
-	jsonrpc.Result
-	// The version of the Model Context Protocol that the server wants to use.
-	// This may not match the version that the client requested. If the client cannot
-	// support this version, it MUST disconnect.
-	ProtocolVersion string             `json:"protocolVersion"`
-	Capabilities    ServerCapabilities `json:"capabilities"`
-	ServerInfo      Implementation     `json:"serverInfo"`
-	// Instructions describing how to use the server and its features.
-	//
-	// This can be used by clients to improve the LLM's understanding of
-	// available tools, resources, etc. It can be thought of like a "hint" to the model.
-	// For example, this information MAY be added to the system prompt.
-	Instructions string `json:"instructions,omitempty"`
-}
-
-// InitializedNotification is sent from the client to the server after
-// initialization has finished.
-type InitializedNotification struct {
-	jsonrpc.Notification
-}
-
-// ListChange represents whether the server supports notification for changes to the capabilities.
-type ListChanged struct {
-	ListChanged *bool `json:"listChanged,omitempty"`
+type RequestMetaObject struct {
+	// If specified, the caller is requesting out-of-band progress
+	// notifications for this request (as represented by
+	// notifications/progress). The value of this parameter is an
+	// opaque token that will be attached to any subsequent
+	// notifications. The receiver is not obligated to provide these
+	// notifications.
+	ProgressToken jsonrpc.ProgressToken `json:"progressToken,omitempty"`
+	/**
+	 * The MCP Protocol Version being used for this request. Required.
+	 *
+	 * For the HTTP transport, this value MUST match the `MCP-Protocol-Version`
+	 * header; otherwise the server MUST return a `400 Bad Request`. If the
+	 * server does not support the requested version, it MUST return an
+	 * UnsupportedProtocolVersionError.
+	 */
+	ProtocolVersion string `json:"io.modelcontextprotocol/protocolVersion"`
+	/**
+	 * Identifies the client software making the request. Required.
+	 *
+	 * The Implementation schema requires `name` and `version`; other
+	 * fields are optional.
+	 */
+	ClientInfo Implementation `json:"io.modelcontextprotocol/clientInfo"`
+	/**
+	 * The client's capabilities for this specific request. Required.
+	 *
+	 * Capabilities are declared per-request rather than once at initialization;
+	 * an empty object means the client supports no optional capabilities.
+	 * Servers MUST NOT infer capabilities from prior requests.
+	 */
+	MetaClientCapabilities *ClientCapabilities `json:"io.modelcontextprotocol/clientCapabilities"`
 }
 
 // ClientCapabilities represents capabilities a client may support. Known
@@ -95,12 +92,44 @@ type ClientCapabilities struct {
 	Sampling struct{} `json:"sampling,omitempty"`
 }
 
-// ServerCapabilities represents capabilities that a server may support. Known
-// capabilities are defined here, in this schema, but this is not a closed set: any
-// server can define its own, additional capabilities.
-type ServerCapabilities struct {
-	Tools   *ListChanged `json:"tools,omitempty"`
-	Prompts *ListChanged `json:"prompts,omitempty"`
+/* Discovery */
+
+/**
+ * A request from the client asking the server to advertise its supported
+ * protocol versions, capabilities, and other metadata. Servers **MUST**
+ * implement `server/discover`. Clients **MAY** call it but are not required
+ * to — version negotiation can also happen inline via per-request `_meta`.
+ */
+type DiscoverRequest struct {
+	jsonrpc.Request
+	Params jsonrpc.RequestParams `json:"params,omitempty"`
+}
+
+// The result returned by the server for a {@link DiscoverRequest | server/discover} request.
+type DiscoverResult struct {
+	jsonrpc.Result
+	/**
+	 * MCP Protocol Versions this server supports. The client should choose a
+	 * version from this list for use in subsequent requests.
+	 */
+	SupportedVersions []string `json:"supportedVersions"`
+	/**
+	 * The capabilities of the server.
+	 */
+	Capabilities ServerCapabilities `json:"capabilities"`
+	/**
+	 * Information about the server software implementation.
+	 */
+	ServerInfo Implementation `json:"serverInfo"`
+	/**
+	 * Natural-language guidance describing the server and its features.
+	 *
+	 * This can be used by clients to improve an LLM's understanding of
+	 * available tools (e.g., by including it in a system prompt). It should
+	 * focus on information that helps the model use the server effectively
+	 * and should not duplicate information already in tool descriptions.
+	 */
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // Base interface for metadata with name (identifier) and title (display name) properties.
@@ -123,6 +152,19 @@ type Implementation struct {
 	Version string `json:"version"`
 }
 
+// ServerCapabilities represents capabilities that a server may support. Known
+// capabilities are defined here, in this schema, but this is not a closed set: any
+// server can define its own, additional capabilities.
+type ServerCapabilities struct {
+	Tools   *ListChanged `json:"tools,omitempty"`
+	Prompts *ListChanged `json:"prompts,omitempty"`
+}
+
+// ListChange represents whether the server supports notification for changes to the capabilities.
+type ListChanged struct {
+	ListChanged *bool `json:"listChanged,omitempty"`
+}
+
 /* Empty result */
 
 // EmptyResult represents a response that indicates success but carries no data.
@@ -133,13 +175,17 @@ type EmptyResult jsonrpc.Result
 // Cursor is an opaque token used to represent a cursor for pagination.
 type Cursor string
 
+// Common params for paginated requests.
 type PaginatedRequest struct {
 	jsonrpc.Request
-	Params struct {
-		// An opaque token representing the current pagination position.
-		// If provided, the server should return results starting after this cursor.
-		Cursor Cursor `json:"cursor,omitempty"`
-	} `json:"params,omitempty"`
+	Params PaginatedRequestParams `json:"params,omitempty"`
+}
+
+type PaginatedRequestParams struct {
+	jsonrpc.RequestParams
+	// An opaque token representing the current pagination position.
+	// If provided, the server should return results starting after this cursor.
+	Cursor Cursor `json:"cursor,omitempty"`
 }
 
 type PaginatedResult struct {
@@ -187,10 +233,20 @@ type InputSchema struct {
 // Used by the client to invoke a tool provided by the server.
 type CallToolRequest struct {
 	jsonrpc.Request
-	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
-	} `json:"params,omitempty"`
+	Params CallToolRequestParams `json:"params,omitempty"`
+}
+
+// Parameters for a `tools/call` request.
+type CallToolRequestParams struct {
+	jsonrpc.RequestParams
+	/**
+	 * The name of the tool.
+	 */
+	Name string `json:"name"`
+	/**
+	 * Arguments to use for the tool call.
+	 */
+	Arguments map[string]any `json:"arguments,omitempty"`
 }
 
 // The sender or recipient of messages and data in a conversation.
@@ -309,10 +365,14 @@ type ListPromptsResult struct {
 // Used by the client to get a prompt provided by the server.
 type GetPromptRequest struct {
 	jsonrpc.Request
-	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
-	} `json:"params"`
+	Params GetPromptRequestParams `json:"params"`
+}
+
+// Parameters for a `prompts/get` request.
+type GetPromptRequestParams struct {
+	jsonrpc.RequestParams
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
 }
 
 // The server's response to a prompts/get request from the client.

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -713,7 +713,7 @@ func TestMcpEndpoint(t *testing.T) {
 						Id:      "missing-method",
 						Request: jsonrpc.Request{},
 					},
-					wantStatusCode: http.StatusOK,
+					wantStatusCode: http.StatusNotFound,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "missing-method",
@@ -734,7 +734,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "foo",
 						},
 					},
-					wantStatusCode: http.StatusOK,
+					wantStatusCode: http.StatusNotFound,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "invalid-method",
@@ -914,24 +914,46 @@ func TestMcpEndpoint(t *testing.T) {
 }
 
 func TestInvalidProtocolVersionHeader(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
+	mockPrompts := []testutils.MockPrompt{prompt1}
+	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
+	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
 
+	reqBody := jsonrpc.JSONRPCRequest{
+		Jsonrpc: jsonrpcVersion,
+		Id:      "tools-list",
+		Request: jsonrpc.Request{
+			Method: "tools/list",
+		},
+	}
+	reqMarshal, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("unexpected error during marshaling of body")
+	}
 	header := map[string]string{}
 	header["MCP-Protocol-Version"] = "foo"
 
-	resp, body, err := runRequest(ts, http.MethodPost, "/", nil, header)
+	resp, body, err := runRequest(ts, http.MethodPost, "/", bytes.NewBuffer(reqMarshal), header)
 	if resp.Status != "400 Bad Request" {
-		t.Fatalf("unexpected status: %s", resp.Status)
+		t.Fatalf("unexpected status: %s; %s", resp.Status, body)
 	}
 	var got map[string]any
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("unexpected error unmarshalling body: %s", err)
 	}
-	want := "invalid protocol version: foo"
-	if got["error"] != want {
+	errMap, ok := got["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'error' field to be a map, got %T", got["error"])
+	}
+	msg, ok := errMap["message"].(string)
+	if !ok {
+		t.Fatalf("expected 'message' field to be a string, got %T", errMap["message"])
+	}
+	want := "unsupported protocol version"
+	if msg != want {
 		t.Fatalf("unexpected error message: got %s, want %s", got["error"], want)
 	}
 	if err != nil {


### PR DESCRIPTION
## Description

This PR aligns the Toolbox server's stateless protocol version validation and negotiation error responses with SEP-2575 (see [Unsupported Protocol Versions](https://modelcontextprotocol.io/seps/2575-stateless-mcp#unsupported-protocol-versions)) and HTTP guidelines in the existing server-side PR (https://github.com/googleapis/mcp-toolbox/pull/3211).

## Changes

1. Added the spec-compliant `UNSUPPORTED_PROTOCOL_VERSION = -32004` error code constant.
2. Updated `NewUnsupportedProtocolVersionError` to return the new `-32004` code instead of the generic `-32602` (`INVALID_PARAMS`).
3. Added a case mapping the new `-32004` error code to `HTTP 400 Bad Request` inside the `httpHandler` error code switch statement, preventing version rejections from incorrectly returning `HTTP 200 OK`.
4. Removed the redundant `INVALID_PARAMS` string-containment check case from the HTTP error mapping switch block since version rejections now use the dedicated `-32004` case.

## PR Checklist
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [x] Appropriate docs were updated
- [x] all 17 stateless protocol conformance tests pass successfully (including version rejection and bad request mapping)