### PR TITLE
ci: add unit tests for each mcp version method

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestToolsetEndpoint(t *testing.T) {
-	mockTools := []testutils.MockTool{tool1, tool2}
-	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, _, _ := testutils.SetUpResources(t, mockTools, nil)
 	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
@@ -53,8 +53,8 @@ func TestToolsetEndpoint(t *testing.T) {
 			toolsetName: "",
 			want: wantResponse{
 				statusCode: http.StatusOK,
-				version:    fakeVersionString,
-				tools:      []string{tool1.Name, tool2.Name},
+				version:    testutils.MockVersionString,
+				tools:      []string{testutils.MockTool1.Name, testutils.MockTool2.Name},
 			},
 		},
 		{
@@ -70,8 +70,8 @@ func TestToolsetEndpoint(t *testing.T) {
 			toolsetName: "tool1_only",
 			want: wantResponse{
 				statusCode: http.StatusOK,
-				version:    fakeVersionString,
-				tools:      []string{tool1.Name},
+				version:    testutils.MockVersionString,
+				tools:      []string{testutils.MockTool1.Name},
 			},
 		},
 		{
@@ -79,8 +79,8 @@ func TestToolsetEndpoint(t *testing.T) {
 			toolsetName: "tool2_only",
 			want: wantResponse{
 				statusCode: http.StatusOK,
-				version:    fakeVersionString,
-				tools:      []string{tool2.Name},
+				version:    testutils.MockVersionString,
+				tools:      []string{testutils.MockTool2.Name},
 			},
 		},
 	}
@@ -125,8 +125,8 @@ func TestToolsetEndpoint(t *testing.T) {
 }
 
 func TestToolGetEndpoint(t *testing.T) {
-	mockTools := []testutils.MockTool{tool1, tool2}
-	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, _, _ := testutils.SetUpResources(t, mockTools, nil)
 	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
@@ -147,20 +147,20 @@ func TestToolGetEndpoint(t *testing.T) {
 	}{
 		{
 			name:     "tool1",
-			toolName: tool1.Name,
+			toolName: testutils.MockTool1.Name,
 			want: wantResponse{
 				statusCode: http.StatusOK,
-				version:    fakeVersionString,
-				tools:      []string{tool1.Name},
+				version:    testutils.MockVersionString,
+				tools:      []string{testutils.MockTool1.Name},
 			},
 		},
 		{
 			name:     "tool2",
-			toolName: tool2.Name,
+			toolName: testutils.MockTool2.Name,
 			want: wantResponse{
 				statusCode: http.StatusOK,
-				version:    fakeVersionString,
-				tools:      []string{tool2.Name},
+				version:    testutils.MockVersionString,
+				tools:      []string{testutils.MockTool2.Name},
 			},
 		},
 		{
@@ -213,8 +213,8 @@ func TestToolGetEndpoint(t *testing.T) {
 }
 
 func TestToolInvokeEndpoint(t *testing.T) {
-	mockTools := []testutils.MockTool{tool1, tool2, tool4, tool5}
-	toolsMap, toolsets, _, _ := setUpResources(t, mockTools, nil)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool4, testutils.MockTool5}
+	toolsMap, toolsets, _, _ := testutils.SetUpResources(t, mockTools, nil)
 	r, shutdown := setUpServer(t, "api", toolsMap, toolsets, nil, nil)
 	defer shutdown()
 	ts := runServer(r, false)
@@ -229,14 +229,14 @@ func TestToolInvokeEndpoint(t *testing.T) {
 	}{
 		{
 			name:        "tool1",
-			toolName:    tool1.Name,
+			toolName:    testutils.MockTool1.Name,
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "{result:[no_params]}\n",
 			isErr:       false,
 		},
 		{
 			name:        "tool2",
-			toolName:    tool2.Name,
+			toolName:    testutils.MockTool2.Name,
 			requestBody: bytes.NewBuffer([]byte(`{"param1": 1, "param2": 2}`)),
 			want:        "{result:[some_params]}\n",
 			isErr:       false,
@@ -250,14 +250,14 @@ func TestToolInvokeEndpoint(t *testing.T) {
 		},
 		{
 			name:        "tool4",
-			toolName:    tool4.Name,
+			toolName:    testutils.MockTool4.Name,
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "",
 			isErr:       true,
 		},
 		{
 			name:        "tool5",
-			toolName:    tool5.Name,
+			toolName:    testutils.MockTool5.Name,
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "",
 			isErr:       true,

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -29,87 +29,14 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
-	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
-
-// fakeVersionString is used as a temporary version string in tests
-const fakeVersionString = "0.0.0"
 
 var (
 	_ tools.Tool     = testutils.MockTool{}
 	_ prompts.Prompt = testutils.MockPrompt{}
 )
-
-var tool1 = testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
-
-var tool2 = testutils.NewMockTool(
-	"some_params",
-	"",
-	parameters.Parameters{
-		parameters.NewIntParameter("param1", "This is the first parameter."),
-		parameters.NewIntParameter("param2", "This is the second parameter."),
-	}, false, false)
-
-var tool3 = testutils.NewMockTool(
-	"array_param", "some description",
-	parameters.Parameters{
-		parameters.NewArrayParameter("my_array", "this param is an array of strings", parameters.NewStringParameter("my_string", "string item")),
-	}, false, false)
-
-var tool4 = testutils.NewMockTool("unauthorized_tool", "", []parameters.Parameter{}, true, false)
-
-var tool5 = testutils.NewMockTool("require_client_auth_tool", "", []parameters.Parameter{}, false, true)
-
-var prompt1 = testutils.NewMockPrompt("prompt1", "", prompts.Arguments{})
-
-var prompt2 = testutils.NewMockPrompt("prompt2", "", prompts.Arguments{
-	{Parameter: parameters.NewStringParameter("arg1", "This is the first argument.")},
-})
-
-// setUpResources setups resources to test against
-func setUpResources(t *testing.T, mockTools []testutils.MockTool, mockPrompts []testutils.MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
-	toolsMap := make(map[string]tools.Tool)
-	var allTools []string
-	for _, tool := range mockTools {
-		toolsMap[tool.Name] = tool
-		allTools = append(allTools, tool.Name)
-	}
-
-	toolsets := make(map[string]tools.Toolset)
-	for name, l := range map[string][]string{
-		"":           allTools,
-		"tool1_only": {allTools[0]},
-		"tool2_only": {allTools[1]},
-	} {
-		tc := tools.ToolsetConfig{Name: name, ToolNames: l}
-		m, err := tc.Initialize(fakeVersionString, toolsMap)
-		if err != nil {
-			t.Fatalf("unable to initialize toolset %q: %s", name, err)
-		}
-		toolsets[name] = m
-	}
-
-	promptsMap := make(map[string]prompts.Prompt)
-	var allPrompts []string
-	for _, prompt := range mockPrompts {
-		promptsMap[prompt.Name] = prompt
-		allPrompts = append(allPrompts, prompt.Name)
-	}
-
-	promptsets := make(map[string]prompts.Promptset)
-	if len(allPrompts) > 0 {
-		psc := prompts.PromptsetConfig{Name: "", PromptNames: allPrompts}
-		ps, err := psc.Initialize(fakeVersionString, promptsMap)
-		if err != nil {
-			t.Fatalf("unable to initialize default promptset: %s", err)
-		}
-		promptsets[""] = ps
-	}
-
-	return toolsMap, toolsets, promptsMap, promptsets
-}
 
 // setUpServer create a new server with tools, toolsets, prompts, and promptsets.
 func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, toolsets map[string]tools.Toolset, prompts map[string]prompts.Prompt, promptsets map[string]prompts.Promptset) (chi.Router, func()) {
@@ -120,12 +47,12 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 		t.Fatalf("unable to initialize logger: %s", err)
 	}
 
-	otelShutdown, err := telemetry.SetupOTel(ctx, fakeVersionString, "", false, "", "toolbox")
+	otelShutdown, err := telemetry.SetupOTel(ctx, testutils.MockVersionString, "", false, "", "toolbox")
 	if err != nil {
 		t.Fatalf("unable to setup otel: %s", err)
 	}
 
-	instrumentation, err := telemetry.CreateTelemetryInstrumentation(fakeVersionString)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(testutils.MockVersionString)
 	if err != nil {
 		t.Fatalf("unable to create custom metrics: %s", err)
 	}
@@ -135,7 +62,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 	resourceManager := resources.NewResourceManager(nil, nil, nil, tools, toolsets, prompts, promptsets)
 
 	server := Server{
-		version:         fakeVersionString,
+		version:         testutils.MockVersionString,
 		logger:          testLogger,
 		instrumentation: instrumentation,
 		sseManager:      sseManager,

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -540,7 +540,7 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 
 	// check if client have `MCP-Protocol-Version` header
 	// Only supported for v2025-06-18+.
-	headerProtocolVersion := r.Header.Get("MCP-Protocol-Version")
+	headerProtocolVersion := r.Header.Get("Mcp-Protocol-Version")
 	if headerProtocolVersion != "" {
 		if !mcp.VerifyProtocolVersion(headerProtocolVersion) {
 			err := fmt.Errorf("invalid protocol version: %s", headerProtocolVersion)

--- a/internal/server/mcp/v20241105/method_test.go
+++ b/internal/server/mcp/v20241105/method_test.go
@@ -1,0 +1,551 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v20241105
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/resources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// Dummy JSONRPC ID for testing
+var (
+	dummyID           jsonrpc.RequestId = 1
+	fakeVersionString                   = "0.0.0"
+)
+
+func TestInitializeHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxVersion := util.WithToolboxVersionKey(ctx, fakeVersionString)
+
+	tests := []struct {
+		name        string
+		body        InitializeRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing version in context",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve toolbox version", // Adjust to match your util.ToolboxVersionFromContext error
+		},
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "invalid mcp initialize request",
+		},
+		{
+			name: "success",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context: ctxVersion,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling: %v", err)
+				}
+			}
+
+			got, err := initializeHandler(tt.context, dummyID, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %v, want error containing %q", err, tt.errContains)
+				}
+				// Optional: You can also assert that 'got' is a jsonrpc.Error response here if you'd like
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Fatalf("expected valid response, got nil")
+				}
+
+				// Verify the response structure for success
+				res, ok := got.(jsonrpc.JSONRPCResponse)
+				if !ok {
+					t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+				}
+
+				if res.Id != dummyID {
+					t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+				}
+
+				initResult, ok := res.Result.(InitializeResult)
+				if !ok {
+					t.Fatalf("expected result of type InitializeResult, got %T", res.Result)
+				}
+				if initResult.ServerInfo.Version != fakeVersionString {
+					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+			}
+		})
+	}
+}
+
+func TestPingHandler(t *testing.T) {
+	got, err := pingHandler(dummyID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected valid response, got nil")
+	}
+
+	res, ok := got.(jsonrpc.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+	}
+
+	if res.Jsonrpc != jsonrpc.JSONRPC_VERSION {
+		t.Errorf("expected JSONRPC version %q, got %q", jsonrpc.JSONRPC_VERSION, res.Jsonrpc)
+	}
+
+	if res.Id != dummyID {
+		t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+	}
+
+	// Verify Result is an empty struct
+	if _, ok := res.Result.(struct{}); !ok {
+		t.Errorf("expected result to be an empty struct, got %T", res.Result)
+	}
+}
+
+func TestToolsListHandler(t *testing.T) {
+	// Initialize tools using provided testutils mock instances
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        ListToolsRequest
+		rawBody     []byte
+		toolset     tools.Toolset
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "invalid mcp tools list request",
+		},
+		{
+			name: "success - stdio (nil header)",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+		{
+			name: "success - http",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsCallHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctxLogger := util.WithLogger(ctx, testLogger)
+	// Setup tools including the auth/unauth ones
+	mockTools := []testutils.MockTool{
+		testutils.MockTool1,
+		testutils.MockTool4,
+		testutils.MockTool5,
+	}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        CallToolRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "invalid mcp tools call request",
+		},
+		{
+			name: "missing logger in context",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve logger",
+		},
+		{
+			name: "tool not in toolset",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "unknown_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "tool with name \"unknown_tool\" does not exist",
+		},
+		{
+			name: "missing client auth token",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "require_client_auth_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "missing access token in the 'Authorization' header",
+		},
+		{
+			name: "successful invocation - no params",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context: ctxLogger,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsCallHandler(tt.context, dummyID, toolsets[""], resourceMgr, body, nil)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsListHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        ListPromptsRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts list request",
+		},
+		{
+			name: "success",
+			body: ListPromptsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "prompts/list",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsListHandler(ctx, dummyID, resourceMgr, promptsets[""], body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsGetHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        GetPromptRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts/get request",
+		},
+		{
+			name: "prompt does not exist",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "missing_prompt",
+				},
+			},
+			wantErr:     true,
+			errContains: "does not exist",
+		},
+		{
+			name: "success with args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt2",
+					Arguments: map[string]any{
+						"arg1": "value1",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success without args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsGetHandler(ctx, dummyID, promptsets[""], resourceMgr, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}

--- a/internal/server/mcp/v20250326/method_test.go
+++ b/internal/server/mcp/v20250326/method_test.go
@@ -1,0 +1,551 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v20250326
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/resources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// Dummy JSONRPC ID for testing
+var (
+	dummyID           jsonrpc.RequestId = 1
+	fakeVersionString                   = "0.0.0"
+)
+
+func TestInitializeHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxVersion := util.WithToolboxVersionKey(ctx, fakeVersionString)
+
+	tests := []struct {
+		name        string
+		body        InitializeRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing version in context",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve toolbox version", // Adjust to match your util.ToolboxVersionFromContext error
+		},
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "invalid mcp initialize request",
+		},
+		{
+			name: "success",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context: ctxVersion,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling: %v", err)
+				}
+			}
+
+			got, err := initializeHandler(tt.context, dummyID, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %v, want error containing %q", err, tt.errContains)
+				}
+				// Optional: You can also assert that 'got' is a jsonrpc.Error response here if you'd like
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Fatalf("expected valid response, got nil")
+				}
+
+				// Verify the response structure for success
+				res, ok := got.(jsonrpc.JSONRPCResponse)
+				if !ok {
+					t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+				}
+
+				if res.Id != dummyID {
+					t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+				}
+
+				initResult, ok := res.Result.(InitializeResult)
+				if !ok {
+					t.Fatalf("expected result of type InitializeResult, got %T", res.Result)
+				}
+				if initResult.ServerInfo.Version != fakeVersionString {
+					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+			}
+		})
+	}
+}
+
+func TestPingHandler(t *testing.T) {
+	got, err := pingHandler(dummyID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected valid response, got nil")
+	}
+
+	res, ok := got.(jsonrpc.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+	}
+
+	if res.Jsonrpc != jsonrpc.JSONRPC_VERSION {
+		t.Errorf("expected JSONRPC version %q, got %q", jsonrpc.JSONRPC_VERSION, res.Jsonrpc)
+	}
+
+	if res.Id != dummyID {
+		t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+	}
+
+	// Verify Result is an empty struct
+	if _, ok := res.Result.(struct{}); !ok {
+		t.Errorf("expected result to be an empty struct, got %T", res.Result)
+	}
+}
+
+func TestToolsListHandler(t *testing.T) {
+	// Initialize tools using provided testutils mock instances
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        ListToolsRequest
+		rawBody     []byte
+		toolset     tools.Toolset
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "invalid mcp tools list request",
+		},
+		{
+			name: "success - stdio (nil header)",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+		{
+			name: "success - http",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsCallHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctxLogger := util.WithLogger(ctx, testLogger)
+	// Setup tools including the auth/unauth ones
+	mockTools := []testutils.MockTool{
+		testutils.MockTool1,
+		testutils.MockTool4,
+		testutils.MockTool5,
+	}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        CallToolRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "invalid mcp tools call request",
+		},
+		{
+			name: "missing logger in context",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve logger",
+		},
+		{
+			name: "tool not in toolset",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "unknown_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "tool with name \"unknown_tool\" does not exist",
+		},
+		{
+			name: "missing client auth token",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "require_client_auth_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "missing access token in the 'Authorization' header",
+		},
+		{
+			name: "successful invocation - no params",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context: ctxLogger,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsCallHandler(tt.context, dummyID, toolsets[""], resourceMgr, body, nil)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsListHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        ListPromptsRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts list request",
+		},
+		{
+			name: "success",
+			body: ListPromptsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "prompts/list",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsListHandler(ctx, dummyID, resourceMgr, promptsets[""], body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsGetHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        GetPromptRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts/get request",
+		},
+		{
+			name: "prompt does not exist",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "missing_prompt",
+				},
+			},
+			wantErr:     true,
+			errContains: "does not exist",
+		},
+		{
+			name: "success with args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt2",
+					Arguments: map[string]any{
+						"arg1": "value1",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success without args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsGetHandler(ctx, dummyID, promptsets[""], resourceMgr, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}

--- a/internal/server/mcp/v20250618/method_test.go
+++ b/internal/server/mcp/v20250618/method_test.go
@@ -1,0 +1,551 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v20250618
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/resources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// Dummy JSONRPC ID for testing
+var (
+	dummyID           jsonrpc.RequestId = 1
+	fakeVersionString                   = "0.0.0"
+)
+
+func TestInitializeHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxVersion := util.WithToolboxVersionKey(ctx, fakeVersionString)
+
+	tests := []struct {
+		name        string
+		body        InitializeRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing version in context",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve toolbox version", // Adjust to match your util.ToolboxVersionFromContext error
+		},
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "invalid mcp initialize request",
+		},
+		{
+			name: "success",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context: ctxVersion,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling: %v", err)
+				}
+			}
+
+			got, err := initializeHandler(tt.context, dummyID, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %v, want error containing %q", err, tt.errContains)
+				}
+				// Optional: You can also assert that 'got' is a jsonrpc.Error response here if you'd like
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Fatalf("expected valid response, got nil")
+				}
+
+				// Verify the response structure for success
+				res, ok := got.(jsonrpc.JSONRPCResponse)
+				if !ok {
+					t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+				}
+
+				if res.Id != dummyID {
+					t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+				}
+
+				initResult, ok := res.Result.(InitializeResult)
+				if !ok {
+					t.Fatalf("expected result of type InitializeResult, got %T", res.Result)
+				}
+				if initResult.ServerInfo.Version != fakeVersionString {
+					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+			}
+		})
+	}
+}
+
+func TestPingHandler(t *testing.T) {
+	got, err := pingHandler(dummyID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected valid response, got nil")
+	}
+
+	res, ok := got.(jsonrpc.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+	}
+
+	if res.Jsonrpc != jsonrpc.JSONRPC_VERSION {
+		t.Errorf("expected JSONRPC version %q, got %q", jsonrpc.JSONRPC_VERSION, res.Jsonrpc)
+	}
+
+	if res.Id != dummyID {
+		t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+	}
+
+	// Verify Result is an empty struct
+	if _, ok := res.Result.(struct{}); !ok {
+		t.Errorf("expected result to be an empty struct, got %T", res.Result)
+	}
+}
+
+func TestToolsListHandler(t *testing.T) {
+	// Initialize tools using provided testutils mock instances
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        ListToolsRequest
+		rawBody     []byte
+		toolset     tools.Toolset
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "invalid mcp tools list request",
+		},
+		{
+			name: "success - stdio (nil header)",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+		{
+			name: "success - http",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsCallHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctxLogger := util.WithLogger(ctx, testLogger)
+	// Setup tools including the auth/unauth ones
+	mockTools := []testutils.MockTool{
+		testutils.MockTool1,
+		testutils.MockTool4,
+		testutils.MockTool5,
+	}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        CallToolRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "invalid mcp tools call request",
+		},
+		{
+			name: "missing logger in context",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve logger",
+		},
+		{
+			name: "tool not in toolset",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "unknown_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "tool with name \"unknown_tool\" does not exist",
+		},
+		{
+			name: "missing client auth token",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "require_client_auth_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "missing access token in the 'Authorization' header",
+		},
+		{
+			name: "successful invocation - no params",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context: ctxLogger,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsCallHandler(tt.context, dummyID, toolsets[""], resourceMgr, body, nil)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsListHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        ListPromptsRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts list request",
+		},
+		{
+			name: "success",
+			body: ListPromptsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "prompts/list",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsListHandler(ctx, dummyID, resourceMgr, promptsets[""], body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsGetHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        GetPromptRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts/get request",
+		},
+		{
+			name: "prompt does not exist",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "missing_prompt",
+				},
+			},
+			wantErr:     true,
+			errContains: "does not exist",
+		},
+		{
+			name: "success with args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt2",
+					Arguments: map[string]any{
+						"arg1": "value1",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success without args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsGetHandler(ctx, dummyID, promptsets[""], resourceMgr, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}

--- a/internal/server/mcp/v20251125/method_test.go
+++ b/internal/server/mcp/v20251125/method_test.go
@@ -1,0 +1,551 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v20251125
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/resources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// Dummy JSONRPC ID for testing
+var (
+	dummyID           jsonrpc.RequestId = 1
+	fakeVersionString                   = "0.0.0"
+)
+
+func TestInitializeHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxVersion := util.WithToolboxVersionKey(ctx, fakeVersionString)
+
+	tests := []struct {
+		name        string
+		body        InitializeRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing version in context",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve toolbox version", // Adjust to match your util.ToolboxVersionFromContext error
+		},
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "invalid mcp initialize request",
+		},
+		{
+			name: "success",
+			body: InitializeRequest{
+				Request: jsonrpc.Request{
+					Method: "initialize",
+				},
+				Params: InitializeParams{
+					ProtocolVersion: PROTOCOL_VERSION,
+				},
+			},
+			context: ctxVersion,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling: %v", err)
+				}
+			}
+
+			got, err := initializeHandler(tt.context, dummyID, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %v, want error containing %q", err, tt.errContains)
+				}
+				// Optional: You can also assert that 'got' is a jsonrpc.Error response here if you'd like
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Fatalf("expected valid response, got nil")
+				}
+
+				// Verify the response structure for success
+				res, ok := got.(jsonrpc.JSONRPCResponse)
+				if !ok {
+					t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+				}
+
+				if res.Id != dummyID {
+					t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+				}
+
+				initResult, ok := res.Result.(InitializeResult)
+				if !ok {
+					t.Fatalf("expected result of type InitializeResult, got %T", res.Result)
+				}
+				if initResult.ServerInfo.Version != fakeVersionString {
+					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+			}
+		})
+	}
+}
+
+func TestPingHandler(t *testing.T) {
+	got, err := pingHandler(dummyID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected valid response, got nil")
+	}
+
+	res, ok := got.(jsonrpc.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+	}
+
+	if res.Jsonrpc != jsonrpc.JSONRPC_VERSION {
+		t.Errorf("expected JSONRPC version %q, got %q", jsonrpc.JSONRPC_VERSION, res.Jsonrpc)
+	}
+
+	if res.Id != dummyID {
+		t.Errorf("expected ID %v, got %v", dummyID, res.Id)
+	}
+
+	// Verify Result is an empty struct
+	if _, ok := res.Result.(struct{}); !ok {
+		t.Errorf("expected result to be an empty struct, got %T", res.Result)
+	}
+}
+
+func TestToolsListHandler(t *testing.T) {
+	// Initialize tools using provided testutils mock instances
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        ListToolsRequest
+		rawBody     []byte
+		toolset     tools.Toolset
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "invalid mcp tools list request",
+		},
+		{
+			name: "success - stdio (nil header)",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+		{
+			name: "success - http",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+				},
+			},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsCallHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctxLogger := util.WithLogger(ctx, testLogger)
+	// Setup tools including the auth/unauth ones
+	mockTools := []testutils.MockTool{
+		testutils.MockTool1,
+		testutils.MockTool4,
+		testutils.MockTool5,
+	}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        CallToolRequest
+		rawBody     []byte
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "invalid mcp tools call request",
+		},
+		{
+			name: "missing logger in context",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve logger",
+		},
+		{
+			name: "tool not in toolset",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "unknown_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "tool with name \"unknown_tool\" does not exist",
+		},
+		{
+			name: "missing client auth token",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "require_client_auth_tool",
+				},
+			},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "missing access token in the 'Authorization' header",
+		},
+		{
+			name: "successful invocation - no params",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "no_params",
+				},
+			},
+			context: ctxLogger,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsCallHandler(tt.context, dummyID, toolsets[""], resourceMgr, body, nil)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsListHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        ListPromptsRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts list request",
+		},
+		{
+			name: "success",
+			body: ListPromptsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "prompts/list",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsListHandler(ctx, dummyID, resourceMgr, promptsets[""], body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsGetHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        GetPromptRequest
+		rawBody     []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			wantErr:     true,
+			errContains: "invalid mcp prompts/get request",
+		},
+		{
+			name: "prompt does not exist",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "missing_prompt",
+				},
+			},
+			wantErr:     true,
+			errContains: "does not exist",
+		},
+		{
+			name: "success with args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt2",
+					Arguments: map[string]any{
+						"arg1": "value1",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success without args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments,omitempty"`
+				}{
+					Name: "prompt1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsGetHandler(ctx, dummyID, promptsets[""], resourceMgr, body)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -82,9 +82,9 @@ var prompt2Args = []any{
 }
 
 func TestMcpEndpointWithoutInitialized(t *testing.T) {
-	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
-	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3, testutils.MockTool4, testutils.MockTool5}
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, mockPrompts)
 	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
@@ -427,9 +427,9 @@ func runInitializeLifecycle(t *testing.T, ts *httptest.Server, protocolVersion s
 }
 
 func TestMcpEndpoint(t *testing.T) {
-	mockTools := []testutils.MockTool{tool1, tool2, tool3, tool4, tool5}
-	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
-	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3, testutils.MockTool4, testutils.MockTool5}
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, mockPrompts)
 	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
@@ -454,7 +454,7 @@ func TestMcpEndpoint(t *testing.T) {
 						"tools":   map[string]any{"listChanged": false},
 						"prompts": map[string]any{"listChanged": false},
 					},
-					"serverInfo": map[string]any{"name": serverName, "version": fakeVersionString},
+					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
 		},
@@ -471,7 +471,7 @@ func TestMcpEndpoint(t *testing.T) {
 						"tools":   map[string]any{"listChanged": false},
 						"prompts": map[string]any{"listChanged": false},
 					},
-					"serverInfo": map[string]any{"name": serverName, "version": fakeVersionString},
+					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
 		},
@@ -488,7 +488,7 @@ func TestMcpEndpoint(t *testing.T) {
 						"tools":   map[string]any{"listChanged": false},
 						"prompts": map[string]any{"listChanged": false},
 					},
-					"serverInfo": map[string]any{"name": serverName, "version": fakeVersionString},
+					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
 		},
@@ -505,7 +505,7 @@ func TestMcpEndpoint(t *testing.T) {
 						"tools":   map[string]any{"listChanged": false},
 						"prompts": map[string]any{"listChanged": false},
 					},
-					"serverInfo": map[string]any{"name": serverName, "version": fakeVersionString},
+					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
 		},
@@ -1091,9 +1091,9 @@ func TestStdioSession(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockTools := []testutils.MockTool{tool1, tool2, tool3}
-	mockPrompts := []testutils.MockPrompt{prompt1, prompt2}
-	toolsMap, toolsets, promptsMap, promptsets := setUpResources(t, mockTools, mockPrompts)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3}
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, mockPrompts)
 
 	pr, pw, err := os.Pipe()
 	if err != nil {
@@ -1105,7 +1105,7 @@ func TestStdioSession(t *testing.T) {
 		t.Fatalf("unable to initialize logger: %s", err)
 	}
 
-	otelShutdown, err := telemetry.SetupOTel(ctx, fakeVersionString, "", false, "", "toolbox")
+	otelShutdown, err := telemetry.SetupOTel(ctx, testutils.MockVersionString, "", false, "", "toolbox")
 	if err != nil {
 		t.Fatalf("unable to setup otel: %s", err)
 	}
@@ -1116,7 +1116,7 @@ func TestStdioSession(t *testing.T) {
 		}
 	}()
 
-	instrumentation, err := telemetry.CreateTelemetryInstrumentation(fakeVersionString)
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation(testutils.MockVersionString)
 	if err != nil {
 		t.Fatalf("unable to create custom metrics: %s", err)
 	}
@@ -1126,7 +1126,7 @@ func TestStdioSession(t *testing.T) {
 	resourceManager := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
 
 	server := &Server{
-		version:         fakeVersionString,
+		version:         testutils.MockVersionString,
 		logger:          testLogger,
 		instrumentation: instrumentation,
 		sseManager:      sseManager,

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -22,10 +22,17 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"testing"
 
 	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
+
+// MockVersionString is used as a temporary version string in tests
+const MockVersionString = "0.0.0"
 
 // formatYaml is a utility function for stripping out tabs in multiline strings
 func FormatYaml(in string) []byte {
@@ -109,4 +116,75 @@ func WaitForString(ctx context.Context, re *regexp.Regexp, pr io.ReadCloser) (st
 			sb.WriteString(o.s)
 		}
 	}
+}
+
+var MockTool1 = NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+
+var MockTool2 = NewMockTool(
+	"some_params",
+	"",
+	parameters.Parameters{
+		parameters.NewIntParameter("param1", "This is the first parameter."),
+		parameters.NewIntParameter("param2", "This is the second parameter."),
+	}, false, false)
+
+var MockTool3 = NewMockTool(
+	"array_param", "some description",
+	parameters.Parameters{
+		parameters.NewArrayParameter("my_array", "this param is an array of strings", parameters.NewStringParameter("my_string", "string item")),
+	}, false, false)
+
+var MockTool4 = NewMockTool("unauthorized_tool", "", []parameters.Parameter{}, true, false)
+
+var MockTool5 = NewMockTool("require_client_auth_tool", "", []parameters.Parameter{}, false, true)
+
+var MockPrompt1 = NewMockPrompt("prompt1", "", prompts.Arguments{})
+
+var MockPrompt2 = NewMockPrompt("prompt2", "", prompts.Arguments{
+	{Parameter: parameters.NewStringParameter("arg1", "This is the first argument.")},
+})
+
+// SetUpResources setups resources to test against
+func SetUpResources(t *testing.T, mockTools []MockTool, mockPrompts []MockPrompt) (map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset) {
+	toolsMap := make(map[string]tools.Tool)
+	var allTools []string
+	for _, tool := range mockTools {
+		toolsMap[tool.Name] = tool
+		allTools = append(allTools, tool.Name)
+	}
+
+	toolsets := make(map[string]tools.Toolset)
+	if len(allTools) > 0 {
+		for name, l := range map[string][]string{
+			"":           allTools,
+			"tool1_only": {allTools[0]},
+			"tool2_only": {allTools[1]},
+		} {
+			tc := tools.ToolsetConfig{Name: name, ToolNames: l}
+			m, err := tc.Initialize(MockVersionString, toolsMap)
+			if err != nil {
+				t.Fatalf("unable to initialize toolset %q: %s", name, err)
+			}
+			toolsets[name] = m
+		}
+	}
+
+	promptsMap := make(map[string]prompts.Prompt)
+	var allPrompts []string
+	for _, prompt := range mockPrompts {
+		promptsMap[prompt.Name] = prompt
+		allPrompts = append(allPrompts, prompt.Name)
+	}
+
+	promptsets := make(map[string]prompts.Promptset)
+	if len(allPrompts) > 0 {
+		psc := prompts.PromptsetConfig{Name: "", PromptNames: allPrompts}
+		ps, err := psc.Initialize(MockVersionString, promptsMap)
+		if err != nil {
+			t.Fatalf("unable to initialize default promptset: %s", err)
+		}
+		promptsets[""] = ps
+	}
+
+	return toolsMap, toolsets, promptsMap, promptsets
 }


### PR DESCRIPTION
Add unit tests for each MCP version's `method.go`