### PR TITLE
chore: Remove v0.29.0 version from documentation

### DIFF
--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -112,10 +112,6 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
   version = "v0.30.0"
   url = "https://mcp-toolbox.dev/v0.30.0/"
 
-[[params.versions]]
-  version = "v0.29.0"
-  url = "https://mcp-toolbox.dev/v0.29.0/"
-
 [[menu.main]]
   name = "GitHub"
   weight = 50

--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -112,6 +112,7 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
   version = "v0.30.0"
   url = "https://mcp-toolbox.dev/v0.30.0/"
 
+
 [[menu.main]]
   name = "GitHub"
   weight = 50


### PR DESCRIPTION
chore: Remove v0.29.0 version from documentation