### PR TITLE
docs: document BaseTool/ConfigBase pattern for adding new tools

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -232,27 +232,39 @@ implementation](https://github.com/googleapis/mcp-toolbox/tree/main/internal/too
 Remember to keep your PRs small. For example, if you are contributing a new Source, only include one or two core Tools within the same PR, the rest of the Tools can come in subsequent PRs. 
 
 * **Create a new directory** under `internal/tools` for your tool type (e.g., `internal/tools/newdb/newdbtool`).
-* **Define a configuration struct** for your tool in a file named `newdbtool.go`.
-Create a `Config` struct and a `Tool` struct to store necessary parameters for
-tools.
+* **Define a `Config` struct** for your tool in a file named `newdbtool.go`.
+  **Embed [`tools.ConfigBase`](https://github.com/googleapis/mcp-toolbox/blob/main/internal/tools/tools.go)
+  with `yaml:",inline"`** so your tool inherits the shared `name`,
+  `description`, `authRequired`, and `scopesRequired` fields (and their getters)
+  for free. Add only the fields specific to your tool (e.g., `Type`, `Source`,
+  `Statement`, `Parameters`, `Annotations`). Do **not** redeclare the shared
+  fields.
+* **Define a `Tool` struct** that **embeds
+  [`tools.BaseTool[Config]`](https://github.com/googleapis/mcp-toolbox/blob/main/internal/tools/tools.go)**.
+  `BaseTool` provides default implementations of most of the `Tool` interface —
+  `GetName`, `GetDescription`, `GetAuthRequired`, `GetScopesRequired`,
+  `GetAnnotations`, `Manifest`, `GetParameters`, `Authorized`,
+  `RequiresClientAuthorization`, `GetAuthTokenHeaderName`, and `EmbedParams`.
+  **Do not re-declare these** — eliminating that boilerplate is the entire point
+  of embedding `BaseTool`.
+    
+  **Override an inherited method only when behavior differs from the default.**
+  For example, override `EmbedParams` to inject a vector formatter (see Vector
+  Search below), or override `RequiresClientAuthorization` /
+  `GetAuthTokenHeaderName` for tools that use client-side OAuth.
 * **Implement the
-  [`ToolConfig`](https://github.com/googleapis/mcp-toolbox/blob/fd300dc606d88bf9f7bba689e2cee4e3565537dd/internal/tools/tools.go#L61)
-  interface**. This interface requires one method:
+  [`ToolConfig`](https://github.com/googleapis/mcp-toolbox/blob/main/internal/tools/tools.go)
+  interface**:
   * `ToolConfigType() string`: Returns a unique string identifier for your tool
     (e.g., `"newdb-tool"`).
-  * `Initialize(sources map[string]Source) (Tool, error)`: Creates a new
-    instance of your tool and validates that it can connect to the specified
-    data source.
-* **Implement the `Tool` interface**. This interface requires the following
-  methods:
-  * `Invoke(ctx context.Context, params map[string]any) ([]any, error)`:
-    Executes the operation on the database using the provided parameters.
-  * `ParseParams(data map[string]any, claims map[string]map[string]any)
-    (ParamValues, error)`: Parses and validates the input parameters.
-  * `Manifest() Manifest`: Returns a manifest describing the tool's capabilities
-    and parameters.
-  * `Authorized(services []string) bool`: Checks if the tool is authorized to
-    run based on the provided authentication services.
+  * `Initialize(srcs map[string]sources.Source) (tools.Tool, error)`: Validates
+    the config, processes parameters, and returns your `Tool` constructed via
+    `tools.NewBaseTool(cfg, annotations, manifest, params)`.
+* **Implement only the two methods `BaseTool` does not provide**:
+  * `Invoke(ctx context.Context, sp tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError)`:
+    Executes the operation. Return typed errors (see [Error
+    Categorization](#error-categorization)).
+  * `ToConfig() tools.ToolConfig`: Returns the embedded `Cfg`.
 * **Implement `init()`** to register the new Tool.
 * **Implement Unit Tests** in a file named `newdbtool_test.go`.
 * **Implement Vector Search** if your new tool supports it. You must:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -259,7 +259,7 @@ Remember to keep your PRs small. For example, if you are contributing a new Sour
     (e.g., `"newdb-tool"`).
   * `Initialize(srcs map[string]sources.Source) (tools.Tool, error)`: Validates
     the config, processes parameters, and returns your `Tool` constructed via
-    `tools.NewBaseTool(cfg, annotations, manifest, params)`.
+    `tools.NewBaseTool(cfg, annotations, manifest, staticParameters)`.
 * **Implement only the two methods `BaseTool` does not provide**:
   * `Invoke(ctx context.Context, sp tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError)`:
     Executes the operation. Return typed errors (see [Error

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -162,11 +162,14 @@ Use the format: `Fixes #<issue_number> 🦕`
 ### Adding a New Tool
 
 1.  Create a new directory: `internal/tools/<newdb>/<toolname>`.
-2.  Define `Config` and `Tool` structs.
-3.  Implement `ToolConfig` interface (`ToolConfigType`, `Initialize`).
-4.  Implement `Tool` interface (defined in `internal/tools/tools.go`, including `Invoke`, `Manifest`, `Authorized`, etc.).
-5.  Implement `init()` to register the tool.
-6.  Add unit tests.
+2.  Define a `Config` struct that **embeds `tools.ConfigBase`** (with `yaml:",inline"`). This supplies the shared `name`, `description`, `authRequired`, and `scopesRequired` fields and their getters — add only tool-specific fields and do not redeclare the shared ones.
+3.  Define a `Tool` struct that **embeds `tools.BaseTool[Config]`**. Do *not* re-declare the boilerplate `Tool` methods (`GetName`, `GetDescription`, `Manifest`, `GetParameters`, `Authorized`, `RequiresClientAuthorization`, `GetAuthTokenHeaderName`, `EmbedParams`, etc.) — they are inherited from `BaseTool`.
+4.  Implement `ToolConfig` interface (`ToolConfigType`, `Initialize`). In `Initialize`, construct the tool via `tools.NewBaseTool(cfg, annotations, manifest, params)`.
+5.  Implement only the methods `BaseTool` does not provide: `Invoke` and `ToConfig`. Override an inherited method (e.g. `EmbedParams`, `RequiresClientAuthorization`, `GetAuthTokenHeaderName`) **only** when the tool's behavior differs from the default.
+6.  Implement `init()` to register the tool.
+7.  Add unit tests.
+
+Refer to `internal/tools/postgres/postgressql/postgressql.go` for the canonical pattern.
 
 ### Adding Documentation
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -164,7 +164,7 @@ Use the format: `Fixes #<issue_number> 🦕`
 1.  Create a new directory: `internal/tools/<newdb>/<toolname>`.
 2.  Define a `Config` struct that **embeds `tools.ConfigBase`** (with `yaml:",inline"`). This supplies the shared `name`, `description`, `authRequired`, and `scopesRequired` fields and their getters — add only tool-specific fields and do not redeclare the shared ones.
 3.  Define a `Tool` struct that **embeds `tools.BaseTool[Config]`**. Do *not* re-declare the boilerplate `Tool` methods (`GetName`, `GetDescription`, `Manifest`, `GetParameters`, `Authorized`, `RequiresClientAuthorization`, `GetAuthTokenHeaderName`, `EmbedParams`, etc.) — they are inherited from `BaseTool`.
-4.  Implement `ToolConfig` interface (`ToolConfigType`, `Initialize`). In `Initialize`, construct the tool via `tools.NewBaseTool(cfg, annotations, manifest, params)`.
+4.  Implement `ToolConfig` interface (`ToolConfigType`, `Initialize`). In `Initialize`, construct the tool via `tools.NewBaseTool(cfg, annotations, manifest, staticParameters)`.
 5.  Implement only the methods `BaseTool` does not provide: `Invoke` and `ToConfig`. Override an inherited method (e.g. `EmbedParams`, `RequiresClientAuthorization`, `GetAuthTokenHeaderName`) **only** when the tool's behavior differs from the default.
 6.  Implement `init()` to register the tool.
 7.  Add unit tests.


### PR DESCRIPTION
## Description

Updates the contributor documentation (`DEVELOPER.md` and `GEMINI.md`) to reflect the new `BaseTool[Config]` / `ConfigBase` embedding pattern for adding tools.

The previous guidance was stale: it described defining bare `Config`/`Tool` structs and implementing the full `Tool` interface (`Invoke`, `ParseParams`, `Manifest`, `Authorized`, ...). After the BaseTool refactor, tools embed `tools.ConfigBase` (shared `name`/`description`/`authRequired`/`scopesRequired` fields) and `tools.BaseTool[Config]` (default implementations of most `Tool` methods), and only need to implement `Invoke` and `ToConfig`.