### PR TITLE
feat: support SEP-2243 header standardization

### DIFF
--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -40,6 +40,8 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 	if err := json.Unmarshal(body, &notification); err != nil {
 		return fmt.Errorf("invalid notification request: %w", err)
 	}
+	// Since we do not enforce notifications, we do not need to check the
+	// `Mcp-Method` header here
 	return nil
 }
 

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -40,18 +40,17 @@ import (
 
 // ProcessMethod returns a response for the request.
 func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
-	stdio := header == nil
 	switch method {
 	case SERVER_DISCOVER:
-		return serverDiscoverHandler(ctx, id, body, stdio)
+		return serverDiscoverHandler(ctx, id, body, header)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body, stdio)
+		return toolsListHandler(id, resourceMgr, toolset, body, header)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
-		return promptsListHandler(ctx, id, resourceMgr, promptset, body, stdio)
+		return promptsListHandler(ctx, id, resourceMgr, promptset, body, header)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, promptset, resourceMgr, body, stdio)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body, header)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
@@ -97,7 +96,30 @@ func validateMetadata(id jsonrpc.RequestId, params RequestParams, stdio bool) (a
 	return nil, nil
 }
 
-func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, stdio bool) (any, error) {
+// validateHeader checks the header of every requests
+// Toolbox do not check for `Mcp-Param-{Name}` header since we are not
+// implementing custom headers from parameters
+// Do not need to check for Base64-encoding or invalid characters since we are
+// only checking `mcp-method` and `mcp-name`
+func validateHeader(id jsonrpc.RequestId, header http.Header, method, name string) (any, error) {
+	// stdio transport will not have header
+	if header == nil {
+		return nil, nil
+	}
+	headerMethod := header.Get("mcp-method")
+	if headerMethod != method {
+		err := fmt.Errorf("Mcp-Method header value '%s' does not match body value '%s'", headerMethod, method)
+		return jsonrpc.NewHeaderMismatchedError(id, err), err
+	}
+	headerName := header.Get("mcp-name")
+	if headerName != name {
+		err := fmt.Errorf("Mcp-Name header value '%s' does not match body value '%s'", headerName, name)
+		return jsonrpc.NewHeaderMismatchedError(id, err), err
+	}
+	return nil, nil
+}
+
+func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, header http.Header) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -108,7 +130,11 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 		err = fmt.Errorf("invalid server discover request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params, stdio)
+	validateHeaderErr, err := validateHeader(id, header, SERVER_DISCOVER, "")
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params, header == nil)
 	if err != nil {
 		return validateErr, err
 	}
@@ -140,13 +166,17 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 	return res, nil
 }
 
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, stdio bool) (any, error) {
+func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, header http.Header) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	validateHeaderErr, err := validateHeader(id, header, TOOLS_LIST, "")
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
 		return validateErr, err
 	}
@@ -178,6 +208,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	if err = json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools call request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateHeaderErr, err := validateHeader(id, header, TOOLS_CALL, req.Params.Name)
+	if err != nil {
+		return validateHeaderErr, err
 	}
 	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
@@ -445,7 +479,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 }
 
 // promptsListHandler handles the "prompts/list" method.
-func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte, stdio bool) (any, error) {
+func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte, header http.Header) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -458,7 +492,11 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 		err = fmt.Errorf("invalid mcp prompts list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	validateHeaderErr, err := validateHeader(id, header, PROMPTS_LIST, "")
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
 		return validateErr, err
 	}
@@ -478,7 +516,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, stdio bool) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -491,7 +529,11 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prom
 		err = fmt.Errorf("invalid mcp prompts/get request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	validateHeaderErr, err := validateHeader(id, header, PROMPTS_GET, req.Params.Name)
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
 		return validateErr, err
 	}

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -15,10 +15,25 @@
 package vdraft
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/googleapis/mcp-toolbox/internal/log"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/resources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// Dummy JSONRPC ID for testing
+var (
+	dummyID           jsonrpc.RequestId = 1
+	fakeVersionString                   = "0.0.0"
 )
 
 func TestValidateMetadata(t *testing.T) {
@@ -162,6 +177,736 @@ func TestValidateMetadata(t *testing.T) {
 				}
 				if res != nil {
 					t.Errorf("validateMetadata() expected nil res on success, got %v", res)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  http.Header
+		method  string
+		reqName string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil header (stdio transport)",
+			header:  nil,
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: false,
+		},
+		{
+			name: "valid header matches body",
+			header: http.Header{
+				"Mcp-Method": []string{"test-method"},
+				"Mcp-Name":   []string{"test-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: false,
+		},
+		{
+			name: "mismatched method",
+			header: http.Header{
+				"Mcp-Method": []string{"wrong-method"},
+				"Mcp-Name":   []string{"test-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Method header value 'wrong-method' does not match body value 'test-method'",
+		},
+		{
+			name: "mismatched name",
+			header: http.Header{
+				"Mcp-Method": []string{"test-method"},
+				"Mcp-Name":   []string{"wrong-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Name header value 'wrong-name' does not match body value 'test-name'",
+		},
+		{
+			name: "missing method in header",
+			header: http.Header{
+				"Mcp-Name": []string{"test-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Method header value '' does not match body value 'test-method'",
+		},
+		{
+			name: "missing name in header",
+			header: http.Header{
+				"Mcp-Method": []string{"test-method"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Name header value '' does not match body value 'test-name'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotObj, err := validateHeader(dummyID, tt.header, tt.method, tt.reqName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateHeader() expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("validateHeader() error = %v, wantMsg %v", err, tt.errMsg)
+				}
+				if gotObj == nil {
+					t.Errorf("validateHeader() expected an error object return value, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("validateHeader() unexpected error: %v", err)
+				}
+				if gotObj != nil {
+					t.Errorf("validateHeader() expected nil object, got %v", gotObj)
+				}
+			}
+		})
+	}
+}
+
+func TestServerDiscoverHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxVersion := util.WithToolboxVersionKey(ctx, fakeVersionString)
+	tests := []struct {
+		name        string
+		body        DiscoverRequest
+		rawBody     []byte
+		header      http.Header
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing version in context",
+			body: DiscoverRequest{
+				Request: jsonrpc.Request{
+					Method: "server/discover",
+				},
+				Params: RequestParams{
+					Meta: &RequestMetaObject{
+						ProtocolVersion: PROTOCOL_VERSION,
+						ClientInfo: Implementation{
+							BaseMetadata: BaseMetadata{Name: "TestClient"},
+							Version:      "1.0",
+						},
+						MetaClientCapabilities: &ClientCapabilities{},
+					},
+				},
+			},
+			header:      nil,
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve toolbox version",
+		},
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "invalid server discover request",
+		},
+		{
+			name: "header validation failure",
+			body: DiscoverRequest{
+				Request: jsonrpc.Request{
+					Method: "server/discover",
+				},
+				Params: RequestParams{
+					Meta: &RequestMetaObject{
+						ProtocolVersion: PROTOCOL_VERSION,
+						ClientInfo: Implementation{
+							BaseMetadata: BaseMetadata{Name: "TestClient"},
+							Version:      "1.0",
+						},
+						MetaClientCapabilities: &ClientCapabilities{},
+					},
+				},
+			},
+			header:      http.Header{"Mcp-Method": []string{"WRONG_METHOD"}},
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "does not match body value",
+		},
+		{
+			name: "success",
+			body: DiscoverRequest{
+				Request: jsonrpc.Request{
+					Method: "server/discover",
+				},
+				Params: RequestParams{
+					Meta: &RequestMetaObject{
+						ProtocolVersion: PROTOCOL_VERSION,
+						ClientInfo: Implementation{
+							BaseMetadata: BaseMetadata{Name: "TestClient"},
+							Version:      "1.0",
+						},
+						MetaClientCapabilities: &ClientCapabilities{},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{SERVER_DISCOVER}},
+			context: ctxVersion,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := serverDiscoverHandler(tt.context, dummyID, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %v, want error containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsListHandler(t *testing.T) {
+	// Initialize tools using provided testutils mock instances
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        ListToolsRequest
+		rawBody     []byte
+		header      http.Header
+		toolset     tools.Toolset
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "invalid mcp tools list request",
+		},
+		{
+			name: "header mismatch",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:      http.Header{"Mcp-Method": []string{"WRONG_METHOD"}},
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "does not match body value",
+		},
+		{
+			name: "success - stdio (nil header)",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:  nil,
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+		{
+			name: "success - http",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{TOOLS_LIST}},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsCallHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctxLogger := util.WithLogger(ctx, testLogger)
+	// Setup tools including the auth/unauth ones
+	mockTools := []testutils.MockTool{
+		testutils.MockTool1,
+		testutils.MockTool4,
+		testutils.MockTool5,
+	}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        CallToolRequest
+		rawBody     []byte
+		header      http.Header
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "invalid mcp tools call request",
+		},
+		{
+			name: "missing logger in context",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "no_params",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      nil,
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve logger",
+		},
+		{
+			name: "tool not in toolset",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "unknown_tool",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      nil,
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "tool with name \"unknown_tool\" does not exist",
+		},
+		{
+			name: "missing client auth token",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "require_client_auth_tool",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      http.Header{"Mcp-Method": []string{TOOLS_CALL}, "Mcp-Name": []string{"require_client_auth_tool"}},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "missing access token in the 'Authorization' header",
+		},
+		{
+			name: "successful invocation - no params",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "no_params",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{TOOLS_CALL}, "Mcp-Name": []string{"no_params"}},
+			context: ctxLogger,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsCallHandler(tt.context, dummyID, toolsets[""], resourceMgr, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsListHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        ListPromptsRequest
+		rawBody     []byte
+		header      http.Header
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			wantErr:     true,
+			errContains: "invalid mcp prompts list request",
+		},
+		{
+			name: "success",
+			body: ListPromptsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "prompts/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{PROMPTS_LIST}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsListHandler(ctx, dummyID, resourceMgr, promptsets[""], body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsGetHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        GetPromptRequest
+		rawBody     []byte
+		header      http.Header
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			wantErr:     true,
+			errContains: "invalid mcp prompts/get request",
+		},
+		{
+			name: "prompt does not exist",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: GetPromptRequestParams{
+					Name: "missing_prompt",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      nil,
+			wantErr:     true,
+			errContains: "does not exist",
+		},
+		{
+			name: "success with args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: GetPromptRequestParams{
+					Name: "prompt2",
+					Arguments: map[string]any{
+						"arg1": "value1",
+					},
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{PROMPTS_GET}, "Mcp-Name": []string{"prompt2"}},
+			wantErr: false,
+		},
+		{
+			name: "success without args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: GetPromptRequestParams{
+					Name: "prompt1",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{PROMPTS_GET}, "Mcp-Name": []string{"prompt1"}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsGetHandler(ctx, dummyID, promptsets[""], resourceMgr, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
 				}
 			}
 		})

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -441,6 +441,7 @@ func TestMcpEndpoint(t *testing.T) {
 		name           string
 		protocol       string
 		idHeader       bool
+		reqHeader      []string
 		initWant       map[string]any
 		invalidMethods []string
 		meta           map[string]any
@@ -483,9 +484,10 @@ func TestMcpEndpoint(t *testing.T) {
 			invalidMethods: []string{"server/discover"},
 		},
 		{
-			name:     "version 2025-06-18",
-			protocol: protocolVersion20250618,
-			idHeader: false,
+			name:      "version 2025-06-18",
+			protocol:  protocolVersion20250618,
+			idHeader:  false,
+			reqHeader: []string{"Mcp-Protocol-Version"},
 			initWant: map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "mcp-initialize",
@@ -501,9 +503,10 @@ func TestMcpEndpoint(t *testing.T) {
 			invalidMethods: []string{"server/discover"},
 		},
 		{
-			name:     "version 2025-11-25",
-			protocol: protocolVersion20251125,
-			idHeader: false,
+			name:      "version 2025-11-25",
+			protocol:  protocolVersion20251125,
+			idHeader:  false,
+			reqHeader: []string{"Mcp-Protocol-Version"},
 			initWant: map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "mcp-initialize",
@@ -522,6 +525,7 @@ func TestMcpEndpoint(t *testing.T) {
 			name:           "version DRAFT",
 			protocol:       protocolVersionDraft,
 			idHeader:       false,
+			reqHeader:      []string{"Mcp-Protocol-Version", "Mcp-Method", "Mcp-Name"},
 			invalidMethods: []string{"ping"},
 			meta: map[string]any{
 				"io.modelcontextprotocol/protocolVersion": protocolVersionDraft,
@@ -539,20 +543,12 @@ func TestMcpEndpoint(t *testing.T) {
 			if len(vtc.initWant) != 0 {
 				sessionId = runInitializeLifecycle(t, ts, vtc.protocol, vtc.initWant, vtc.idHeader)
 			}
-
-			header := map[string]string{}
-			if sessionId != "" {
-				header["Mcp-Session-Id"] = sessionId
-			}
-			if vtc.protocol != protocolVersion20241105 && vtc.protocol != protocolVersion20250326 {
-				header["MCP-Protocol-Version"] = vtc.protocol
-			}
-
 			testCases := []*struct {
 				name           string
 				url            string
 				isErr          bool
-				body           any
+				body           jsonrpc.JSONRPCRequest
+				batchBody      []jsonrpc.JSONRPCRequest
 				methodName     string
 				wantStatusCode int
 				want           map[string]any
@@ -831,7 +827,7 @@ func TestMcpEndpoint(t *testing.T) {
 					name:  "batch requests",
 					url:   "/",
 					isErr: true,
-					body: []any{
+					batchBody: []jsonrpc.JSONRPCRequest{
 						jsonrpc.JSONRPCRequest{
 							Jsonrpc: "1.0",
 							Id:      "batch-requests1",
@@ -937,22 +933,41 @@ func TestMcpEndpoint(t *testing.T) {
 			for i := range testCases {
 				tc := *testCases[i]
 				t.Run(tc.name, func(t *testing.T) {
+					// add required header
+					header := map[string]string{}
+					if sessionId != "" {
+						header["Mcp-Session-Id"] = sessionId
+					}
+					if slices.Contains(vtc.reqHeader, "Mcp-Protocol-Version") {
+						header["Mcp-Protocol-Version"] = vtc.protocol
+					}
+					if slices.Contains(vtc.reqHeader, "Mcp-Method") {
+						header["Mcp-Method"] = tc.methodName
+					}
+					if slices.Contains(vtc.reqHeader, "Mcp-Name") && (tc.methodName == "tools/call" || tc.methodName == "prompts/get") {
+						params := tc.body.Params.(map[string]any)
+						header["Mcp-Name"] = params["name"].(string)
+					}
 					if vtc.meta != nil {
-						switch v := tc.body.(type) {
-						case jsonrpc.JSONRPCRequest:
-							if v.Params != nil {
-								v.Params.(map[string]any)["_meta"] = vtc.meta
-							} else {
-								v.Params = map[string]any{
-									"_meta": vtc.meta,
-								}
+						body := tc.body
+						if body.Params != nil {
+							body.Params.(map[string]any)["_meta"] = vtc.meta
+						} else {
+							body.Params = map[string]any{
+								"_meta": vtc.meta,
 							}
-							tc.body = v
 						}
+						tc.body = body
 					}
 					reqMarshal, err := json.Marshal(tc.body)
 					if err != nil {
 						t.Fatalf("unexpected error during marshaling of body")
+					}
+					if tc.batchBody != nil {
+						reqMarshal, err = json.Marshal(tc.batchBody)
+						if err != nil {
+							t.Fatalf("unexpected error during marshaling of body")
+						}
 					}
 
 					if vtc.protocol != protocolVersion20241105 && len(header) == 0 {


### PR DESCRIPTION
Support [SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization#server-behavior): HTTP Header Standardization for Streamable HTTP Transport.

SEP-2243 focuses on exposing critical context and routing information through standard HTTP headers to facilitate streamable transport. Under this specification, POST requests are required to include `Mcp-Method` (all methods) and `Mcp-Name` (only for tools/call, prompt/get etc.) headers that correspond to the request body. Compliance with the introducing MCP version requires these headers to mitigate security risks and prevent errors caused by conflicting data sources within the network. Servers must reject any requests where header values do not match the body content.

Also added unit tests for all functions in method.go.