### PR TITLE
ci: run all integration tests when no changed files are detected

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -23,6 +23,10 @@ steps:
         git fetch --unshallow || true
         git fetch origin main > /dev/null 2>&1
         git diff --name-only origin/main...HEAD > /workspace/changed_files.txt
+        if [ ! -s /workspace/changed_files.txt ]; then
+          echo "No changed files detected. Writing a representative CI path to run all test shards."
+          echo ".ci/integration.cloudbuild.yaml" > /workspace/changed_files.txt
+        fi
 
   - id: "install-dependencies"
     name: golang:1


### PR DESCRIPTION
## Description
This PR resolves an issue where scheduled nightly integration tests and post-merge builds silently skipped all DB tests.

## RCA
During nightly scheduled builds or direct runs on the `main` branch, `git diff origin/main...HEAD` returns no changes. This creates an empty `changed_files.txt`. Since every database shard checks this file to conditionally run or skip tests based on file changes, all shards were skipped, leading to zero tests being run during nightly validation.

## Solution
Updated the `detect-changes` step in `.ci/integration.cloudbuild.yaml` to check if `changed_files.txt` is empty. If it is empty (which only happens for scheduled runs, manual triggers on a branch, or post-merge runs), it writes a single representative CI config path (`.ci/integration.cloudbuild.yaml`) to the file. 

Since every database shard's pattern matches `.ci/` to ensure that CI changes re-run all tests, this single path is sufficient to trigger all shards.