### PR TITLE
chore: add support to deprecate primitive

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -357,6 +357,18 @@ and data.
   [internal/prebuiltconfigs/prebuiltconfigs_test.go](internal/prebuiltconfigs/prebuiltconfigs_test.go)
   and [cmd/root_test.go](cmd/root_test.go).
 
+### Deprecating an Existing Primitive
+
+A primitive (e.g., sources, tools, auth services) will only be removed after it
+has been marked as deprecated for at least one major version, or four minor
+versions (approximately two months, given our biweekly release cadence).
+
+To mark a primitive as deprecated, you must add our deprecation helper function
+to the initialization of the primitive.
+
+During the next major version release, any primitive that meets these
+deprecation timeframe requirements will be permanently removed.
+
 ## Testing
 
 ### Infrastructure

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -307,7 +307,7 @@ func initializeTools(ctx context.Context, cfg ServerConfig, instrumentation *tel
 				trace.WithAttributes(attribute.String("tool_name", name)),
 			)
 			defer span.End()
-			t, err := tc.Initialize()
+			t, err := tc.Initialize(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("unable to initialize tool %q: %w", name, err)
 			}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1354,7 +1354,7 @@ type offlineToolConfig struct {
 
 func (c offlineToolConfig) ToolConfigType() string { return "offline-test-tool" }
 
-func (c offlineToolConfig) Initialize() (tools.Tool, error) {
+func (c offlineToolConfig) Initialize(context.Context) (tools.Tool, error) {
 	return testutils.NewMockTool(c.name, "offline tool", nil, false, false), nil
 }
 

--- a/internal/tools/alloydb/alloydbcreatecluster/alloydbcreatecluster.go
+++ b/internal/tools/alloydb/alloydbcreatecluster/alloydbcreatecluster.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a new AlloyDB cluster. This is a long-running operation, but the API call returns quickly. This will return operation id to be used by get operations tool. Take all parameters from user in one go."

--- a/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
+++ b/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a new AlloyDB instance (PRIMARY or READ_POOL) within a cluster. This is a long-running operation. This will return operation id to be used by get operations tool. Take all parameters from user in one go."

--- a/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
+++ b/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a new AlloyDB user within a cluster. Takes the new user's name and a secure password. Optionally, a list of database roles can be assigned. Always ask the user for the type of user to create. ALLOYDB_IAM_USER is recommended."

--- a/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
+++ b/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Retrieves details about a specific AlloyDB cluster."

--- a/internal/tools/alloydb/alloydbgetinstance/alloydbgetinstance.go
+++ b/internal/tools/alloydb/alloydbgetinstance/alloydbgetinstance.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Retrieves details about a specific AlloyDB instance."

--- a/internal/tools/alloydb/alloydbgetuser/alloydbgetuser.go
+++ b/internal/tools/alloydb/alloydbgetuser/alloydbgetuser.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Retrieves details about a specific AlloyDB user."

--- a/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
+++ b/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		cfg.Description = "Lists all AlloyDB clusters in a given project and location."
 	}

--- a/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
+++ b/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Lists all AlloyDB instances in a given project, location and cluster."

--- a/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
+++ b/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Lists all AlloyDB users in a given project, location and cluster."

--- a/internal/tools/alloydb/alloydbwaitforoperation/alloydbwaitforoperation.go
+++ b/internal/tools/alloydb/alloydbwaitforoperation/alloydbwaitforoperation.go
@@ -115,7 +115,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "This will poll on operations API until the operation is done. For checking operation status we need projectId, locationID and operationId. Once instance is created give follow up steps on how to use the variables to bring data plane MCP server up in local and remote setup."

--- a/internal/tools/alloydbainl/alloydbainl.go
+++ b/internal/tools/alloydbainl/alloydbainl.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
+++ b/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
@@ -74,7 +74,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution_test.go
+++ b/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution_test.go
@@ -130,7 +130,7 @@ func TestInvoke(t *testing.T) {
 	sourcesMap := map[string]sources.Source{
 		"my-bq-source": src,
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 	sourcesMap := map[string]sources.Source{
 		"my-bq-source": testSrc,
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(ctx)
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
+++ b/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
@@ -122,7 +122,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -75,7 +75,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
@@ -180,7 +180,7 @@ func TestInvokeDatasetRestrictions(t *testing.T) {
 	sourcesMap := map[string]sources.Source{
 		"my-bq-source": testSrc,
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(ctx)
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
+++ b/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
@@ -73,7 +73,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigqueryforecast/bigqueryforecast_test.go
+++ b/internal/tools/bigquery/bigqueryforecast/bigqueryforecast_test.go
@@ -15,6 +15,7 @@
 package bigqueryforecast_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -92,7 +93,7 @@ func TestInvoke(t *testing.T) {
 	sourcesMap := map[string]sources.Source{
 		"my-bq-source": src,
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -315,7 +316,7 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 	sourcesMap := map[string]sources.Source{
 		"my-bq-source": testSrc,
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(ctx)
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
+++ b/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
+++ b/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
@@ -71,7 +71,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
+++ b/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
@@ -68,7 +68,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
+++ b/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
@@ -71,7 +71,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigquery/bigquerysearchcatalog/bigquerysearchcatalog.go
+++ b/internal/tools/bigquery/bigquerysearchcatalog/bigquerysearchcatalog.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	prompt := parameters.NewStringParameter("prompt", "Prompt representing search intention. Do not rewrite the prompt.")
 	datasetIds := parameters.NewArrayParameterWithDefault("datasetIds", []any{}, "Array of dataset IDs.", parameters.NewStringParameter("datasetId", "The IDs of the bigquery dataset."))
 	projectIds := parameters.NewArrayParameterWithDefault("projectIds", []any{}, "Array of project IDs.", parameters.NewStringParameter("projectId", "The IDs of the bigquery project."))

--- a/internal/tools/bigquery/bigquerysql/bigquerysql.go
+++ b/internal/tools/bigquery/bigquerysql/bigquerysql.go
@@ -75,7 +75,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/bigtable/bigtable.go
+++ b/internal/tools/bigtable/bigtable.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cassandra/cassandracql/cassandracql.go
+++ b/internal/tools/cassandra/cassandracql/cassandracql.go
@@ -65,7 +65,7 @@ func (c Config) ToolConfigType() string {
 }
 
 // Initialize implements tools.ToolConfig.
-func (c Config) Initialize() (tools.Tool, error) {
+func (c Config) Initialize(context.Context) (tools.Tool, error) {
 	if c.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", c.Name)
 	}

--- a/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
+++ b/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
@@ -58,7 +58,7 @@ func (cfg Config) ToolConfigType() string {
 	return executeSQLType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/clickhouse/clickhouselistdatabases/clickhouselistdatabases.go
+++ b/internal/tools/clickhouse/clickhouselistdatabases/clickhouselistdatabases.go
@@ -59,7 +59,7 @@ func (cfg Config) ToolConfigType() string {
 	return listDatabasesType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/clickhouse/clickhouselisttables/clickhouselisttables.go
+++ b/internal/tools/clickhouse/clickhouselisttables/clickhouselisttables.go
@@ -69,7 +69,7 @@ func (cfg Config) ToolConfigType() string {
 	return listTablesType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/clickhouse/clickhousesql/clickhousesql.go
+++ b/internal/tools/clickhouse/clickhousesql/clickhousesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return sqlType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/clickhouse/clickhousesql/clickhousesql_test.go
+++ b/internal/tools/clickhouse/clickhousesql/clickhousesql_test.go
@@ -121,7 +121,7 @@ func TestSQLConfigInitializeValidSource(t *testing.T) {
 		Parameters: parameters.Parameters{},
 	}
 
-	tool, err := config.Initialize()
+	tool, err := config.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}

--- a/internal/tools/clickhouse/clickhousesql/clickhousesql_test.go
+++ b/internal/tools/clickhouse/clickhousesql/clickhousesql_test.go
@@ -15,6 +15,7 @@
 package clickhouse
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"

--- a/internal/tools/cloudgda/cloudgda.go
+++ b/internal/tools/cloudgda/cloudgda.go
@@ -124,7 +124,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudgda/cloudgda_test.go
+++ b/internal/tools/cloudgda/cloudgda_test.go
@@ -187,7 +187,7 @@ func TestInitialize(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			tool, err := tc.cfg.Initialize()
+			tool, err := tc.cfg.Initialize(context.Background())
 			if err != nil {
 				t.Fatalf("did not expect an error but got: %v", err)
 			}
@@ -258,7 +258,7 @@ func TestInvoke(t *testing.T) {
 		},
 	}
 
-	tool, err := toolCfg.Initialize()
+	tool, err := toolCfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirfetchpage/cloudhealthcarefhirfetchpage.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirfetchpage/cloudhealthcarefhirfetchpage.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirpatienteverything/cloudhealthcarefhirpatienteverything.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirpatienteverything/cloudhealthcarefhirpatienteverything.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirpatientsearch/cloudhealthcarefhirpatientsearch.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirpatientsearch/cloudhealthcarefhirpatientsearch.go
@@ -86,7 +86,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdataset/cloudhealthcaregetdataset.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdataset/cloudhealthcaregetdataset.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstore/cloudhealthcaregetdicomstore.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstore/cloudhealthcaregetdicomstore.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstoremetrics/cloudhealthcaregetdicomstoremetrics.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstoremetrics/cloudhealthcaregetdicomstoremetrics.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirresource/cloudhealthcaregetfhirresource.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirresource/cloudhealthcaregetfhirresource.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstore/cloudhealthcaregetfhirstore.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstore/cloudhealthcaregetfhirstore.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstoremetrics/cloudhealthcaregetfhirstoremetrics.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstoremetrics/cloudhealthcaregetfhirstoremetrics.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcarelistdicomstores/cloudhealthcarelistdicomstores.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarelistdicomstores/cloudhealthcarelistdicomstores.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcarelistfhirstores/cloudhealthcarelistfhirstores.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarelistfhirstores/cloudhealthcarelistfhirstores.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcareretrieverendereddicominstance/cloudhealthcareretrieverendereddicominstance.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcareretrieverendereddicominstance/cloudhealthcareretrieverendereddicominstance.go
@@ -69,7 +69,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicominstances/cloudhealthcaresearchdicominstances.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicominstances/cloudhealthcaresearchdicominstances.go
@@ -76,7 +76,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomseries/cloudhealthcaresearchdicomseries.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomseries/cloudhealthcaresearchdicomseries.go
@@ -74,7 +74,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomstudies/cloudhealthcaresearchdicomstudies.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomstudies/cloudhealthcaresearchdicomstudies.go
@@ -72,7 +72,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudmonitoring/cloudmonitoring.go
+++ b/internal/tools/cloudmonitoring/cloudmonitoring.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudmonitoring/cloudmonitoring_test.go
+++ b/internal/tools/cloudmonitoring/cloudmonitoring_test.go
@@ -15,6 +15,7 @@
 package cloudmonitoring_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 

--- a/internal/tools/cloudmonitoring/cloudmonitoring_test.go
+++ b/internal/tools/cloudmonitoring/cloudmonitoring_test.go
@@ -79,7 +79,7 @@ func TestInitialize(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			tool, err := tc.cfg.Initialize()
+			tool, err := tc.cfg.Initialize(context.Background())
 
 			if tc.wantErr != "" {
 				if err == nil {

--- a/internal/tools/cloudsql/cloudsqlcloneinstance/cloudsqlcloneinstance.go
+++ b/internal/tools/cloudsql/cloudsqlcloneinstance/cloudsqlcloneinstance.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Clone an existing Cloud SQL instance into a new instance. The clone can be a direct copy of the source instance, or a point-in-time-recovery (PITR) clone from a specific timestamp. The call returns a Cloud SQL Operation object. Call wait_for_operation tool after this, make sure to use multiplier as 4 to poll the opertation status till it is marked DONE."

--- a/internal/tools/cloudsql/cloudsqlcreatebackup/cloudsqlcreatebackup.go
+++ b/internal/tools/cloudsql/cloudsqlcreatebackup/cloudsqlcreatebackup.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a backup on a Cloud SQL instance."

--- a/internal/tools/cloudsql/cloudsqlcreatedatabase/cloudsqlcreatedatabase.go
+++ b/internal/tools/cloudsql/cloudsqlcreatedatabase/cloudsqlcreatedatabase.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a new database in a Cloud SQL instance."

--- a/internal/tools/cloudsql/cloudsqlcreateusers/cloudsqlcreateusers.go
+++ b/internal/tools/cloudsql/cloudsqlcreateusers/cloudsqlcreateusers.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a new user in a Cloud SQL instance. Both built-in and IAM users are supported. IAM users require an email account as the user name. IAM is the more secure and recommended way to manage users. The agent should always ask the user what type of user they want to create. For more information, see https://cloud.google.com/sql/docs/postgres/add-manage-iam-users"

--- a/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
+++ b/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		cfg.Description = "Gets a particular cloud sql instance."
 	}

--- a/internal/tools/cloudsql/cloudsqllistdatabases/cloudsqllistdatabases.go
+++ b/internal/tools/cloudsql/cloudsqllistdatabases/cloudsqllistdatabases.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Lists all databases for a Cloud SQL instance."

--- a/internal/tools/cloudsql/cloudsqllistinstances/cloudsqllistinstances.go
+++ b/internal/tools/cloudsql/cloudsqllistinstances/cloudsqllistinstances.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Lists all type of Cloud SQL instances for a project."

--- a/internal/tools/cloudsql/cloudsqlrestorebackup/cloudsqlrestorebackup.go
+++ b/internal/tools/cloudsql/cloudsqlrestorebackup/cloudsqlrestorebackup.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		cfg.Description = "Restores a backup on a Cloud SQL instance."
 	}

--- a/internal/tools/cloudsql/cloudsqlwaitforoperation/cloudsqlwaitforoperation.go
+++ b/internal/tools/cloudsql/cloudsqlwaitforoperation/cloudsqlwaitforoperation.go
@@ -116,7 +116,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "This will poll on operations API until the operation is done. For checking operation status we need projectId and operationId. Once instance is created give follow up steps on how to use the variables to bring data plane MCP server up in local and remote setup."

--- a/internal/tools/cloudsqladmin/cloudsqladminexecutemany/cloudsqladminexecutemany.go
+++ b/internal/tools/cloudsqladmin/cloudsqladminexecutemany/cloudsqladminexecutemany.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Cloud SQL Admin ExecuteSqlMany tool.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	params := parameters.Parameters{
 		parameters.NewStringParameter("project", "The GCP project ID."),
 		parameters.NewStringParameter("instanceId", "The Cloud SQL instance ID."),

--- a/internal/tools/cloudsqladmin/cloudsqladminsqlmany/cloudsqladminsqlmany.go
+++ b/internal/tools/cloudsqladmin/cloudsqladminsqlmany/cloudsqladminsqlmany.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudsqlmssql/cloudsqlmssqlcreateinstance/cloudsqlmssqlcreateinstance.go
+++ b/internal/tools/cloudsqlmssql/cloudsqlmssqlcreateinstance/cloudsqlmssqlcreateinstance.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a SQL Server instance using `Production` and `Development` presets. For the `Development` template, it chooses a 2 vCPU, 8 GiB RAM (`db-custom-2-8192`) configuration with Non-HA/zonal availability. For the `Production` template, it chooses a 4 vCPU, 26 GiB RAM (`db-custom-4-26624`) configuration with HA/regional availability. The Enterprise edition is used in both cases. The default database version is `SQLSERVER_2022_STANDARD`. The agent should ask the user if they want to use a different version."

--- a/internal/tools/cloudsqlmysql/cloudsqlmysqlcreateinstance/cloudsqlmysqlcreateinstance.go
+++ b/internal/tools/cloudsqlmysql/cloudsqlmysqlcreateinstance/cloudsqlmysqlcreateinstance.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a MySQL instance using `Production` and `Development` presets. For the `Development` template, it chooses a 2 vCPU, 16 GiB RAM, 100 GiB SSD configuration with Non-HA/zonal availability. For the `Production` template, it chooses an 8 vCPU, 64 GiB RAM, 250 GiB SSD configuration with HA/regional availability. The Enterprise Plus edition is used in both cases. The default database version is `MYSQL_8_4`. The agent should ask the user if they want to use a different version."

--- a/internal/tools/cloudsqlpg/cloudsqlpgcreateinstances/cloudsqlpgcreateinstances.go
+++ b/internal/tools/cloudsqlpg/cloudsqlpgcreateinstances/cloudsqlpgcreateinstances.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 
 	if cfg.Description == "" {
 		cfg.Description = "Creates a Postgres instance using `Production` and `Development` presets. For the `Development` template, it chooses a 2 vCPU, 16 GiB RAM, 100 GiB SSD configuration with Non-HA/zonal availability. For the `Production` template, it chooses an 8 vCPU, 64 GiB RAM, 250 GiB SSD configuration with HA/regional availability. The Enterprise Plus edition is used in both cases. The default database version is `POSTGRES_17`. The agent should ask the user if they want to use a different version."

--- a/internal/tools/cloudsqlpg/cloudsqlpgupgradeprecheck/cloudsqlpgupgradeprecheck.go
+++ b/internal/tools/cloudsqlpg/cloudsqlpgupgradeprecheck/cloudsqlpgupgradeprecheck.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize initializes the tool from the configuration.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameter("project", "The project ID"),
 		parameters.NewStringParameter("instance", "The name of the instance to check"),

--- a/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	// parameters are marked required/ optional based on the vector assist function defintions
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("spec_id", "The unique ID of the vector specification to apply.", false),

--- a/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
+++ b/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
@@ -72,7 +72,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	// parameters are marked required/ optional based on the vector assist function defintions
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("table_name", "Table name on which vector workload needs to be set up.", true),

--- a/internal/tools/cloudsqlpg/vectorassistdeletespec/vectorassistdeletespec.go
+++ b/internal/tools/cloudsqlpg/vectorassistdeletespec/vectorassistdeletespec.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("spec_id", "Unique ID for the vector spec to delete.", true),
 	}

--- a/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
+++ b/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
@@ -73,7 +73,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	// parameters are marked required/ optional based on the vector assist function defintions
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("spec_id", "Generate the vector query corresponding to this vector spec.", false),

--- a/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("spec_id", "Unique ID for the vector spec.", true),
 	}

--- a/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
+++ b/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
@@ -87,7 +87,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("schema_name", "public", "Optional parameter: Schema name of the table."),
 		parameters.NewStringParameterWithRequired("table_name", "Table name experiencing degraded vector search recall.", true),

--- a/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
+++ b/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("table_name", "Table name to list vector specifications for.", true),
 		parameters.NewStringParameterWithRequired("column_name", "Column name to list vector specifications for.", false),

--- a/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
@@ -72,7 +72,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	// parameters are marked required/ optional based on the vector assist function defintions
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("spec_id", "Unique ID for the vector spec you want to modify.", true),

--- a/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject.go
+++ b/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject_test.go
@@ -133,7 +133,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-copy-object",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
+++ b/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket_test.go
+++ b/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket_test.go
@@ -132,7 +132,7 @@ func initTool(t *testing.T) tools.Tool {
 		Type:   "cloud-storage-create-bucket",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket.go
+++ b/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket_test.go
+++ b/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket_test.go
@@ -127,7 +127,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-delete-bucket",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject.go
+++ b/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject_test.go
@@ -129,7 +129,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-delete-object",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject.go
+++ b/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject_test.go
@@ -130,7 +130,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-download-object",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy_test.go
@@ -127,7 +127,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-get-bucket-iam-policy",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata_test.go
@@ -128,7 +128,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-get-bucket-metadata",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata_test.go
@@ -126,7 +126,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-get-object-metadata",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
+++ b/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
@@ -71,7 +71,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets_test.go
+++ b/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets_test.go
@@ -128,7 +128,7 @@ func initTool(t *testing.T) tools.Tool {
 		Type:   "cloud-storage-list-buckets",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
+++ b/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
@@ -72,7 +72,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects_test.go
+++ b/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects_test.go
@@ -136,7 +136,7 @@ func TestInvokeMaxResultsValidation(t *testing.T) {
 				Type:   "cloud-storage-list-objects",
 				Source: "my-gcs",
 			}
-			tool, err := cfg.Initialize()
+			tool, err := cfg.Initialize(context.Background())
 			if err != nil {
 				t.Fatalf("failed to initialize tool: %v", err)
 			}

--- a/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject.go
+++ b/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject_test.go
@@ -131,7 +131,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-move-object",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
+++ b/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
@@ -68,7 +68,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject.go
+++ b/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject_test.go
+++ b/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject_test.go
@@ -130,7 +130,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-upload-object",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject.go
+++ b/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject_test.go
@@ -133,7 +133,7 @@ func TestInvokeValidation(t *testing.T) {
 		Type:   "cloud-storage-write-object",
 		Source: "my-gcs",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/cockroachdb/cockroachdbexecutesql/cockroachdbexecutesql.go
+++ b/internal/tools/cockroachdb/cockroachdbexecutesql/cockroachdbexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cockroachdb/cockroachdblistschemas/cockroachdblistschemas.go
+++ b/internal/tools/cockroachdb/cockroachdblistschemas/cockroachdblistschemas.go
@@ -75,7 +75,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cockroachdb/cockroachdblisttables/cockroachdblisttables.go
+++ b/internal/tools/cockroachdb/cockroachdblisttables/cockroachdblisttables.go
@@ -135,7 +135,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/cockroachdb/cockroachdbsql/cockroachdbsql.go
+++ b/internal/tools/cockroachdb/cockroachdbsql/cockroachdbsql.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
@@ -98,7 +98,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
@@ -69,7 +69,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/couchbase/couchbase.go
+++ b/internal/tools/couchbase/couchbase.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/dataform/dataformcompilelocal/dataformcompilelocal.go
+++ b/internal/tools/dataform/dataformcompilelocal/dataformcompilelocal.go
@@ -54,7 +54,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage.go
+++ b/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage.go
@@ -76,7 +76,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	locations := parameters.NewArrayParameter(
 		"locations",
 		"Required. The locations to search in. Must contain at least 1 location. The first location will be used to initiate the search.",

--- a/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage_test.go
+++ b/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage_test.go
@@ -135,7 +135,7 @@ func TestInvoke(t *testing.T) {
 		Type:   "datalineage-search-lineage",
 		Source: "my-lineage",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/dataplex/dataplexcheckdataquality/dataplexcheckdataquality.go
+++ b/internal/tools/dataplex/dataplexcheckdataquality/dataplexcheckdataquality.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	resourcePath := parameters.NewStringParameter("resourcePath", "The BigQuery table or Cloud Storage path to check. For BigQuery: accepts raw table name (e.g. 'my_table'), dataset.table (e.g. 'my_dataset.my_table'), or fully-qualified path (e.g. '//bigquery.googleapis.com/projects/{project}/datasets/{dataset}/tables/{table}'). For Cloud Storage: accepts raw bucket name (e.g. 'my-bucket'), gs:// URI (e.g. 'gs://my-bucket'), or fully-qualified path (e.g. '//storage.googleapis.com/projects/{project}/buckets/{bucket}').")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan should be created and executed (e.g., 'us-central1').")
 	specJSON := parameters.NewStringParameter("specJSON", "A JSON-serialized string of the Dataplex DataQualitySpec proto message containing the rules and optional configuration. Example format: {\"rules\": [{\"column\": \"my_col\", \"dimension\": \"COMPLETENESS\", \"nonNullExpectation\": {}}], \"catalogPublishingEnabled\": false}")

--- a/internal/tools/dataplex/dataplexdiscovermetadata/dataplexdiscovermetadata.go
+++ b/internal/tools/dataplex/dataplexdiscovermetadata/dataplexdiscovermetadata.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	resourcePath := parameters.NewStringParameter("resourcePath", "The Cloud Storage bucket to discover. Accepts raw bucket name (e.g. 'my-bucket'), standard gs:// URI (e.g. 'gs://my-bucket'), or fully-qualified resource path (e.g. '//storage.googleapis.com/projects/{project}/buckets/{bucket}').")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan should be created and executed (e.g., 'us-central1'). This should match the location of the GCS bucket.")
 

--- a/internal/tools/dataplex/dataplexgeneratedatainsights/dataplexgeneratedatainsights.go
+++ b/internal/tools/dataplex/dataplexgeneratedatainsights/dataplexgeneratedatainsights.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	resourcePath := parameters.NewStringParameter("resourcePath", "The fully-qualified BigQuery resource path of the dataset or table to analyze. Format: //bigquery.googleapis.com/projects/{project}/datasets/{dataset} or //bigquery.googleapis.com/projects/{project}/datasets/{dataset}/tables/{table}.")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan should be created and executed (e.g., 'us-central1'). This should match the location of the BigQuery resource or the published location of the asset in the catalog.")
 	publish := parameters.NewBooleanParameterWithDefault("publish", false, "Optional. If true, automatically publishes the results to the Knowledge Catalog upon successful completion. False by default.")

--- a/internal/tools/dataplex/dataplexgeneratedataprofile/dataplexgeneratedataprofile.go
+++ b/internal/tools/dataplex/dataplexgeneratedataprofile/dataplexgeneratedataprofile.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	resourcePath := parameters.NewStringParameter("resourcePath", "The BigQuery table to analyze. Accepts raw table name (e.g. 'my_table'), dataset.table (e.g. 'my_dataset.my_table'), or fully-qualified resource path (e.g. '//bigquery.googleapis.com/projects/{project}/datasets/{dataset}/tables/{table}').")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan should be created and executed (e.g., 'us-central1'). This should match the location of the BigQuery resource.")
 	publish := parameters.NewBooleanParameter("publish", "Whether to publish the generated profile results to the Dataplex Universal Catalog.")

--- a/internal/tools/dataplex/dataplexgetdatainsights/dataplexgetdatainsights.go
+++ b/internal/tools/dataplex/dataplexgetdatainsights/dataplexgetdatainsights.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	scanID := parameters.NewStringParameter("scanId", "The unique ID of the Dataplex DataScan (e.g. 'nq-doc-12345...'). This is extracted from the target or name field of the creation operation.")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan was created (e.g. 'us-central1').")
 

--- a/internal/tools/dataplex/dataplexgetdataprofile/dataplexgetdataprofile.go
+++ b/internal/tools/dataplex/dataplexgetdataprofile/dataplexgetdataprofile.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	scanID := parameters.NewStringParameter("scanId", "The unique ID of the Dataplex DataScan (e.g. 'nq-prof-12345...'). This is extracted from the target or name field of the creation operation.")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan was created (e.g. 'us-central1').")
 

--- a/internal/tools/dataplex/dataplexgetdataqualityresults/dataplexgetdataqualityresults.go
+++ b/internal/tools/dataplex/dataplexgetdataqualityresults/dataplexgetdataqualityresults.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	scanID := parameters.NewStringParameter("scanId", "The unique ID of the Dataplex DataScan (e.g. 'nq-dq-12345...'). This is extracted from the target or name field of the creation operation.")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan was created (e.g. 'us-central1').")
 

--- a/internal/tools/dataplex/dataplexgetdiscoveryresults/dataplexgetdiscoveryresults.go
+++ b/internal/tools/dataplex/dataplexgetdiscoveryresults/dataplexgetdiscoveryresults.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	scanID := parameters.NewStringParameter("scanId", "The unique ID of the Dataplex DataScan (e.g. 'nq-disc-12345...'). This is extracted from the target or name field of the creation operation.")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan was created (e.g. 'us-central1').")
 

--- a/internal/tools/dataplex/dataplexgetoperation/dataplexgetoperation.go
+++ b/internal/tools/dataplex/dataplexgetoperation/dataplexgetoperation.go
@@ -59,7 +59,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	operationName := parameters.NewStringParameter("operationName", "The fully-qualified resource name of the operation returned by generate_data_insights. Format: projects/{project}/locations/{location}/operations/{operation_id}.")
 
 	allParameters := parameters.Parameters{operationName}

--- a/internal/tools/dataplex/dataplexgetrunstatus/dataplexgetrunstatus.go
+++ b/internal/tools/dataplex/dataplexgetrunstatus/dataplexgetrunstatus.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	scanID := parameters.NewStringParameter("scanId", "The unique ID of the Dataplex DataScan (e.g. 'nq-doc-12345...').")
 	location := parameters.NewStringParameter("location", "The Google Cloud region where the Dataplex scan was created (e.g. 'us-central1').")
 	jobID := parameters.NewStringParameterWithRequired("jobId", "Optional. The specific unique ID of the background job run (DataScanJob) to track. If not provided, tracks the latest execution run.", false)

--- a/internal/tools/dataplex/dataplexlookupcontext/dataplexlookupcontext.go
+++ b/internal/tools/dataplex/dataplexlookupcontext/dataplexlookupcontext.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	resources := parameters.NewArrayParameter("resources",
 		"A list of up to 10 resource names. Resources may belong to different projects, but all must belong to the same location.",
 		parameters.NewStringParameter("resource",

--- a/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
+++ b/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	viewDesc := `
 				## Argument: view
 

--- a/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
+++ b/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	query := parameters.NewStringParameter("query", "The query against which aspect type should be matched.")
 	pageSize := parameters.NewIntParameterWithDefault("pageSize", 5, "Optional. Number of returned aspect types in the search page.")
 	orderBy := parameters.NewStringParameterWithDefault("orderBy", "relevance", "Optional. Specifies the ordering of results. Supported values are: relevance, last_modified_timestamp, last_modified_timestamp asc")

--- a/internal/tools/dataplex/dataplexsearchdqscans/dataplexsearchdqscans.go
+++ b/internal/tools/dataplex/dataplexsearchdqscans/dataplexsearchdqscans.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	filter := parameters.NewStringParameterWithDefault("filter", "", "Optional. Filter string to search/filter data quality scans. E.g. \"display_name = \\\"my-scan\\\"\"")
 	dataScanID := parameters.NewStringParameterWithDefault("dataScanId", "", "Optional. The resource name of the data scan to filter by: projects/{project}/locations/{locationId}/dataScans/{dataScanId}.")
 	resourcePath := parameters.NewStringParameterWithDefault("resourcePath", "", "Optional. The resource path of the table or storage bucket to filter by. Maps to data.entity in the filter string. E.g. \"//bigquery.googleapis.com/projects/P/datasets/D/tables/T\"")

--- a/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
+++ b/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	query := parameters.NewStringParameter("query",
 		"A query string for searching entries, following Dataplex search syntax. "+
 			"Supports logical operators (AND, OR, NOT) and grouping. "+

--- a/internal/tools/dataproc/dataprocgetcluster/dataprocgetcluster.go
+++ b/internal/tools/dataproc/dataprocgetcluster/dataprocgetcluster.go
@@ -59,7 +59,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Gets a Dataproc cluster"

--- a/internal/tools/dataproc/dataprocgetjob/dataprocgetjob.go
+++ b/internal/tools/dataproc/dataprocgetjob/dataprocgetjob.go
@@ -59,7 +59,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Gets a Dataproc job"

--- a/internal/tools/dataproc/dataproclistclusters/dataproclistclusters.go
+++ b/internal/tools/dataproc/dataproclistclusters/dataproclistclusters.go
@@ -58,7 +58,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Lists and filters Dataproc clusters"

--- a/internal/tools/dataproc/dataproclistjobs/dataproclistjobs.go
+++ b/internal/tools/dataproc/dataproclistjobs/dataproclistjobs.go
@@ -58,7 +58,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Lists and filters Dataproc jobs"

--- a/internal/tools/dgraph/dgraph.go
+++ b/internal/tools/dgraph/dgraph.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/elasticsearch/elasticsearchesql/elasticsearchesql.go
+++ b/internal/tools/elasticsearch/elasticsearchesql/elasticsearchesql.go
@@ -72,7 +72,7 @@ type Tool struct {
 
 var _ tools.Tool = Tool{}
 
-func (c Config) Initialize() (tools.Tool, error) {
+func (c Config) Initialize(context.Context) (tools.Tool, error) {
 	if c.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", c.Name)
 	}

--- a/internal/tools/elasticsearch/elasticsearchexecuteesql/elasticsearchexecuteesql.go
+++ b/internal/tools/elasticsearch/elasticsearchexecuteesql/elasticsearchexecuteesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firebird/firebirdexecutesql/firebirdexecutesql.go
+++ b/internal/tools/firebird/firebirdexecutesql/firebirdexecutesql.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firebird/firebirdsql/firebirdsql.go
+++ b/internal/tools/firebird/firebirdsql/firebirdsql.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
+++ b/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestoredeletedocuments/firestoredeletedocuments.go
+++ b/internal/tools/firestore/firestoredeletedocuments/firestoredeletedocuments.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestoregetdocuments/firestoregetdocuments.go
+++ b/internal/tools/firestore/firestoregetdocuments/firestoregetdocuments.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestoregetrules/firestoregetrules.go
+++ b/internal/tools/firestore/firestoregetrules/firestoregetrules.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestorelistcollections/firestorelistcollections.go
+++ b/internal/tools/firestore/firestorelistcollections/firestorelistcollections.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestorequery/firestorequery.go
+++ b/internal/tools/firestore/firestorequery/firestorequery.go
@@ -85,7 +85,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance from the configuration
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
+++ b/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
@@ -110,7 +110,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance from the configuration
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
+++ b/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument_test.go
+++ b/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument_test.go
@@ -149,7 +149,7 @@ func TestConfig_Initialize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tool, err := tt.config.Initialize()
+			tool, err := tt.config.Initialize(context.Background())
 
 			if tt.wantErr {
 				if err == nil {

--- a/internal/tools/firestore/firestorevalidaterules/firestorevalidaterules.go
+++ b/internal/tools/firestore/firestorevalidaterules/firestorevalidaterules.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -75,7 +75,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
+++ b/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
+++ b/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -136,7 +136,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookercreateagent/lookercreateagent.go
+++ b/internal/tools/looker/lookercreateagent/lookercreateagent.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookercreateagent/lookercreateagent_test.go
+++ b/internal/tools/looker/lookercreateagent/lookercreateagent_test.go
@@ -156,7 +156,7 @@ func TestInvokeValidation(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestManifest(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestAnnotations(t *testing.T) {
 		},
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
+++ b/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
+++ b/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
+++ b/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
+++ b/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
+++ b/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerdeleteagent/lookerdeleteagent_test.go
+++ b/internal/tools/looker/lookerdeleteagent/lookerdeleteagent_test.go
@@ -156,7 +156,7 @@ func TestInvokeValidation(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestManifest(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestAnnotations(t *testing.T) {
 		},
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
+++ b/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
+++ b/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
+++ b/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerdevmode/lookerdevmode.go
+++ b/internal/tools/looker/lookerdevmode/lookerdevmode.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
+++ b/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetagent/lookergetagent.go
+++ b/internal/tools/looker/lookergetagent/lookergetagent.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetagent/lookergetagent_test.go
+++ b/internal/tools/looker/lookergetagent/lookergetagent_test.go
@@ -156,7 +156,7 @@ func TestInvokeValidation(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestManifest(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestAnnotations(t *testing.T) {
 		},
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
+++ b/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetconnections/lookergetconnections.go
+++ b/internal/tools/looker/lookergetconnections/lookergetconnections.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
+++ b/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
+++ b/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
+++ b/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
+++ b/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
+++ b/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetexplores/lookergetexplores.go
+++ b/internal/tools/looker/lookergetexplores/lookergetexplores.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetfilters/lookergetfilters.go
+++ b/internal/tools/looker/lookergetfilters/lookergetfilters.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
+++ b/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
+++ b/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetlooks/lookergetlooks.go
+++ b/internal/tools/looker/lookergetlooks/lookergetlooks.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
+++ b/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetmodels/lookergetmodels.go
+++ b/internal/tools/looker/lookergetmodels/lookergetmodels.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetparameters/lookergetparameters.go
+++ b/internal/tools/looker/lookergetparameters/lookergetparameters.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
+++ b/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
+++ b/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
+++ b/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookergetprojects/lookergetprojects.go
+++ b/internal/tools/looker/lookergetprojects/lookergetprojects.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
+++ b/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
+++ b/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
+++ b/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerlistagents/lookerlistagents.go
+++ b/internal/tools/looker/lookerlistagents/lookerlistagents.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerlistagents/lookerlistagents_test.go
+++ b/internal/tools/looker/lookerlistagents/lookerlistagents_test.go
@@ -158,7 +158,7 @@ func TestManifest(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestAnnotations(t *testing.T) {
 		},
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
+++ b/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
+++ b/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookermakelook/lookermakelook.go
+++ b/internal/tools/looker/lookermakelook/lookermakelook.go
@@ -68,7 +68,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerquery/lookerquery.go
+++ b/internal/tools/looker/lookerquery/lookerquery.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerquerysql/lookerquerysql.go
+++ b/internal/tools/looker/lookerquerysql/lookerquerysql.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
+++ b/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
+++ b/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
@@ -68,7 +68,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerrunlook/lookerrunlook.go
+++ b/internal/tools/looker/lookerrunlook/lookerrunlook.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
+++ b/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
+++ b/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
+++ b/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookerupdateagent/lookerupdateagent_test.go
+++ b/internal/tools/looker/lookerupdateagent/lookerupdateagent_test.go
@@ -156,7 +156,7 @@ func TestInvokeValidation(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestManifest(t *testing.T) {
 		Source: "my-instance",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestAnnotations(t *testing.T) {
 		},
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}

--- a/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
+++ b/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
+++ b/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mindsdb/mindsdbexecutesql/mindsdbexecutesql.go
+++ b/internal/tools/mindsdb/mindsdbexecutesql/mindsdbexecutesql.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mindsdb/mindsdbsql/mindsdbsql.go
+++ b/internal/tools/mindsdb/mindsdbsql/mindsdbsql.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbaggregate/mongodbaggregate.go
+++ b/internal/tools/mongodb/mongodbaggregate/mongodbaggregate.go
@@ -68,7 +68,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbdeletemany/mongodbdeletemany.go
+++ b/internal/tools/mongodb/mongodbdeletemany/mongodbdeletemany.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbdeleteone/mongodbdeleteone.go
+++ b/internal/tools/mongodb/mongodbdeleteone/mongodbdeleteone.go
@@ -66,7 +66,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbfind/mongodbfind.go
+++ b/internal/tools/mongodb/mongodbfind/mongodbfind.go
@@ -73,7 +73,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbfindone/mongodbfindone.go
+++ b/internal/tools/mongodb/mongodbfindone/mongodbfindone.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbinsertmany/mongodbinsertmany.go
+++ b/internal/tools/mongodb/mongodbinsertmany/mongodbinsertmany.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbinsertone/mongodbinsertone.go
+++ b/internal/tools/mongodb/mongodbinsertone/mongodbinsertone.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbupdatemany/mongodbupdatemany.go
+++ b/internal/tools/mongodb/mongodbupdatemany/mongodbupdatemany.go
@@ -69,7 +69,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mongodb/mongodbupdateone/mongodbupdateone.go
+++ b/internal/tools/mongodb/mongodbupdateone/mongodbupdateone.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
+++ b/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mssql/mssqllisttables/mssqllisttables.go
+++ b/internal/tools/mssql/mssqllisttables/mssqllisttables.go
@@ -310,7 +310,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mssql/mssqlsql/mssqlsql.go
+++ b/internal/tools/mssql/mssqlsql/mssqlsql.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqlgetqueryplan/mysqlgetqueryplan.go
+++ b/internal/tools/mysql/mysqlgetqueryplan/mysqlgetqueryplan.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllistactivequeries/mysqllistactivequeries.go
+++ b/internal/tools/mysql/mysqllistactivequeries/mysqllistactivequeries.go
@@ -127,7 +127,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllistalllocks/mysqllistalllocks.go
+++ b/internal/tools/mysql/mysqllistalllocks/mysqllistalllocks.go
@@ -115,7 +115,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttablefragmentation/mysqllisttablefragmentation.go
+++ b/internal/tools/mysql/mysqllisttablefragmentation/mysqllisttablefragmentation.go
@@ -83,7 +83,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttables/mysqllisttables.go
+++ b/internal/tools/mysql/mysqllisttables/mysqllisttables.go
@@ -214,7 +214,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttablesmissinguniqueindexes/mysqllisttablesmissinguniqueindexes.go
+++ b/internal/tools/mysql/mysqllisttablesmissinguniqueindexes/mysqllisttablesmissinguniqueindexes.go
@@ -84,7 +84,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttablestats/mysqllisttablestats.go
+++ b/internal/tools/mysql/mysqllisttablestats/mysqllisttablestats.go
@@ -100,7 +100,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqlshowquerystats/mysqlshowquerystats.go
+++ b/internal/tools/mysql/mysqlshowquerystats/mysqlshowquerystats.go
@@ -83,7 +83,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/mysql/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysql/mysqlsql/mysqlsql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/neo4j/neo4jcypher/neo4jcypher.go
+++ b/internal/tools/neo4j/neo4jcypher/neo4jcypher.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
+++ b/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/neo4j/neo4jschema/neo4jschema.go
+++ b/internal/tools/neo4j/neo4jschema/neo4jschema.go
@@ -77,7 +77,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize sets up the tool with its dependencies and returns a ready-to-use Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/oceanbase/oceanbaseexecutesql/oceanbaseexecutesql.go
+++ b/internal/tools/oceanbase/oceanbaseexecutesql/oceanbaseexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/oceanbase/oceanbasesql/oceanbasesql.go
+++ b/internal/tools/oceanbase/oceanbasesql/oceanbasesql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/oracle/oracleexecutesql/oracleexecutesql.go
+++ b/internal/tools/oracle/oracleexecutesql/oracleexecutesql.go
@@ -50,7 +50,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/oracle/oraclesql/oraclesql.go
+++ b/internal/tools/oracle/oraclesql/oraclesql.go
@@ -53,7 +53,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/postgres/postgresdatabaseoverview/postgresdatabaseoverview.go
+++ b/internal/tools/postgres/postgresdatabaseoverview/postgresdatabaseoverview.go
@@ -74,7 +74,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{}
 	if cfg.Description == "" {
 		cfg.Description = "Fetches the current state of the PostgreSQL server, returning the version, whether it's a replica, uptime duration, maximum connection limit, number of current connections, number of active connections, and the percentage of connections in use."

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
@@ -60,7 +60,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/postgres/postgresgetcolumncardinality/postgresgetcolumncardinality.go
+++ b/internal/tools/postgres/postgresgetcolumncardinality/postgresgetcolumncardinality.go
@@ -79,7 +79,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("schema_name", "public", "Optional: The schema name in which the table is present."),
 		parameters.NewStringParameterWithRequired("table_name", "Required: The table name in which the column is present.", true),

--- a/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
+++ b/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
@@ -83,7 +83,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistavailableextensions/postgreslistavailableextensions.go
+++ b/internal/tools/postgres/postgreslistavailableextensions/postgreslistavailableextensions.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistdatabasestats/postgreslistdatabasestats.go
+++ b/internal/tools/postgres/postgreslistdatabasestats/postgreslistdatabasestats.go
@@ -126,7 +126,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("database_name", "", "Optional: A specific database name pattern to search for."),
 		parameters.NewBooleanParameterWithDefault("include_templates", false, "Optional: Whether to include template databases in the results."),

--- a/internal/tools/postgres/postgreslistindexes/postgreslistindexes.go
+++ b/internal/tools/postgres/postgreslistindexes/postgreslistindexes.go
@@ -106,7 +106,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("schema_name", "", "Optional: a text to filter results by schema name. The input is used within a LIKE clause."),
 		parameters.NewStringParameterWithDefault("table_name", "", "Optional: a text to filter results by table name. The input is used within a LIKE clause."),

--- a/internal/tools/postgres/postgreslistinstalledextensions/postgreslistinstalledextensions.go
+++ b/internal/tools/postgres/postgreslistinstalledextensions/postgreslistinstalledextensions.go
@@ -81,7 +81,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistlocks/postgreslistlocks.go
+++ b/internal/tools/postgres/postgreslistlocks/postgreslistlocks.go
@@ -81,7 +81,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{}
 
 	if cfg.Description == "" {

--- a/internal/tools/postgres/postgreslistpgsettings/postgreslistpgsettings.go
+++ b/internal/tools/postgres/postgreslistpgsettings/postgreslistpgsettings.go
@@ -79,7 +79,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("setting_name", "", "Optional: A specific configuration parameter name pattern to search for."),
 		parameters.NewIntParameterWithDefault("limit", 50, "Optional: The maximum number of rows to return."),

--- a/internal/tools/postgres/postgreslistpublicationtables/postgreslistpublicationtables.go
+++ b/internal/tools/postgres/postgreslistpublicationtables/postgreslistpublicationtables.go
@@ -90,7 +90,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("table_names", "", "Optional: Filters by a comma-separated list of table names."),
 		parameters.NewStringParameterWithDefault("publication_names", "", "Optional: Filters by a comma-separated list of publication names."),

--- a/internal/tools/postgres/postgreslistquerystats/postgreslistquerystats.go
+++ b/internal/tools/postgres/postgreslistquerystats/postgreslistquerystats.go
@@ -80,7 +80,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("database_name", "", "Optional: The database name to list query stats for."),
 		parameters.NewIntParameterWithDefault("limit", 50, "Optional: The maximum number of results to return. Defaults to 50."),

--- a/internal/tools/postgres/postgreslistroles/postgreslistroles.go
+++ b/internal/tools/postgres/postgreslistroles/postgreslistroles.go
@@ -102,7 +102,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("role_name", "", "Optional: a text to filter results by role name. The input is used within a LIKE clause."),
 		parameters.NewIntParameterWithDefault("limit", 50, "Optional: The maximum number of rows to return. Default is 10"),

--- a/internal/tools/postgres/postgreslistschemas/postgreslistschemas.go
+++ b/internal/tools/postgres/postgreslistschemas/postgreslistschemas.go
@@ -114,7 +114,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("schema_name", "", "Optional: A specific schema name pattern to search for."),
 		parameters.NewStringParameterWithDefault("owner", "", "Optional: A specific schema owner name pattern to search for."),

--- a/internal/tools/postgres/postgreslistsequences/postgreslistsequences.go
+++ b/internal/tools/postgres/postgreslistsequences/postgreslistsequences.go
@@ -80,7 +80,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("schema_name", "", "Optional: A specific schema name pattern to search for."),
 		parameters.NewStringParameterWithDefault("sequence_name", "", "Optional: A specific sequence name pattern to search for."),

--- a/internal/tools/postgres/postgresliststoredprocedure/postgresliststoredprocedure.go
+++ b/internal/tools/postgres/postgresliststoredprocedure/postgresliststoredprocedure.go
@@ -88,7 +88,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithRequired("role_name", "Optional: The owner name to filter the stored procedures by. Defaults to NULL.", false),
 		parameters.NewStringParameterWithRequired("schema_name", "Optional: The schema name to filter the stored procedures by. Defaults to NULL.", false),

--- a/internal/tools/postgres/postgreslisttables/postgreslisttables.go
+++ b/internal/tools/postgres/postgreslisttables/postgreslisttables.go
@@ -138,7 +138,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
+++ b/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
@@ -86,7 +86,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("tablespace_name", "", "Optional: a text to filter results by tablespace name. The input is used within a LIKE clause."),
 		parameters.NewIntParameterWithDefault("limit", 50, "Optional: The maximum number of rows to return."),

--- a/internal/tools/postgres/postgreslisttablestats/postgreslisttablestats.go
+++ b/internal/tools/postgres/postgreslisttablestats/postgreslisttablestats.go
@@ -107,7 +107,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("schema_name", "public", "Optional: A specific schema name to filter by"),
 		parameters.NewStringParameterWithRequired("table_name", "Optional: A specific table name to filter by", false),

--- a/internal/tools/postgres/postgreslisttriggers/postgreslisttriggers.go
+++ b/internal/tools/postgres/postgreslisttriggers/postgreslisttriggers.go
@@ -106,7 +106,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("trigger_name", "", "Optional: A specific trigger name pattern to search for."),
 		parameters.NewStringParameterWithDefault("schema_name", "", "Optional: A specific schema name pattern to search for."),

--- a/internal/tools/postgres/postgreslistviews/postgreslistviews.go
+++ b/internal/tools/postgres/postgreslistviews/postgreslistviews.go
@@ -81,7 +81,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("view_name", "", "Optional: A specific view name to search for."),
 		parameters.NewStringParameterWithDefault("schema_name", "", "Optional: A specific schema name to search for."),

--- a/internal/tools/postgres/postgreslongrunningtransactions/postgreslongrunningtransactions.go
+++ b/internal/tools/postgres/postgreslongrunningtransactions/postgreslongrunningtransactions.go
@@ -88,7 +88,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault("min_duration", "5 minutes", "Optional: Only show transactions running at least this long (e.g., '1 minute', '15 minutes', '30 seconds')."),
 		parameters.NewIntParameterWithDefault("limit", 20, "Optional: The maximum number of long-running transactions to return. Defaults to 20."),

--- a/internal/tools/postgres/postgresreplicationstats/postgresreplicationstats.go
+++ b/internal/tools/postgres/postgresreplicationstats/postgresreplicationstats.go
@@ -78,7 +78,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters := parameters.Parameters{}
 
 	if cfg.Description == "" {

--- a/internal/tools/postgres/postgressql/postgressql.go
+++ b/internal/tools/postgres/postgressql/postgressql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/redis/redis.go
+++ b/internal/tools/redis/redis.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/scylladb/scyllacql/scyllacql.go
+++ b/internal/tools/scylladb/scyllacql/scyllacql.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize implements tools.ToolConfig.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	allParameters, paramManifest, err := parameters.ProcessParameters(cfg.TemplateParameters, cfg.Parameters)
 	if err != nil {
 		return nil, fmt.Errorf("unable to process parameters: %w", err)

--- a/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Cancels a running Serverless Spark (aka Dataproc Serverless) batch operation. Note that the batch state will not change immediately after the tool returns; it can take a minute or so for the cancellation to be reflected."

--- a/internal/tools/serverlessspark/serverlesssparkcreatepysparkbatch/serverlesssparkcreatepysparkbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkcreatepysparkbatch/serverlesssparkcreatepysparkbatch.go
@@ -56,7 +56,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return createbatch.NewTool(cfg.Config, cfg, &PySparkBatchBuilder{})
 }
 

--- a/internal/tools/serverlessspark/serverlesssparkcreatesparkbatch/serverlesssparkcreatesparkbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkcreatesparkbatch/serverlesssparkcreatesparkbatch.go
@@ -56,7 +56,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return createbatch.NewTool(cfg.Config, cfg, &SparkBatchBuilder{})
 }
 

--- a/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Gets a Serverless Spark (aka Dataproc Serverless) batch"

--- a/internal/tools/serverlessspark/serverlesssparkgetsession/serverlesssparkgetsession.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetsession/serverlesssparkgetsession.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Gets a Serverless Spark (aka Dataproc Serverless) session"

--- a/internal/tools/serverlessspark/serverlesssparkgetsessiontemplate/serverlesssparkgetsessiontemplate.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetsessiontemplate/serverlesssparkgetsessiontemplate.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Gets a Serverless Spark (aka Dataproc Serverless) session template"

--- a/internal/tools/serverlessspark/serverlesssparklistbatches/serverlesssparklistbatches.go
+++ b/internal/tools/serverlessspark/serverlesssparklistbatches/serverlesssparklistbatches.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Lists available Serverless Spark (aka Dataproc Serverless) batches"

--- a/internal/tools/serverlessspark/serverlesssparklistsessions/serverlesssparklistsessions.go
+++ b/internal/tools/serverlessspark/serverlesssparklistsessions/serverlesssparklistsessions.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize creates a new Tool instance.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	desc := cfg.Description
 	if desc == "" {
 		desc = "Lists available Serverless Spark (aka Dataproc Serverless) sessions"

--- a/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
+++ b/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
@@ -65,7 +65,7 @@ func (cfg Config) ToolConfigType() string {
 }
 
 // Initialize sets up the Tool using the provided sources map.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/singlestore/singlestoresql/singlestoresql.go
+++ b/internal/tools/singlestore/singlestoresql/singlestoresql.go
@@ -70,7 +70,7 @@ func (cfg Config) ToolConfigType() string {
 // Initialize sets up and returns a new Tool instance based on the provided configuration.
 // It processes tool parameters and constructs the necessary manifests for tool operation.
 // Returns an initialized Tool or an error if setup fails.
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql.go
+++ b/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql_test.go
+++ b/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql_test.go
@@ -15,6 +15,7 @@
 package snowflakeexecutesql_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -76,7 +77,7 @@ func TestFailInitializeMissingDescription(t *testing.T) {
 		Type:       "snowflake-execute-sql",
 		Source:     "my-snowflake-source",
 	}
-	_, err := cfg.Initialize()
+	_, err := cfg.Initialize(context.Background())
 	if err == nil {
 		t.Fatalf("expect initialize to fail")
 	}

--- a/internal/tools/snowflake/snowflakesql/snowflakesql.go
+++ b/internal/tools/snowflake/snowflakesql/snowflakesql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
+++ b/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/spanner/spannerlistgraphs/spannerlistgraphs.go
+++ b/internal/tools/spanner/spannerlistgraphs/spannerlistgraphs.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	// Define parameters for the tool
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault(

--- a/internal/tools/spanner/spannerlisttables/spannerlisttables.go
+++ b/internal/tools/spanner/spannerlisttables/spannerlisttables.go
@@ -63,7 +63,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	// Define parameters for the tool
 	allParameters := parameters.Parameters{
 		parameters.NewStringParameterWithDefault(

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	prompt := parameters.NewStringParameter("prompt", "Prompt representing search intention. Do not rewrite the prompt.")
 
 	databaseIds := parameters.NewArrayParameterWithDefault(

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
@@ -114,7 +114,7 @@ func TestConfig_Initialize(t *testing.T) {
 		Source: "test-source",
 	}
 
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("Initialize failed: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestTool_Invoke(t *testing.T) {
 		Type:   "spanner-search-catalog",
 		Source: "test-source",
 	}
-	tool, err := cfg.Initialize()
+	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("Initialize failed: %v", err)
 	}

--- a/internal/tools/spanner/spannersql/spannersql.go
+++ b/internal/tools/spanner/spannersql/spannersql.go
@@ -67,7 +67,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/sqlite/sqliteexecutesql/sqliteexecutesql.go
+++ b/internal/tools/sqlite/sqliteexecutesql/sqliteexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/sqlite/sqlitesql/sqlitesql.go
+++ b/internal/tools/sqlite/sqlitesql/sqlitesql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
+++ b/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/tidb/tidbsql/tidbsql.go
+++ b/internal/tools/tidb/tidbsql/tidbsql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -67,7 +67,7 @@ func DecodeConfig(ctx context.Context, resourceType string, name string, decoder
 
 type ToolConfig interface {
 	ToolConfigType() string
-	Initialize() (Tool, error)
+	Initialize(context.Context) (Tool, error)
 }
 
 // https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -34,7 +34,7 @@ type stubConfig struct {
 }
 
 func (stubConfig) ToolConfigType() string { return "stub" }
-func (stubConfig) Initialize() (tools.Tool, error) {
+func (stubConfig) Initialize(context.Context) (tools.Tool, error) {
 	return nil, nil
 }
 

--- a/internal/tools/trino/trinoexecutesql/trinoexecutesql.go
+++ b/internal/tools/trino/trinoexecutesql/trinoexecutesql.go
@@ -61,7 +61,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/trino/trinosql/trinosql.go
+++ b/internal/tools/trino/trinosql/trinosql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/utility/wait/wait.go
+++ b/internal/tools/utility/wait/wait.go
@@ -54,7 +54,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/valkey/valkey.go
+++ b/internal/tools/valkey/valkey.go
@@ -62,7 +62,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/tools/yugabytedbsql/yugabytedbsql.go
+++ b/internal/tools/yugabytedbsql/yugabytedbsql.go
@@ -64,7 +64,7 @@ func (cfg Config) ToolConfigType() string {
 	return resourceType
 }
 
-func (cfg Config) Initialize() (tools.Tool, error) {
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -176,6 +176,23 @@ func LoggerFromContext(ctx context.Context) (log.Logger, error) {
 	return nil, fmt.Errorf("unable to retrieve logger")
 }
 
+// LogPrimitiveDeprecation is a helper function to mark a primitive as
+// deprecated.
+//
+// kind: kind of primitive. E.g. source / tool / authService / etc.
+// primitiveType: the type of primitive being deprecated. E.g. postgres-sql
+// migrationStep: the migration step for this deprecation. E.g. "Please use
+// [Alternative] instead." / "Please remove this from your configuration file."
+func LogPrimitiveDeprecation(ctx context.Context, kind string, primitiveType string, migrationStep string) error {
+	l, err := LoggerFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	msg := fmt.Sprintf("%s '%s' is deprecated and will be removed in the next major release. %s", kind, primitiveType, migrationStep)
+	l.WarnContext(ctx, msg)
+	return nil
+}
+
 const instrumentationKey contextKey = "instrumentation"
 
 // WithInstrumentation adds an instrumentation into the context as a value

--- a/tests/cloudmonitoring/cloud_monitoring_integration_test.go
+++ b/tests/cloudmonitoring/cloud_monitoring_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -27,7 +28,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
-func newTestTool(t *testing.T, toolType string) cloudmonitoring.Tool {
+func newTestTool(t *testing.T, ctx context.Context, toolType string) cloudmonitoring.Tool {
 	t.Helper()
 	cfg := cloudmonitoring.Config{
 		ConfigBase: tools.ConfigBase{
@@ -37,7 +38,7 @@ func newTestTool(t *testing.T, toolType string) cloudmonitoring.Tool {
 		Type:   toolType,
 		Source: "test-source",
 	}
-	toolIface, err := cfg.Initialize()
+	toolIface, err := cfg.Initialize(ctx)
 	if err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
@@ -46,6 +47,9 @@ func newTestTool(t *testing.T, toolType string) cloudmonitoring.Tool {
 
 func TestTool_Invoke(t *testing.T) {
 	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 
 	// Mock the monitoring server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +68,7 @@ func TestTool_Invoke(t *testing.T) {
 	defer server.Close()
 
 	// Create a new observability tool
-	tool := newTestTool(t, "cloud-monitoring-query-prometheus")
+	tool := newTestTool(t, ctx, "cloud-monitoring-query-prometheus")
 
 	// Define the test parameters
 	params := parameters.ParamValues{
@@ -73,7 +77,7 @@ func TestTool_Invoke(t *testing.T) {
 	}
 
 	// Invoke the tool
-	result, err := tool.Invoke(context.Background(), nil, params, "")
+	result, err := tool.Invoke(ctx, nil, params, "")
 	if err != nil {
 		t.Fatalf("Invoke() error = %v", err)
 	}
@@ -94,6 +98,9 @@ func TestTool_Invoke(t *testing.T) {
 func TestTool_Invoke_Error(t *testing.T) {
 	t.Parallel()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	// Mock the monitoring server to return an error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -101,7 +108,7 @@ func TestTool_Invoke_Error(t *testing.T) {
 	defer server.Close()
 
 	// Create a new observability tool
-	tool := newTestTool(t, "clou-monitoring-query-prometheus")
+	tool := newTestTool(t, ctx, "clou-monitoring-query-prometheus")
 
 	// Define the test parameters
 	params := parameters.ParamValues{
@@ -110,7 +117,7 @@ func TestTool_Invoke_Error(t *testing.T) {
 	}
 
 	// Invoke the tool
-	_, err := tool.Invoke(context.Background(), nil, params, "")
+	_, err := tool.Invoke(ctx, nil, params, "")
 	if err == nil {
 		t.Fatal("Invoke() error = nil, want error")
 	}


### PR DESCRIPTION
This PR adds the following: 
* Guide in DEVELOPER.MD on deprecating primitive
* Add a helper function `LogPrimitiveDeprecation(ctx context.Context, primitiveType string, name string, migrationStep string) error` to deprecate primitive in `util/util.go`.
* Add `context.Context` to each tool's initialization. This is needed to retrieve log


To deprecate a primitive (source / tool etc.), we just have to add the following to the primitive's initialization method:
```
err := util.LogPrimitiveDeprecation("Tool", cfg.ToolConfigType, "Please use alternative-tool instead.")
if err != nil {
  return fmt.Errorf("unable to log deprecation: %w", err)
}
```