### PR TITLE
feat: http tool forward authorization header(#3306)

### DIFF
--- a/internal/sources/http/http.go
+++ b/internal/sources/http/http.go
@@ -50,14 +50,15 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name                   string            `yaml:"name" validate:"required"`
-	Type                   string            `yaml:"type" validate:"required"`
-	BaseURL                string            `yaml:"baseUrl"`
-	Timeout                string            `yaml:"timeout"`
-	DefaultHeaders         map[string]string `yaml:"headers"`
-	QueryParams            map[string]string `yaml:"queryParams"`
-	ReturnFullError        bool              `yaml:"returnFullError"`
-	DisableSslVerification bool              `yaml:"disableSslVerification"`
+	Name                        string            `yaml:"name" validate:"required"`
+	Type                        string            `yaml:"type" validate:"required"`
+	BaseURL                     string            `yaml:"baseUrl"`
+	Timeout                     string            `yaml:"timeout"`
+	DefaultHeaders              map[string]string `yaml:"headers"`
+	QueryParams                 map[string]string `yaml:"queryParams"`
+	ReturnFullError             bool              `yaml:"returnFullError"`
+	DisableSslVerification      bool              `yaml:"disableSslVerification"`
+	ForwardAuthorizationHeader  bool              `yaml:"forwardAuthorizationHeader"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -142,6 +143,10 @@ func (s *Source) HttpBaseURL() string {
 
 func (s *Source) HttpQueryParams() map[string]string {
 	return s.QueryParams
+}
+
+func (s *Source) HttpForwardAuthorizationHeader() bool {
+	return s.ForwardAuthorizationHeader
 }
 
 func (s *Source) Client() *http.Client {

--- a/internal/sources/http/http_test.go
+++ b/internal/sources/http/http_test.go
@@ -85,6 +85,25 @@ func TestParseFromYamlHttp(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "forward authorization header enabled",
+			in: `
+			kind: source
+			name: my-http-instance
+			type: http
+			baseUrl: http://test_server/
+			forwardAuthorizationHeader: true
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-http-instance": http.Config{
+					Name:                       "my-http-instance",
+					Type:                       http.SourceType,
+					BaseURL:                    "http://test_server/",
+					Timeout:                    "30s",
+					ForwardAuthorizationHeader: true,
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -52,6 +52,7 @@ type compatibleSource interface {
 	HttpDefaultHeaders() map[string]string
 	HttpBaseURL() string
 	HttpQueryParams() map[string]string
+	HttpForwardAuthorizationHeader() bool
 	RunRequest(context.Context, *http.Request) (any, error)
 }
 
@@ -327,6 +328,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	// Set request headers
 	for k, v := range allHeaders {
 		req.Header.Set(k, v)
+	}
+
+	// Forward the caller's Authorization header if configured and token is present
+	if source.HttpForwardAuthorizationHeader() && accessToken != "" {
+		req.Header.Set("Authorization", string(accessToken))
 	}
 
 	resp, err := source.RunRequest(ctx, req)

--- a/internal/tools/http/http_test.go
+++ b/internal/tools/http/http_test.go
@@ -15,15 +15,34 @@
 package http_test
 
 import (
+	"bytes"
+	"context"
+	nethttp "net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/log"
 	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	sourcehttp "github.com/googleapis/mcp-toolbox/internal/sources/http"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
 	http "github.com/googleapis/mcp-toolbox/internal/tools/http"
+	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
+
+// mockSourceProvider implements tools.SourceProvider backed by a real Source.
+type mockSourceProvider struct {
+	sources map[string]sources.Source
+}
+
+func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	s, ok := m.sources[name]
+	return s, ok
+}
 
 func TestParseFromYamlHTTP(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
@@ -219,4 +238,112 @@ func TestFailParseFromYamlHTTP(t *testing.T) {
 		})
 	}
 
+}
+
+func newTestContext(t *testing.T) context.Context {
+	t.Helper()
+	logger, err := log.NewLogger("standard", log.Debug, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	return util.WithLogger(context.Background(), logger)
+}
+
+func TestInvokeForwardAuthorizationHeader(t *testing.T) {
+	tcs := []struct {
+		desc                       string
+		forwardAuthorizationHeader bool
+		accessToken                tools.AccessToken
+		staticHeader               string // pre-configured Authorization header on the tool
+		wantAuthHeader             string // what the upstream server should receive
+	}{
+		{
+			desc:                       "forwards token when enabled and token present",
+			forwardAuthorizationHeader: true,
+			accessToken:                "Bearer caller-token",
+			wantAuthHeader:             "Bearer caller-token",
+		},
+		{
+			desc:                       "does not forward when disabled",
+			forwardAuthorizationHeader: false,
+			accessToken:                "Bearer caller-token",
+			wantAuthHeader:             "",
+		},
+		{
+			desc:                       "does not forward when token is empty",
+			forwardAuthorizationHeader: true,
+			accessToken:                "",
+			wantAuthHeader:             "",
+		},
+		{
+			desc:                       "forwarded token overrides static tool header",
+			forwardAuthorizationHeader: true,
+			accessToken:                "Bearer caller-token",
+			staticHeader:               "Bearer static-key",
+			wantAuthHeader:             "Bearer caller-token",
+		},
+		{
+			desc:                       "static header preserved when forwarding disabled",
+			forwardAuthorizationHeader: false,
+			accessToken:                "Bearer caller-token",
+			staticHeader:               "Bearer static-key",
+			wantAuthHeader:             "Bearer static-key",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			var receivedAuth string
+			upstream := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+				receivedAuth = r.Header.Get("Authorization")
+				w.WriteHeader(nethttp.StatusOK)
+				_, _ = w.Write([]byte(`"ok"`))
+			}))
+			defer upstream.Close()
+
+			ctx := newTestContext(t)
+
+			sourceCfg := sourcehttp.Config{
+				Name:                       "test-source",
+				Type:                       sourcehttp.SourceType,
+				BaseURL:                    upstream.URL + "/",
+				Timeout:                    "5s",
+				ForwardAuthorizationHeader: tc.forwardAuthorizationHeader,
+			}
+			initializedSource, err := sourceCfg.Initialize(ctx, nil)
+			if err != nil {
+				t.Fatalf("failed to initialize source: %v", err)
+			}
+
+			toolHeaders := map[string]string{}
+			if tc.staticHeader != "" {
+				toolHeaders["Authorization"] = tc.staticHeader
+			}
+
+			toolCfg := http.Config{
+				Name:        "test_tool",
+				Type:        "http",
+				Source:      "test-source",
+				Description: "test tool",
+				Method:      "GET",
+				Path:        "ping",
+				Headers:     toolHeaders,
+			}
+			srcs := map[string]sources.Source{"test-source": initializedSource}
+			tool, err := toolCfg.Initialize(srcs)
+			if err != nil {
+				t.Fatalf("failed to initialize tool: %v", err)
+			}
+
+			provider := &mockSourceProvider{sources: srcs}
+			_, toolboxErr := tool.Invoke(ctx, provider, parameters.ParamValues{}, tc.accessToken)
+			if toolboxErr != nil {
+				t.Fatalf("unexpected invoke error: %v", toolboxErr)
+			}
+
+			if receivedAuth != tc.wantAuthHeader {
+				t.Errorf("Authorization header: got %q, want %q", receivedAuth, tc.wantAuthHeader)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

issue #3306

```yaml
kind: source
name: my-http-source
type: http
baseUrl: https://api.example.com/data
timeout: 10s # default to 30s
forwardAuthorizationHeader: true
```

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

