### PR TITLE
feat(tool/redis,tool/valkey): add native vector embedding support

### DIFF
--- a/docs/en/integrations/redis/tools/redis-tool.md
+++ b/docs/en/integrations/redis/tools/redis-tool.md
@@ -63,3 +63,53 @@ parameters:
     type: array
     description: The user names to be set.  
 ```
+
+### Vector Search
+
+Redis supports vector similarity search (using RediSearch). When using an `embeddingModel` with a `redis` tool, the tool automatically converts text parameters into the little-endian binary vector format required by Redis.
+
+#### Vector Ingestion Example
+
+This tool stores a text content and its vector representation as a binary string in a Redis hash.
+
+```yaml
+kind: tool
+name: insert_doc_redis
+type: redis
+source: my-redis-source
+commands:
+  - ["HSET", "doc:$id", "content", "$content", "embedding", "$text_to_embed"]
+description: |
+  Index new documents for semantic search in Redis.
+parameters:
+  - name: id
+    type: string
+    description: The unique ID of the document.
+  - name: content
+    type: string
+    description: The text content to store.
+  - name: text_to_embed
+    type: string
+    valueFromParam: content
+    embeddedBy: gemini-model
+```
+
+#### Vector Search Example
+
+This tool performs a semantic search using `FT.SEARCH` with KNN vector similarity. The search query string provided by the Agent is converted into a binary vector before the search command is executed.
+
+```yaml
+kind: tool
+name: search_docs_redis
+type: redis
+source: my-redis-source
+commands:
+  - ["FT.SEARCH", "idx:docs", "(*)=>[KNN 5 @embedding $query]", "PARAMS", "2", "query", "$query", "DIALECT", "2"]
+description: |
+  Search for documents in Redis using natural language.
+parameters:
+  - name: query
+    type: string
+    description: The search query.
+    embeddedBy: gemini-model
+```

--- a/docs/en/integrations/valkey/tools/valkey-tool.md
+++ b/docs/en/integrations/valkey/tools/valkey-tool.md
@@ -58,3 +58,53 @@ parameters:
     type: array
     description: The user names to be set.  
 ```
+
+### Vector Search
+
+Valkey supports vector similarity search. When using an `embeddingModel` with a `valkey` tool, the tool automatically converts text parameters into the little-endian binary vector format required by Valkey.
+
+#### Vector Ingestion Example
+
+This tool stores a text content and its vector representation as a binary string in a Valkey hash.
+
+```yaml
+kind: tool
+name: insert_doc_valkey
+type: valkey
+source: my-valkey-source
+commands:
+  - ["HSET", "doc:$id", "content", "$content", "embedding", "$text_to_embed"]
+description: |
+  Index new documents for semantic search in Valkey.
+parameters:
+  - name: id
+    type: string
+    description: The unique ID of the document.
+  - name: content
+    type: string
+    description: The text content to store.
+  - name: text_to_embed
+    type: string
+    valueFromParam: content
+    embeddedBy: gemini-model
+```
+
+#### Vector Search Example
+
+This tool performs a semantic search using `FT.SEARCH` with KNN vector similarity. The search query string provided by the Agent is converted into a binary vector before the search command is executed.
+
+```yaml
+kind: tool
+name: search_docs_valkey
+type: valkey
+source: my-valkey-source
+commands:
+  - ["FT.SEARCH", "idx:docs", "(*)=>[KNN 5 @embedding $query]", "PARAMS", "2", "query", "$query", "DIALECT", "2"]
+description: |
+  Search for documents in Valkey using natural language.
+parameters:
+  - name: query
+    type: string
+    description: The search query.
+    embeddedBy: gemini-model
+```

--- a/internal/embeddingmodels/embeddingmodels.go
+++ b/internal/embeddingmodels/embeddingmodels.go
@@ -16,6 +16,8 @@ package embeddingmodels
 
 import (
 	"context"
+	"encoding/binary"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -56,4 +58,14 @@ func FormatVectorForPgvector(vectorFloats []float32) any {
 	return b.String()
 }
 
+// FormatVectorForRedis converts a slice of float32s into a little-endian binary string representation.
+func FormatVectorForRedis(vectorFloats []float32) any {
+	buf := make([]byte, len(vectorFloats)*4)
+	for i, f := range vectorFloats {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return string(buf)
+}
+
 var _ VectorFormatter = FormatVectorForPgvector
+var _ VectorFormatter = FormatVectorForRedis

--- a/internal/tools/redis/redis.go
+++ b/internal/tools/redis/redis.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	redissrc "github.com/googleapis/mcp-toolbox/internal/sources/redis"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -86,6 +87,10 @@ type Tool struct {
 
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
+}
+
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.Cfg.Parameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForRedis)
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {

--- a/internal/tools/redis/redis_test.go
+++ b/internal/tools/redis/redis_test.go
@@ -15,10 +15,17 @@
 package redis_test
 
 import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	redissrc "github.com/googleapis/mcp-toolbox/internal/sources/redis"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/redis"
@@ -80,4 +87,218 @@ func TestParseFromYamlRedis(t *testing.T) {
 		})
 	}
 
+}
+
+type mockEmbeddingModel struct {
+	embedFn func(context.Context, []string) ([][]float32, error)
+}
+
+func (m mockEmbeddingModel) EmbeddingModelType() string {
+	return "mock"
+}
+
+func (m mockEmbeddingModel) ToConfig() embeddingmodels.EmbeddingModelConfig {
+	return nil
+}
+
+func (m mockEmbeddingModel) EmbedParameters(ctx context.Context, texts []string) ([][]float32, error) {
+	return m.embedFn(ctx, texts)
+}
+
+func TestRedisEmbedParams(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := redis.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "redis_tool",
+			Description: "some description",
+		},
+		Type:     "redis",
+		Source:   "my-source",
+		Commands: [][]string{{"HSET", "doc:1", "vec", "$query"}},
+		Parameters: parameters.Parameters{
+			&parameters.StringParameter{
+				CommonParameter: parameters.CommonParameter{
+					Name:       "query",
+					Type:       parameters.TypeString,
+					Desc:       "some description",
+					EmbeddedBy: "my_model",
+				},
+			},
+		},
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	mockModel := mockEmbeddingModel{
+		embedFn: func(ctx context.Context, texts []string) ([][]float32, error) {
+			if len(texts) != 1 || texts[0] != "hello" {
+				return nil, fmt.Errorf("unexpected texts: %v", texts)
+			}
+			return [][]float32{{0.1, -0.2, 0.3}}, nil
+		},
+	}
+
+	embeddingModelsMap := map[string]embeddingmodels.EmbeddingModel{
+		"my_model": mockModel,
+	}
+
+	paramValues := parameters.ParamValues{
+		{
+			Name:  "query",
+			Value: "hello",
+		},
+	}
+
+	gotParams, err := tool.EmbedParams(ctx, paramValues, embeddingModelsMap)
+	if err != nil {
+		t.Fatalf("EmbedParams failed: %v", err)
+	}
+
+	if len(gotParams) != 1 {
+		t.Fatalf("expected 1 param value, got %d", len(gotParams))
+	}
+
+	gotVal, ok := gotParams[0].Value.(string)
+	if !ok {
+		t.Fatalf("expected string value, got %T", gotParams[0].Value)
+	}
+
+	if len(gotVal) != 12 { // 3 floats * 4 bytes each
+		t.Fatalf("expected binary string length of 12, got %d", len(gotVal))
+	}
+
+	floats := make([]float32, 3)
+	for i := 0; i < 3; i++ {
+		bits := binary.LittleEndian.Uint32([]byte(gotVal[i*4 : (i+1)*4]))
+		floats[i] = math.Float32frombits(bits)
+	}
+
+	wantFloats := []float32{0.1, -0.2, 0.3}
+	if diff := cmp.Diff(wantFloats, floats); diff != "" {
+		t.Fatalf("incorrect floats: diff %s", diff)
+	}
+}
+
+type mockSource struct {
+	executedCmds [][]any
+}
+
+func (m *mockSource) SourceType() string {
+	return "redis"
+}
+
+func (m *mockSource) ToConfig() sources.SourceConfig {
+	return nil
+}
+
+func (m *mockSource) RedisClient() redissrc.RedisClient {
+	return nil
+}
+
+func (m *mockSource) RunCommand(ctx context.Context, cmds [][]any) (any, error) {
+	m.executedCmds = cmds
+	return "ok", nil
+}
+
+type mockSourceProvider struct {
+	src sources.Source
+}
+
+func (p mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	return p.src, true
+}
+
+func TestRedisToolInvokeWithEmbedding(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := redis.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "search_products",
+			Description: "Search products using vector similarity",
+		},
+		Type:     "redis",
+		Source:   "my-redis",
+		Commands: [][]string{{"FT.SEARCH", "idx:products", "(*)=>[KNN 5 @vector_field $query_vec]", "PARAMS", "2", "query_vec", "$query_vec", "DIALECT", "2"}},
+		Parameters: parameters.Parameters{
+			&parameters.StringParameter{
+				CommonParameter: parameters.CommonParameter{
+					Name:       "query_vec",
+					Type:       parameters.TypeString,
+					Desc:       "The query text to embed",
+					EmbeddedBy: "gemini_model",
+				},
+			},
+		},
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	mockModel := mockEmbeddingModel{
+		embedFn: func(ctx context.Context, texts []string) ([][]float32, error) {
+			return [][]float32{{0.1, -0.2, 0.3}}, nil
+		},
+	}
+	embeddingModelsMap := map[string]embeddingmodels.EmbeddingModel{
+		"gemini_model": mockModel,
+	}
+
+	mSrc := &mockSource{}
+	provider := mockSourceProvider{src: mSrc}
+
+	rawParams := map[string]any{
+		"query_vec": "hello",
+	}
+	parsedParams, err := parameters.ParseParams(tool.GetParameters(), rawParams, nil)
+	if err != nil {
+		t.Fatalf("failed to parse params: %v", err)
+	}
+
+	embeddedParams, err := tool.EmbedParams(ctx, parsedParams, embeddingModelsMap)
+	if err != nil {
+		t.Fatalf("failed to embed params: %v", err)
+	}
+
+	_, tbErr := tool.Invoke(ctx, provider, embeddedParams, "")
+	if tbErr != nil {
+		t.Fatalf("tool invocation failed: %v", tbErr)
+	}
+
+	if len(mSrc.executedCmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(mSrc.executedCmds))
+	}
+	cmd := mSrc.executedCmds[0]
+
+	if len(cmd) != 9 {
+		t.Fatalf("expected 9 args, got %d", len(cmd))
+	}
+
+	binStr, ok := cmd[6].(string)
+	if !ok {
+		t.Fatalf("expected string at index 6, got %T", cmd[6])
+	}
+	if len(binStr) != 12 {
+		t.Fatalf("expected binary string length 12, got %d", len(binStr))
+	}
+
+	floats := make([]float32, 3)
+	for i := 0; i < 3; i++ {
+		bits := binary.LittleEndian.Uint32([]byte(binStr[i*4 : (i+1)*4]))
+		floats[i] = math.Float32frombits(bits)
+	}
+	wantFloats := []float32{0.1, -0.2, 0.3}
+	if diff := cmp.Diff(wantFloats, floats); diff != "" {
+		t.Fatalf("incorrect floats in executed command: diff %s", diff)
+	}
+
+	wantCmd := []any{"FT.SEARCH", "idx:products", "(*)=>[KNN 5 @vector_field $query_vec]", "PARAMS", "2", "query_vec", binStr, "DIALECT", "2"}
+	if diff := cmp.Diff(wantCmd, cmd); diff != "" {
+		t.Fatalf("command mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/internal/tools/valkey/valkey.go
+++ b/internal/tools/valkey/valkey.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -86,6 +87,10 @@ type Tool struct {
 
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
+}
+
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.Cfg.Parameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForRedis)
 }
 
 func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {

--- a/internal/tools/valkey/valkey_test.go
+++ b/internal/tools/valkey/valkey_test.go
@@ -15,14 +15,21 @@
 package valkey_test
 
 import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/valkey"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+	valkeyio "github.com/valkey-io/valkey-go"
 )
 
 func TestParseFromYamlvalkey(t *testing.T) {
@@ -80,4 +87,215 @@ func TestParseFromYamlvalkey(t *testing.T) {
 		})
 	}
 
+}
+
+type mockEmbeddingModel struct {
+	embedFn func(context.Context, []string) ([][]float32, error)
+}
+
+func (m mockEmbeddingModel) EmbeddingModelType() string {
+	return "mock"
+}
+
+func (m mockEmbeddingModel) ToConfig() embeddingmodels.EmbeddingModelConfig {
+	return nil
+}
+
+func (m mockEmbeddingModel) EmbedParameters(ctx context.Context, texts []string) ([][]float32, error) {
+	return m.embedFn(ctx, texts)
+}
+
+func TestValkeyEmbedParams(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := valkey.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "valkey_tool",
+			Description: "some description",
+		},
+		Type:     "valkey",
+		Source:   "my-source",
+		Commands: [][]string{{"HSET", "doc:1", "vec", "$query"}},
+		Parameters: parameters.Parameters{
+			&parameters.StringParameter{
+				CommonParameter: parameters.CommonParameter{
+					Name:       "query",
+					Type:       parameters.TypeString,
+					Desc:       "some description",
+					EmbeddedBy: "my_model",
+				},
+			},
+		},
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	mockModel := mockEmbeddingModel{
+		embedFn: func(ctx context.Context, texts []string) ([][]float32, error) {
+			if len(texts) != 1 || texts[0] != "hello" {
+				return nil, fmt.Errorf("unexpected texts: %v", texts)
+			}
+			return [][]float32{{0.1, -0.2, 0.3}}, nil
+		},
+	}
+
+	embeddingModelsMap := map[string]embeddingmodels.EmbeddingModel{
+		"my_model": mockModel,
+	}
+
+	paramValues := parameters.ParamValues{
+		{
+			Name:  "query",
+			Value: "hello",
+		},
+	}
+
+	gotParams, err := tool.EmbedParams(ctx, paramValues, embeddingModelsMap)
+	if err != nil {
+		t.Fatalf("EmbedParams failed: %v", err)
+	}
+
+	if len(gotParams) != 1 {
+		t.Fatalf("expected 1 param value, got %d", len(gotParams))
+	}
+
+	gotVal, ok := gotParams[0].Value.(string)
+	if !ok {
+		t.Fatalf("expected string value, got %T", gotParams[0].Value)
+	}
+
+	if len(gotVal) != 12 { // 3 floats * 4 bytes each
+		t.Fatalf("expected binary string length of 12, got %d", len(gotVal))
+	}
+
+	floats := make([]float32, 3)
+	for i := 0; i < 3; i++ {
+		bits := binary.LittleEndian.Uint32([]byte(gotVal[i*4 : (i+1)*4]))
+		floats[i] = math.Float32frombits(bits)
+	}
+
+	wantFloats := []float32{0.1, -0.2, 0.3}
+	if diff := cmp.Diff(wantFloats, floats); diff != "" {
+		t.Fatalf("incorrect floats: diff %s", diff)
+	}
+}
+
+type mockSource struct {
+	executedCmds [][]string
+}
+
+func (m *mockSource) SourceType() string {
+	return "valkey"
+}
+
+func (m *mockSource) ToConfig() sources.SourceConfig {
+	return nil
+}
+
+func (m *mockSource) ValkeyClient() valkeyio.Client {
+	return nil
+}
+
+func (m *mockSource) RunCommand(ctx context.Context, cmds [][]string) (any, error) {
+	m.executedCmds = cmds
+	return "ok", nil
+}
+
+type mockSourceProvider struct {
+	src sources.Source
+}
+
+func (p mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	return p.src, true
+}
+
+func TestValkeyToolInvokeWithEmbedding(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := valkey.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "search_products",
+			Description: "Search products using vector similarity",
+		},
+		Type:     "valkey",
+		Source:   "my-valkey",
+		Commands: [][]string{{"FT.SEARCH", "idx:products", "(*)=>[KNN 5 @vector_field $query_vec]", "PARAMS", "2", "query_vec", "$query_vec", "DIALECT", "2"}},
+		Parameters: parameters.Parameters{
+			&parameters.StringParameter{
+				CommonParameter: parameters.CommonParameter{
+					Name:       "query_vec",
+					Type:       parameters.TypeString,
+					Desc:       "The query text to embed",
+					EmbeddedBy: "gemini_model",
+				},
+			},
+		},
+	}
+
+	tool, err := cfg.Initialize(nil)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	mockModel := mockEmbeddingModel{
+		embedFn: func(ctx context.Context, texts []string) ([][]float32, error) {
+			return [][]float32{{0.1, -0.2, 0.3}}, nil
+		},
+	}
+	embeddingModelsMap := map[string]embeddingmodels.EmbeddingModel{
+		"gemini_model": mockModel,
+	}
+
+	mSrc := &mockSource{}
+	provider := mockSourceProvider{src: mSrc}
+
+	rawParams := map[string]any{
+		"query_vec": "hello",
+	}
+	parsedParams, err := parameters.ParseParams(tool.GetParameters(), rawParams, nil)
+	if err != nil {
+		t.Fatalf("failed to parse params: %v", err)
+	}
+
+	embeddedParams, err := tool.EmbedParams(ctx, parsedParams, embeddingModelsMap)
+	if err != nil {
+		t.Fatalf("failed to embed params: %v", err)
+	}
+
+	_, tbErr := tool.Invoke(ctx, provider, embeddedParams, "")
+	if tbErr != nil {
+		t.Fatalf("tool invocation failed: %v", tbErr)
+	}
+
+	if len(mSrc.executedCmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(mSrc.executedCmds))
+	}
+	cmd := mSrc.executedCmds[0]
+
+	if len(cmd) != 9 {
+		t.Fatalf("expected 9 args, got %d", len(cmd))
+	}
+
+	binStr := cmd[6]
+	if len(binStr) != 12 {
+		t.Fatalf("expected binary string length 12, got %d", len(binStr))
+	}
+
+	floats := make([]float32, 3)
+	for i := 0; i < 3; i++ {
+		bits := binary.LittleEndian.Uint32([]byte(binStr[i*4 : (i+1)*4]))
+		floats[i] = math.Float32frombits(bits)
+	}
+	wantFloats := []float32{0.1, -0.2, 0.3}
+	if diff := cmp.Diff(wantFloats, floats); diff != "" {
+		t.Fatalf("incorrect floats in executed command: diff %s", diff)
+	}
+
+	wantCmd := []string{"FT.SEARCH", "idx:products", "(*)=>[KNN 5 @vector_field $query_vec]", "PARAMS", "2", "query_vec", binStr, "DIALECT", "2"}
+	if diff := cmp.Diff(wantCmd, cmd); diff != "" {
+		t.Fatalf("command mismatch (-want +got):\n%s", diff)
+	}
 }


### PR DESCRIPTION
## Description

This PR adds native vector embedding support to the `redis` and `valkey` tools. 

Since these tools construct and execute commands by performing string replacements (using `replaceCommandsParams`), passing unformatted slices of float32s resulted in malformed string representations like `[%!s(float32=0.1) %!s(float32=0.2)]`.

To solve this:
1. Added `FormatVectorForRedis` in `internal/embeddingmodels/embeddingmodels.go` which converts `[]float32` vector arrays into a little-endian float32 binary string. This is the standard format required for Redis and Valkey Vector Similarity Search (using `HSET` or `JSON` fields with vector indexes).
2. Overrode `EmbedParams` in the `redis` and `valkey` tool implementations to use this formatter.
3. Added comprehensive unit tests in `redis_test.go` and `valkey_test.go` to verify correctness.

## PR Checklist

- [x] Make sure you reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose) before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #3158 🦕
