### PR TITLE
fix(server/auth): centralize tool scopes validation

### DIFF
--- a/internal/server/mcp/util/auth.go
+++ b/internal/server/mcp/util/auth.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/googleapis/mcp-toolbox/internal/auth"
+	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// ValidateScopes validates if the claims contain all required scopes for a tool call.
+func ValidateScopes(ctx context.Context, toolScopes []string, authServices map[string]auth.AuthService) error {
+	// Find MCP enabled auth service
+	var mcpSvcName string
+	for _, aS := range authServices {
+		cfg := aS.ToConfig()
+		if genCfg, ok := cfg.(generic.Config); ok && genCfg.McpEnabled {
+			mcpSvcName = aS.GetName()
+			break
+		}
+	}
+
+	if mcpSvcName != "" && len(toolScopes) > 0 {
+		claims := util.AuthTokenClaimsFromContext(ctx)
+		if claims == nil {
+			return &generic.MCPAuthError{
+				Code:           http.StatusForbidden,
+				Message:        "missing claims for MCP authorization",
+				ScopesRequired: toolScopes,
+			}
+		}
+
+		scopeClaim, _ := claims["scope"].(string)
+		tokenScopes := strings.Split(scopeClaim, " ")
+
+		// Check if all required scopes are present in the token
+		missing := false
+		for _, ts := range toolScopes {
+			if !slices.Contains(tokenScopes, ts) {
+				missing = true
+				break
+			}
+		}
+
+		if missing {
+			return &generic.MCPAuthError{
+				Code:           http.StatusForbidden,
+				Message:        "insufficient scopes for this tool",
+				ScopesRequired: toolScopes,
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/server/mcp/util/auth.go
+++ b/internal/server/mcp/util/auth.go
@@ -51,19 +51,13 @@ func ValidateScopes(ctx context.Context, toolScopes []string, authServices map[s
 		tokenScopes := strings.Fields(scopeClaim)
 
 		// Check if all required scopes are present in the token
-		missing := false
 		for _, ts := range toolScopes {
 			if !slices.Contains(tokenScopes, ts) {
-				missing = true
-				break
-			}
-		}
-
-		if missing {
-			return &generic.MCPAuthError{
-				Code:           http.StatusForbidden,
-				Message:        "insufficient scopes for this tool",
-				ScopesRequired: toolScopes,
+				return &generic.MCPAuthError{
+					Code:           http.StatusForbidden,
+					Message:        "insufficient scopes for this tool",
+					ScopesRequired: toolScopes,
+				}
 			}
 		}
 	}

--- a/internal/server/mcp/util/auth.go
+++ b/internal/server/mcp/util/auth.go
@@ -28,16 +28,16 @@ import (
 // ValidateScopes validates if the claims contain all required scopes for a tool call.
 func ValidateScopes(ctx context.Context, toolScopes []string, authServices map[string]auth.AuthService) error {
 	// Find MCP enabled auth service
-	var mcpSvcName string
+	var mcpEnabled bool
 	for _, aS := range authServices {
 		cfg := aS.ToConfig()
 		if genCfg, ok := cfg.(generic.Config); ok && genCfg.McpEnabled {
-			mcpSvcName = aS.GetName()
+			mcpEnabled = true
 			break
 		}
 	}
 
-	if mcpSvcName != "" && len(toolScopes) > 0 {
+	if mcpEnabled && len(toolScopes) > 0 {
 		claims := util.AuthTokenClaimsFromContext(ctx)
 		if claims == nil {
 			return &generic.MCPAuthError{
@@ -48,7 +48,7 @@ func ValidateScopes(ctx context.Context, toolScopes []string, authServices map[s
 		}
 
 		scopeClaim, _ := claims["scope"].(string)
-		tokenScopes := strings.Split(scopeClaim, " ")
+		tokenScopes := strings.Fields(scopeClaim)
 
 		// Check if all required scopes are present in the token
 		missing := false

--- a/internal/server/mcp/util/auth_test.go
+++ b/internal/server/mcp/util/auth_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/auth"
+	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+type mockAuthService struct {
+	name       string
+	mcpEnabled bool
+}
+
+func (aS mockAuthService) AuthServiceType() string {
+	return "mock"
+}
+
+func (aS mockAuthService) GetName() string {
+	return aS.name
+}
+
+func (aS mockAuthService) GetClaimsFromHeader(context.Context, http.Header) (map[string]any, error) {
+	return nil, nil
+}
+
+func (aS mockAuthService) ToConfig() auth.AuthServiceConfig {
+	return generic.Config{
+		Name:       aS.name,
+		McpEnabled: aS.mcpEnabled,
+	}
+}
+
+func TestValidateScopes(t *testing.T) {
+	tests := []struct {
+		name         string
+		toolScopes   []string
+		authServices map[string]auth.AuthService
+		setupCtx     func(context.Context) context.Context
+		wantErr      bool
+		errMessage   string
+	}{
+		{
+			name:       "no required scopes",
+			toolScopes: nil,
+			authServices: map[string]auth.AuthService{
+				"svc1": mockAuthService{name: "svc1", mcpEnabled: true},
+			},
+			setupCtx: func(ctx context.Context) context.Context {
+				return ctx
+			},
+			wantErr: false,
+		},
+		{
+			name:       "mcp auth service not enabled",
+			toolScopes: []string{"read:files"},
+			authServices: map[string]auth.AuthService{
+				"svc1": mockAuthService{name: "svc1", mcpEnabled: false},
+			},
+			setupCtx: func(ctx context.Context) context.Context {
+				return ctx
+			},
+			wantErr: false,
+		},
+		{
+			name:       "missing claims in context",
+			toolScopes: []string{"read:files"},
+			authServices: map[string]auth.AuthService{
+				"svc1": mockAuthService{name: "svc1", mcpEnabled: true},
+			},
+			setupCtx: func(ctx context.Context) context.Context {
+				return ctx
+			},
+			wantErr:    true,
+			errMessage: "missing claims for MCP authorization",
+		},
+		{
+			name:       "insufficient scopes",
+			toolScopes: []string{"read:files", "write:files"},
+			authServices: map[string]auth.AuthService{
+				"svc1": mockAuthService{name: "svc1", mcpEnabled: true},
+			},
+			setupCtx: func(ctx context.Context) context.Context {
+				claims := map[string]any{
+					"scope": "read:files",
+				}
+				return util.WithAuthTokenClaims(ctx, claims)
+			},
+			wantErr:    true,
+			errMessage: "insufficient scopes for this tool",
+		},
+		{
+			name:       "sufficient scopes",
+			toolScopes: []string{"read:files", "write:files"},
+			authServices: map[string]auth.AuthService{
+				"svc1": mockAuthService{name: "svc1", mcpEnabled: true},
+			},
+			setupCtx: func(ctx context.Context) context.Context {
+				claims := map[string]any{
+					"scope": "read:files write:files other:scope",
+				}
+				return util.WithAuthTokenClaims(ctx, claims)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := tc.setupCtx(context.Background())
+			err := ValidateScopes(ctx, tc.toolScopes, tc.authServices)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				var authErr *generic.MCPAuthError
+				if !errors.As(err, &authErr) {
+					t.Fatalf("expected generic.MCPAuthError, got: %T", err)
+				}
+				if authErr.Code != http.StatusForbidden {
+					t.Errorf("expected Code StatusForbidden (403), got: %d", authErr.Code)
+				}
+				if authErr.Message != tc.errMessage {
+					t.Errorf("expected error message %q, got %q", tc.errMessage, authErr.Message)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
-	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -267,6 +268,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 	logger.DebugContext(ctx, "tool invocation authorized")
+
+	if err := mcputil.ValidateScopes(ctx, tool.GetScopesRequired(), authServices); err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
 
 	params, err := parameters.ParseParams(tool.GetParameters(), data, claimsFromAuth)
 	if err != nil {

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
-	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -267,6 +268,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 	logger.DebugContext(ctx, "tool invocation authorized")
+
+	if err := mcputil.ValidateScopes(ctx, tool.GetScopesRequired(), authServices); err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
 
 	params, err := parameters.ParseParams(tool.GetParameters(), data, claimsFromAuth)
 	if err != nil {

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
-	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -266,6 +267,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 	logger.DebugContext(ctx, "tool invocation authorized")
+
+	if err := mcputil.ValidateScopes(ctx, tool.GetScopesRequired(), authServices); err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
 
 	params, err := parameters.ParseParams(tool.GetParameters(), data, claimsFromAuth)
 	if err != nil {

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -21,12 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -269,48 +268,8 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 	logger.DebugContext(ctx, "tool invocation authorized")
 
-	// Find MCP enabled auth service
-	var mcpSvcName string
-	for _, aS := range authServices {
-		cfg := aS.ToConfig()
-		if genCfg, ok := cfg.(generic.Config); ok && genCfg.McpEnabled {
-			mcpSvcName = aS.GetName()
-			break
-		}
-	}
-
-	toolScopes := tool.GetScopesRequired()
-	if mcpSvcName != "" && len(toolScopes) > 0 {
-		claims := util.AuthTokenClaimsFromContext(ctx)
-		if claims == nil {
-			err = &generic.MCPAuthError{
-				Code:           http.StatusForbidden,
-				Message:        "missing claims for MCP authorization",
-				ScopesRequired: toolScopes,
-			}
-			return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
-		}
-
-		scopeClaim, _ := claims["scope"].(string)
-		tokenScopes := strings.Split(scopeClaim, " ")
-
-		// Check if all required scopes are present in the token
-		missing := false
-		for _, ts := range toolScopes {
-			if !slices.Contains(tokenScopes, ts) {
-				missing = true
-				break
-			}
-		}
-
-		if missing {
-			err = &generic.MCPAuthError{
-				Code:           http.StatusForbidden,
-				Message:        "insufficient scopes for this tool",
-				ScopesRequired: toolScopes,
-			}
-			return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
-		}
+	if err := mcputil.ValidateScopes(ctx, tool.GetScopesRequired(), authServices); err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
 	params, err := parameters.ParseParams(tool.GetParameters(), data, claimsFromAuth)

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
-	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"

--- a/tests/auth/auth_integration_test.go
+++ b/tests/auth/auth_integration_test.go
@@ -272,32 +272,48 @@ func TestMcpAuth(t *testing.T) {
 			if url == "" {
 				url = apiSSE
 			}
-			var body io.Reader
-			if tc.body != nil {
-				body = bytes.NewBuffer(tc.body)
+
+			runTest := func(t *testing.T, protocolVersion string) {
+				var body io.Reader
+				if tc.body != nil {
+					body = bytes.NewBuffer(tc.body)
+				}
+				req, _ := http.NewRequest(method, url, body)
+				if tc.token != "" {
+					req.Header.Add("Authorization", "Bearer "+tc.token)
+				}
+				if method == http.MethodPost {
+					req.Header.Set("Content-Type", "application/json")
+					if protocolVersion != "" {
+						req.Header.Set("MCP-Protocol-Version", protocolVersion)
+					}
+				}
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("unable to send request: %s", err)
+				}
+				defer resp.Body.Close()
+
+				if resp.StatusCode != tc.wantStatusCode {
+					bodyBytes, _ := io.ReadAll(resp.Body)
+					t.Fatalf("expected %d, got %d: %s", tc.wantStatusCode, resp.StatusCode, string(bodyBytes))
+				}
+
+				if tc.checkWWWAuth != nil {
+					authHeader := resp.Header.Get("WWW-Authenticate")
+					tc.checkWWWAuth(t, authHeader)
+				}
 			}
-			req, _ := http.NewRequest(method, url, body)
-			if tc.token != "" {
-				req.Header.Add("Authorization", "Bearer "+tc.token)
-			}
+
 			if method == http.MethodPost {
-				req.Header.Set("Content-Type", "application/json")
-				req.Header.Set("MCP-Protocol-Version", "2025-11-25")
-			}
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("unable to send request: %s", err)
-			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode != tc.wantStatusCode {
-				bodyBytes, _ := io.ReadAll(resp.Body)
-				t.Fatalf("expected %d, got %d: %s", tc.wantStatusCode, resp.StatusCode, string(bodyBytes))
-			}
-
-			if tc.checkWWWAuth != nil {
-				authHeader := resp.Header.Get("WWW-Authenticate")
-				tc.checkWWWAuth(t, authHeader)
+				versions := []string{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"}
+				for _, v := range versions {
+					t.Run("version_"+v, func(t *testing.T) {
+						runTest(t, v)
+					})
+				}
+			} else {
+				runTest(t, "")
 			}
 		})
 	}


### PR DESCRIPTION
All MCP protocol versions will validate auth token scopes to prevent authorization bypass through older protocol versions.

Reported by HE WEI (ギカク) @hewei-gikaku