### PR TITLE
feat(source/alloydb,source/cloudsqlpg): add queryExecMode field

### DIFF
--- a/docs/en/integrations/alloydb/source.md
+++ b/docs/en/integrations/alloydb/source.md
@@ -144,3 +144,4 @@ The interface is identical, so there's no additional configuration required on t
 | password  |  string  |    false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
 | ipType    |  string  |    false     | IP Type of the AlloyDB instance; must be one of `public` or `private`. Default: `public`.                                |
 | sqlCommenter | boolean |  false     | Overrides the global `--sql-commenter` flag for this source. When set, it takes priority; when omitted, the global flag applies. |
+| queryExecMode | string | false | pgx query execution mode. Valid values: `cache_statement` (default), `cache_describe`, `describe_exec`, `exec`, `simple_protocol`. Useful with connection poolers that don't support prepared statement caching. |

--- a/docs/en/integrations/cloud-sql-pg/source.md
+++ b/docs/en/integrations/cloud-sql-pg/source.md
@@ -146,3 +146,4 @@ The interface is identical, so there's no additional configuration required on t
 | password  |  string  |    false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
 | ipType    |  string  |    false     | IP Type of the Cloud SQL instance; must be one of `public`, `private`, or `psc`. Default: `public`.                      |
 | sqlCommenter | boolean |  false     | Overrides the global `--sql-commenter` flag for this source. When set, it takes priority; when omitted, the global flag applies. |
+| queryExecMode | string | false | pgx query execution mode. Valid values: `cache_statement` (default), `cache_describe`, `describe_exec`, `exec`, `simple_protocol`. Useful with connection poolers that don't support prepared statement caching. |

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -50,17 +50,18 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name         string         `yaml:"name" validate:"required"`
-	Type         string         `yaml:"type" validate:"required"`
-	Project      string         `yaml:"project" validate:"required"`
-	Region       string         `yaml:"region" validate:"required"`
-	Cluster      string         `yaml:"cluster" validate:"required"`
-	Instance     string         `yaml:"instance" validate:"required"`
-	IPType       sources.IPType `yaml:"ipType" validate:"required"`
-	User         string         `yaml:"user"`
-	Password     string         `yaml:"password"`
-	Database     string         `yaml:"database" validate:"required"`
-	SQLCommenter *bool          `yaml:"sqlCommenter"`
+	Name          string         `yaml:"name" validate:"required"`
+	Type          string         `yaml:"type" validate:"required"`
+	Project       string         `yaml:"project" validate:"required"`
+	Region        string         `yaml:"region" validate:"required"`
+	Cluster       string         `yaml:"cluster" validate:"required"`
+	Instance      string         `yaml:"instance" validate:"required"`
+	IPType        sources.IPType `yaml:"ipType" validate:"required"`
+	User          string         `yaml:"user"`
+	Password      string         `yaml:"password"`
+	Database      string         `yaml:"database" validate:"required"`
+	SQLCommenter  *bool          `yaml:"sqlCommenter"`
+	QueryExecMode string         `yaml:"queryExecMode" validate:"omitempty,oneof=cache_statement cache_describe describe_exec exec simple_protocol"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -68,7 +69,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.QueryExecMode)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -184,7 +185,7 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 	return dsn, useIAM, nil
 }
 
-func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ipType, user, pass, dbname, queryExecMode string) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
@@ -198,6 +199,12 @@ func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name,
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse connection uri: %w", err)
 	}
+	execMode, err := sources.ParsePGXQueryExecMode(queryExecMode)
+	if err != nil {
+		return nil, err
+	}
+	config.ConnConfig.DefaultQueryExecMode = execMode
+
 	// Create a new dialer with options
 	userAgent, err := util.UserAgentFromContext(ctx)
 	if err != nil {

--- a/internal/sources/alloydbpg/alloydb_pg_test.go
+++ b/internal/sources/alloydbpg/alloydb_pg_test.go
@@ -120,6 +120,37 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "example with query exec mode",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: alloydb-postgres
+			project: my-project
+			region: my-region
+			cluster: my-cluster
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			queryExecMode: simple_protocol
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-pg-instance": alloydbpg.Config{
+					Name:          "my-pg-instance",
+					Type:          alloydbpg.SourceType,
+					Project:       "my-project",
+					Region:        "my-region",
+					Cluster:       "my-cluster",
+					Instance:      "my-instance",
+					IPType:        "public",
+					Database:      "my_db",
+					User:          "my_user",
+					Password:      "my_pass",
+					QueryExecMode: "simple_protocol",
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -189,6 +220,23 @@ func TestFailParseFromYaml(t *testing.T) {
 			password: my_pass
 			`,
 			err: "error unmarshaling source: unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",
+		},
+		{
+			desc: "invalid query exec mode",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: alloydb-postgres
+			project: my-project
+			region: my-region
+			cluster: my-cluster
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			queryExecMode: invalid_mode
+			`,
+			err: "error unmarshaling source: unable to parse source \"my-pg-instance\" as \"alloydb-postgres\": [7:16] Key: 'Config.QueryExecMode' Error:Field validation for 'QueryExecMode' failed on the 'oneof' tag\n   4 | name: my-pg-instance\n   5 | password: my_pass\n   6 | project: my-project\n>  7 | queryExecMode: invalid_mode\n                      ^\n   8 | region: my-region\n   9 | type: alloydb-postgres\n  10 | user: my_user",
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -49,16 +49,17 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (sources
 }
 
 type Config struct {
-	Name         string         `yaml:"name" validate:"required"`
-	Type         string         `yaml:"type" validate:"required"`
-	Project      string         `yaml:"project" validate:"required"`
-	Region       string         `yaml:"region" validate:"required"`
-	Instance     string         `yaml:"instance" validate:"required"`
-	IPType       sources.IPType `yaml:"ipType" validate:"required"`
-	Database     string         `yaml:"database" validate:"required"`
-	User         string         `yaml:"user"`
-	Password     string         `yaml:"password"`
-	SQLCommenter *bool          `yaml:"sqlCommenter"`
+	Name          string         `yaml:"name" validate:"required"`
+	Type          string         `yaml:"type" validate:"required"`
+	Project       string         `yaml:"project" validate:"required"`
+	Region        string         `yaml:"region" validate:"required"`
+	Instance      string         `yaml:"instance" validate:"required"`
+	IPType        sources.IPType `yaml:"ipType" validate:"required"`
+	Database      string         `yaml:"database" validate:"required"`
+	User          string         `yaml:"user"`
+	Password      string         `yaml:"password"`
+	SQLCommenter  *bool          `yaml:"sqlCommenter"`
+	QueryExecMode string         `yaml:"queryExecMode" validate:"omitempty,oneof=cache_statement cache_describe describe_exec exec simple_protocol"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -66,7 +67,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.QueryExecMode)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -171,7 +172,7 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 	return dsn, useIAM, nil
 }
 
-func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname, queryExecMode string) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
@@ -186,6 +187,11 @@ func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse connection uri: %w", err)
 	}
+	execMode, err := sources.ParsePGXQueryExecMode(queryExecMode)
+	if err != nil {
+		return nil, err
+	}
+	config.ConnConfig.DefaultQueryExecMode = execMode
 
 	// Create a new dialer with options
 	userAgent, err := util.UserAgentFromContext(ctx)

--- a/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
@@ -142,6 +142,35 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "example with query exec mode",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: cloud-sql-postgres
+			project: my-project
+			region: my-region
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			queryExecMode: simple_protocol
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-pg-instance": cloudsqlpg.Config{
+					Name:          "my-pg-instance",
+					Type:          cloudsqlpg.SourceType,
+					Project:       "my-project",
+					Region:        "my-region",
+					Instance:      "my-instance",
+					IPType:        "public",
+					Database:      "my_db",
+					User:          "my_user",
+					Password:      "my_pass",
+					QueryExecMode: "simple_protocol",
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -208,6 +237,22 @@ func TestFailParseFromYaml(t *testing.T) {
 			password: my_pass
 			`,
 			err: "error unmarshaling source: unable to parse source \"my-pg-instance\" as \"cloud-sql-postgres\": Key: 'Config.Project' Error:Field validation for 'Project' failed on the 'required' tag",
+		},
+		{
+			desc: "invalid query exec mode",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: cloud-sql-postgres
+			project: my-project
+			region: my-region
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			queryExecMode: invalid_mode
+			`,
+			err: "error unmarshaling source: unable to parse source \"my-pg-instance\" as \"cloud-sql-postgres\": [6:16] Key: 'Config.QueryExecMode' Error:Field validation for 'QueryExecMode' failed on the 'oneof' tag\n   3 | name: my-pg-instance\n   4 | password: my_pass\n   5 | project: my-project\n>  6 | queryExecMode: invalid_mode\n                      ^\n   7 | region: my-region\n   8 | type: cloud-sql-postgres\n   9 | user: my_user",
 		},
 	}
 	for _, tc := range tcs {

--- a/internal/sources/postgres/postgres.go
+++ b/internal/sources/postgres/postgres.go
@@ -25,7 +25,6 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/sources/sqlcommenter"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/orderedmap"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -152,7 +151,7 @@ func initPostgresConnectionPool(ctx context.Context, tracer trace.Tracer, name, 
 		return nil, fmt.Errorf("unable to parse connection uri: %w", err)
 	}
 
-	execMode, err := ParseQueryExecMode(queryExecMode)
+	execMode, err := sources.ParsePGXQueryExecMode(queryExecMode)
 	if err != nil {
 		return nil, err
 	}
@@ -186,21 +185,4 @@ func BuildPostgresURL(host, port, user, pass, dbname string, queryParams map[str
 		u.RawQuery = q.Encode()
 	}
 	return u.String()
-}
-
-func ParseQueryExecMode(queryExecMode string) (pgx.QueryExecMode, error) {
-	switch queryExecMode {
-	case "", "cache_statement":
-		return pgx.QueryExecModeCacheStatement, nil
-	case "cache_describe":
-		return pgx.QueryExecModeCacheDescribe, nil
-	case "describe_exec":
-		return pgx.QueryExecModeDescribeExec, nil
-	case "exec":
-		return pgx.QueryExecModeExec, nil
-	case "simple_protocol":
-		return pgx.QueryExecModeSimpleProtocol, nil
-	default:
-		return 0, fmt.Errorf("invalid queryExecMode %q: must be one of %q, %q, %q, %q, or %q", queryExecMode, "cache_statement", "cache_describe", "describe_exec", "exec", "simple_protocol")
-	}
 }

--- a/internal/sources/postgres/postgres_test.go
+++ b/internal/sources/postgres/postgres_test.go
@@ -276,7 +276,7 @@ func TestParseQueryExecMode(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := postgres.ParseQueryExecMode(tc.in)
+			got, err := sources.ParsePGXQueryExecMode(tc.in)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("parseQueryExecMode() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/cloudsqlconn"
+	"github.com/jackc/pgx/v5"
 	"golang.org/x/oauth2/google"
 )
 
@@ -125,4 +126,21 @@ func GetIAMAccessToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("retrieved token is invalid or expired")
 	}
 	return token.AccessToken, nil
+}
+
+func ParsePGXQueryExecMode(queryExecMode string) (pgx.QueryExecMode, error) {
+	switch queryExecMode {
+	case "", "cache_statement":
+		return pgx.QueryExecModeCacheStatement, nil
+	case "cache_describe":
+		return pgx.QueryExecModeCacheDescribe, nil
+	case "describe_exec":
+		return pgx.QueryExecModeDescribeExec, nil
+	case "exec":
+		return pgx.QueryExecModeExec, nil
+	case "simple_protocol":
+		return pgx.QueryExecModeSimpleProtocol, nil
+	default:
+		return 0, fmt.Errorf("invalid queryExecMode %q: must be one of %q, %q, %q, %q, or %q", queryExecMode, "cache_statement", "cache_describe", "describe_exec", "exec", "simple_protocol")
+	}
 }


### PR DESCRIPTION
## Description

Adds `queryExecMode` support to the AlloyDB for PostgreSQL and Cloud SQL for PostgreSQL sources, using the same pgx query execution mode parser as the PostgreSQL source.

This lets managed Postgres sources opt into modes such as `simple_protocol` when prepared statement caching is not compatible with the connection pooler.

## PR Checklist

- [x] Make sure you reviewed CONTRIBUTING.md
- [x] Make sure to open an issue as a bug/issue before writing your code
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

Tests:
- GOTOOLCHAIN=local go test -count=1 ./internal/sources/postgres ./internal/sources/alloydbpg ./internal/sources/cloudsqlpg

Fixes #2385.