### PR TITLE
feat(tool/redis,tool/valkey): add native vector embedding support

### DIFF
--- a/internal/embeddingmodels/embeddingmodels.go
+++ b/internal/embeddingmodels/embeddingmodels.go
@@ -16,6 +16,8 @@ package embeddingmodels
 
 import (
 	"context"
+	"encoding/binary"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -56,4 +58,14 @@ func FormatVectorForPgvector(vectorFloats []float32) any {
 	return b.String()
 }
 
+// FormatVectorForRedis converts a slice of float32s into a little-endian binary string representation.
+func FormatVectorForRedis(vectorFloats []float32) any {
+	buf := make([]byte, len(vectorFloats)*4)
+	for i, f := range vectorFloats {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return string(buf)
+}
+
 var _ VectorFormatter = FormatVectorForPgvector
+var _ VectorFormatter = FormatVectorForRedis

--- a/internal/sources/datalineage/datalineage.go
+++ b/internal/sources/datalineage/datalineage.go
@@ -99,7 +99,7 @@ func initLineageConnection(
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
 
-	cred, err := google.FindDefaultCredentials(ctx)
+	cred, err := google.FindDefaultCredentials(ctx, sources.CloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find default Google Cloud credentials for project %q: %w", project, err)
 	}

--- a/internal/sources/dataplex/dataplex.go
+++ b/internal/sources/dataplex/dataplex.go
@@ -115,7 +115,7 @@ func initDataplexConnection(
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
 
-	cred, err := google.FindDefaultCredentials(ctx)
+	cred, err := google.FindDefaultCredentials(ctx, sources.CloudPlatformScope)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to find default Google Cloud credentials for project %q: %w", project, err)
 	}

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -24,6 +24,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// CloudPlatformScope is the OAuth2 scope for Google Cloud Platform services.
+const CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
 // SourceConfigFactory defines the function signature for creating a SourceConfig.
 type SourceConfigFactory func(ctx context.Context, name string, decoder *yaml.Decoder) (SourceConfig, error)
 

--- a/internal/tools/redis/redis.go
+++ b/internal/tools/redis/redis.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	redissrc "github.com/googleapis/mcp-toolbox/internal/sources/redis"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -87,6 +88,10 @@ type Tool struct {
 
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
+}
+
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.Cfg.Parameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForRedis)
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {

--- a/internal/tools/redis/redis_test.go
+++ b/internal/tools/redis/redis_test.go
@@ -15,9 +15,14 @@
 package redis_test
 
 import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -80,4 +85,98 @@ func TestParseFromYamlRedis(t *testing.T) {
 		})
 	}
 
+}
+
+type mockEmbeddingModel struct {
+	embedFn func(context.Context, []string) ([][]float32, error)
+}
+
+func (m mockEmbeddingModel) EmbeddingModelType() string {
+	return "mock"
+}
+
+func (m mockEmbeddingModel) ToConfig() embeddingmodels.EmbeddingModelConfig {
+	return nil
+}
+
+func (m mockEmbeddingModel) EmbedParameters(ctx context.Context, texts []string) ([][]float32, error) {
+	return m.embedFn(ctx, texts)
+}
+
+func TestRedisEmbedParams(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := redis.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "redis_tool",
+			Description: "some description",
+		},
+		Type:     "redis",
+		Source:   "my-source",
+		Commands: [][]string{{"HSET", "doc:1", "vec", "$query"}},
+		Parameters: parameters.Parameters{
+			&parameters.StringParameter{
+				CommonParameter: parameters.CommonParameter{
+					Name:       "query",
+					Type:       parameters.TypeString,
+					Desc:       "some description",
+					EmbeddedBy: "my_model",
+				},
+			},
+		},
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	mockModel := mockEmbeddingModel{
+		embedFn: func(ctx context.Context, texts []string) ([][]float32, error) {
+			if len(texts) != 1 || texts[0] != "hello" {
+				return nil, fmt.Errorf("unexpected texts: %v", texts)
+			}
+			return [][]float32{{0.1, -0.2, 0.3}}, nil
+		},
+	}
+
+	embeddingModelsMap := map[string]embeddingmodels.EmbeddingModel{
+		"my_model": mockModel,
+	}
+
+	paramValues := parameters.ParamValues{
+		{
+			Name:  "query",
+			Value: "hello",
+		},
+	}
+
+	gotParams, err := tool.EmbedParams(ctx, paramValues, embeddingModelsMap)
+	if err != nil {
+		t.Fatalf("EmbedParams failed: %v", err)
+	}
+
+	if len(gotParams) != 1 {
+		t.Fatalf("expected 1 param value, got %d", len(gotParams))
+	}
+
+	gotVal, ok := gotParams[0].Value.(string)
+	if !ok {
+		t.Fatalf("expected string value, got %T", gotParams[0].Value)
+	}
+
+	if len(gotVal) != 12 { // 3 floats * 4 bytes each
+		t.Fatalf("expected binary string length of 12, got %d", len(gotVal))
+	}
+
+	floats := make([]float32, 3)
+	for i := 0; i < 3; i++ {
+		bits := binary.LittleEndian.Uint32([]byte(gotVal[i*4 : (i+1)*4]))
+		floats[i] = math.Float32frombits(bits)
+	}
+
+	wantFloats := []float32{0.1, -0.2, 0.3}
+	if diff := cmp.Diff(wantFloats, floats); diff != "" {
+		t.Fatalf("incorrect floats: diff %s", diff)
+	}
 }

--- a/internal/tools/valkey/valkey.go
+++ b/internal/tools/valkey/valkey.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -87,6 +88,10 @@ type Tool struct {
 
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
+}
+
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.Cfg.Parameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForRedis)
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {

--- a/internal/tools/valkey/valkey_test.go
+++ b/internal/tools/valkey/valkey_test.go
@@ -15,9 +15,14 @@
 package valkey_test
 
 import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -80,4 +85,98 @@ func TestParseFromYamlvalkey(t *testing.T) {
 		})
 	}
 
+}
+
+type mockEmbeddingModel struct {
+	embedFn func(context.Context, []string) ([][]float32, error)
+}
+
+func (m mockEmbeddingModel) EmbeddingModelType() string {
+	return "mock"
+}
+
+func (m mockEmbeddingModel) ToConfig() embeddingmodels.EmbeddingModelConfig {
+	return nil
+}
+
+func (m mockEmbeddingModel) EmbedParameters(ctx context.Context, texts []string) ([][]float32, error) {
+	return m.embedFn(ctx, texts)
+}
+
+func TestValkeyEmbedParams(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := valkey.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "valkey_tool",
+			Description: "some description",
+		},
+		Type:     "valkey",
+		Source:   "my-source",
+		Commands: [][]string{{"HSET", "doc:1", "vec", "$query"}},
+		Parameters: parameters.Parameters{
+			&parameters.StringParameter{
+				CommonParameter: parameters.CommonParameter{
+					Name:       "query",
+					Type:       parameters.TypeString,
+					Desc:       "some description",
+					EmbeddedBy: "my_model",
+				},
+			},
+		},
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	mockModel := mockEmbeddingModel{
+		embedFn: func(ctx context.Context, texts []string) ([][]float32, error) {
+			if len(texts) != 1 || texts[0] != "hello" {
+				return nil, fmt.Errorf("unexpected texts: %v", texts)
+			}
+			return [][]float32{{0.1, -0.2, 0.3}}, nil
+		},
+	}
+
+	embeddingModelsMap := map[string]embeddingmodels.EmbeddingModel{
+		"my_model": mockModel,
+	}
+
+	paramValues := parameters.ParamValues{
+		{
+			Name:  "query",
+			Value: "hello",
+		},
+	}
+
+	gotParams, err := tool.EmbedParams(ctx, paramValues, embeddingModelsMap)
+	if err != nil {
+		t.Fatalf("EmbedParams failed: %v", err)
+	}
+
+	if len(gotParams) != 1 {
+		t.Fatalf("expected 1 param value, got %d", len(gotParams))
+	}
+
+	gotVal, ok := gotParams[0].Value.(string)
+	if !ok {
+		t.Fatalf("expected string value, got %T", gotParams[0].Value)
+	}
+
+	if len(gotVal) != 12 { // 3 floats * 4 bytes each
+		t.Fatalf("expected binary string length of 12, got %d", len(gotVal))
+	}
+
+	floats := make([]float32, 3)
+	for i := 0; i < 3; i++ {
+		bits := binary.LittleEndian.Uint32([]byte(gotVal[i*4 : (i+1)*4]))
+		floats[i] = math.Float32frombits(bits)
+	}
+
+	wantFloats := []float32{0.1, -0.2, 0.3}
+	if diff := cmp.Diff(wantFloats, floats); diff != "" {
+		t.Fatalf("incorrect floats: diff %s", diff)
+	}
 }

--- a/tests/datalineage/datalineage_integration_test.go
+++ b/tests/datalineage/datalineage_integration_test.go
@@ -30,6 +30,7 @@ import (
 	lineage "cloud.google.com/go/datacatalog/lineage/apiv1"
 	lineagepb "cloud.google.com/go/datacatalog/lineage/apiv1/lineagepb"
 	"github.com/google/uuid"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/tests"
 	"golang.org/x/oauth2/google"
@@ -54,7 +55,7 @@ func getDatalineageVars(t *testing.T) map[string]any {
 }
 
 func initLineageConnection(ctx context.Context) (*lineage.Client, error) {
-	cred, err := google.FindDefaultCredentials(ctx)
+	cred, err := google.FindDefaultCredentials(ctx, sources.CloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find default Google Cloud credentials: %w", err)
 	}

--- a/tests/dataplex/dataplex_integration_test.go
+++ b/tests/dataplex/dataplex_integration_test.go
@@ -31,6 +31,7 @@ import (
 	dataplex "cloud.google.com/go/dataplex/apiv1"
 	dataplexpb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/google/uuid"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/tests"
 	"golang.org/x/oauth2/google"
@@ -75,7 +76,7 @@ func initBigQueryConnection(ctx context.Context, project string) (*bigqueryapi.C
 }
 
 func initDataplexConnection(ctx context.Context) (*dataplex.CatalogClient, error) {
-	cred, err := google.FindDefaultCredentials(ctx)
+	cred, err := google.FindDefaultCredentials(ctx, sources.CloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find default Google Cloud credentials: %w", err)
 	}
@@ -196,7 +197,7 @@ func setupDataplexSearchDataQualityScan(t *testing.T, ctx context.Context, clien
 }
 
 func initDataplexDataScanConnection(ctx context.Context) (*dataplex.DataScanClient, error) {
-	cred, err := google.FindDefaultCredentials(ctx)
+	cred, err := google.FindDefaultCredentials(ctx, sources.CloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find default Google Cloud credentials: %w", err)
 	}


### PR DESCRIPTION
## Description

This PR adds native vector embedding support to the `redis` and `valkey` tools. 

Since these tools construct and execute commands by performing string replacements (using `replaceCommandsParams`), passing unformatted slices of float32s resulted in malformed string representations like `[%!s(float32=0.1) %!s(float32=0.2)]`.

To solve this:
1. Added `FormatVectorForRedis` in `internal/embeddingmodels/embeddingmodels.go` which converts `[]float32` vector arrays into a little-endian float32 binary string. This is the standard format required for Redis and Valkey Vector Similarity Search (using `HSET` or `JSON` fields with vector indexes).
2. Overrode `EmbedParams` in the `redis` and `valkey` tool implementations to use this formatter.
3. Added comprehensive unit tests in `redis_test.go` and `valkey_test.go` to verify correctness.

## PR Checklist

- [x] Make sure you reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose) before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #3158 🦕
