### PR TITLE
ci: standardize cloud-sql and dataproc shards to use change detection

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -1068,10 +1068,18 @@ steps:
     args:
       - -c
       - |
-        .ci/test_with_coverage.sh \
-          "Cloud SQL Wait for Operation" \
-          cloudsql \
-          cloudsql
+        PATTERN="cloudsql|internal/server/|tests/common.go|tests/tool.go|.ci/"
+
+        if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
+          echo "Changes detected. Running Cloud SQL Wait for Operation tests..."
+          .ci/test_with_coverage.sh \
+            "Cloud SQL Wait for Operation" \
+            cloudsql \
+            cloudsql
+        else
+          echo "No relevant changes for Cloud SQL Wait for Operation. Skipping shard."
+          exit 0
+        fi
 
   - id: "tidb"
     name: golang:1
@@ -1381,8 +1389,8 @@ steps:
         fi
 
   - id: "dataproc"
-    name: golang:1
-    waitFor: ["compile-test-binary"]
+    name: "golang:1"
+    waitFor: ["compile-test-binary", "detect-changes"]
     entrypoint: /bin/bash
     env:
       - "GOPATH=/gopath"
@@ -1396,9 +1404,17 @@ steps:
     args:
       - -c
       - |
-        .ci/test_with_coverage.sh \
-          "Dataproc" \
-          dataproc
+        PATTERN="dataproc|internal/server/|tests/common.go|tests/tool.go|.ci/"
+
+        if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
+          echo "Changes detected. Running Dataproc tests..."
+          .ci/test_with_coverage.sh \
+            "Dataproc" \
+            dataproc
+        else
+          echo "No relevant changes for Dataproc. Skipping shard."
+          exit 0
+        fi
 
   - id: "singlestore"
     name: golang:1


### PR DESCRIPTION
## Description
This PR standardizes the `cloud-sql` and `dataproc` integration test shards in `.ci/integration.cloudbuild.yaml` to utilize the conditional change detection mechanism.