### PR TITLE
ci(alloydbainl): update integration test result after updating model

### DIFF
--- a/tests/alloydbainl/alloydb_ai_nl_integration_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_integration_test.go
@@ -136,7 +136,7 @@ func runAINLToolInvokeTest(t *testing.T) {
 			api:           "http://127.0.0.1:5000/api/tool/my-simple-tool/invoke",
 			requestHeader: map[string]string{},
 			requestBody:   bytes.NewBuffer([]byte(`{"question": "return the number 1"}`)),
-			want:          "[{\"execute_nl_query\":{\"?column?\":1}}]",
+			want:          "[{\"execute_nl_query\":{\"number_one\":1}}]",
 			isErr:         false,
 		},
 		{
@@ -174,7 +174,7 @@ func runAINLToolInvokeTest(t *testing.T) {
 			requestHeader: map[string]string{"my-google-auth_token": idToken},
 			requestBody:   bytes.NewBuffer([]byte(`{"question": "return the number 1"}`)),
 			isErr:         false,
-			want:          "[{\"execute_nl_query\":{\"?column?\":1}}]",
+			want:          "[{\"execute_nl_query\":{\"number_one\":1}}]",
 		},
 		{
 			name:          "Invoke my-auth-required-tool with invalid auth token",
@@ -267,7 +267,7 @@ func runAINLMCPToolCallMethod(t *testing.T) {
 					},
 				},
 			},
-			want: `{"jsonrpc":"2.0","id":"my-simple-tool","result":{"content":[{"type":"text","text":"{\"execute_nl_query\":{\"?column?\":1}}"}]}}`,
+			want: `{"jsonrpc":"2.0","id":"my-simple-tool","result":{"content":[{"type":"text","text":"{\"execute_nl_query\":{\"number_one\":1}}"}]}}`,
 		},
 		{
 			name:          "MCP Invoke invalid tool",

--- a/tests/alloydbainl/alloydb_ai_nl_mcp_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_mcp_test.go
@@ -139,7 +139,7 @@ func TestAlloyDBAINLCallTool(t *testing.T) {
 			name:     "invoke my-simple-tool",
 			toolName: "my-simple-tool",
 			args:     map[string]any{"question": "return the number 1"},
-			want:     "{\"execute_nl_query\":{\"?column?\":1}}",
+			want:     "{\"execute_nl_query\":{\"number_one\":1}}",
 			isErr:    false,
 		},
 		{
@@ -169,7 +169,7 @@ func TestAlloyDBAINLCallTool(t *testing.T) {
 			args:          map[string]any{"question": "return the number 1"},
 			requestHeader: map[string]string{"my-google-auth_token": idToken},
 			isErr:         false,
-			want:          "{\"execute_nl_query\":{\"?column?\":1}}",
+			want:          "{\"execute_nl_query\":{\"number_one\":1}}",
 		},
 		{
 			name:           "Invoke my-auth-required-tool with invalid auth token",


### PR DESCRIPTION
We had updated our alloydb ai nl to use gemini-2.5-flash model instead. With this update, the return response differs. The simple `return 1` query response was updated from `{?column?:1}` to `{number_one:1}`