### PR TITLE
docs: Update documentation to retain docs from v0.28.0+

### DIFF
--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -116,6 +116,7 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
   version = "v0.28.0"
   url = "https://mcp-toolbox.dev/v0.28.0/"
 
+
 [[menu.main]]
   name = "GitHub"
   weight = 50

--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -116,10 +116,6 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
   version = "v0.28.0"
   url = "https://mcp-toolbox.dev/v0.28.0/"
 
-[[params.versions]]
-  version = "v0.27.0"
-  url = "https://mcp-toolbox.dev/v0.27.0/"
-
 [[menu.main]]
   name = "GitHub"
   weight = 50


### PR DESCRIPTION
docs: Update documentation to retain docs from v0.28.0+

This is due to the cloudflare constraint that only 20,000 files can be uploaded per deployment