### PR TITLE
feat(ci): automate npm publishing via OSS Exit Gate

### DIFF
--- a/.ci/npm_retry.cloudbuild.yaml
+++ b/.ci/npm_retry.cloudbuild.yaml
@@ -1,0 +1,51 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Retry-only pipeline for the OSS Exit Gate npm publish steps. Use when the
+# npm portion of the versioned release fails after Go binaries are already in
+# GCS. Each platform package's prepack script downloads its binary from GCS by
+# version, and publish_npm_to_ar.sh's idempotency check skips packages already
+# in AR.
+#
+# Invoke after checking out the version's tag locally:
+#   git checkout v<X.Y.Z>
+#   gcloud builds submit \
+#     --config=.ci/npm_retry.cloudbuild.yaml \
+#     --region=us-central1 \
+#     --service-account=projects/database-toolbox/serviceAccounts/release@database-toolbox.iam.gserviceaccount.com \
+#     .
+
+steps:
+  - id: "publish-npm-to-ar"
+    name: node:20
+    script: |
+      #!/usr/bin/env bash
+      bash .ci/publish_npm_to_ar.sh
+
+  - id: "trigger-exit-gate"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "publish-npm-to-ar"
+    env:
+      - "BUILD_ID=$BUILD_ID"
+    script: |
+      #!/usr/bin/env bash
+      bash .ci/trigger_exit_gate.sh
+
+options:
+  automapSubstitutions: true
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
+  pool:
+    name: projects/$PROJECT_ID/locations/us-central1/workerPools/run-release

--- a/.ci/publish_npm_to_ar.sh
+++ b/.ci/publish_npm_to_ar.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Publishes the six @toolbox-sdk npm packages (5 platform-specific + 1 wrapper)
+# to the OSS Exit Gate internal Artifact Registry. The Exit Gate then ships
+# them externally to npmjs.org once trigger_exit_gate.sh uploads the manifest.
+#
+# Required CWD: repo root (so npm/server-*/ paths resolve, and freshly-built
+# binaries toolbox.<os>.<arch> are present in the workspace).
+
+set -eo pipefail
+
+# OSS Exit Gate constants — owned by Exit Gate, not build configuration.
+readonly AR_REGISTRY="https://us-npm.pkg.dev/oss-exit-gate-prod/mcp-toolbox--npm/"
+readonly AR_HOST="us-npm.pkg.dev"
+
+cat > .npmrc <<EOF
+@toolbox-sdk:registry=${AR_REGISTRY}
+//${AR_HOST}/:always-auth=true
+EOF
+
+npx --yes google-artifactregistry-auth
+
+# Stages a Cloud-Build-produced binary into a platform npm package and publishes
+# it. Copying the binary into bin/ short-circuits the package's prepack
+# download script (it skips when the binary already exists).
+#
+# Args:
+#   pkg:  npm folder under npm/ (e.g., server-linux-x64)
+#   src:  go build output in the workspace (e.g., toolbox.linux.amd64)
+#   dest: binary name inside the package's bin/ (toolbox or toolbox.exe)
+publish_platform() {
+  local pkg="$1" src="$2" dest="$3"
+  mkdir -p "npm/${pkg}/bin"
+  cp "${src}" "npm/${pkg}/bin/${dest}"
+  chmod +x "npm/${pkg}/bin/${dest}"
+  (cd "npm/${pkg}" && npm publish)
+}
+
+publish_platform "server-linux-x64"    "toolbox.linux.amd64"   "toolbox"
+publish_platform "server-darwin-arm64" "toolbox.darwin.arm64"  "toolbox"
+publish_platform "server-darwin-x64"   "toolbox.darwin.amd64"  "toolbox"
+publish_platform "server-win32-x64"    "toolbox.windows.amd64" "toolbox.exe"
+publish_platform "server-win32-arm64"  "toolbox.windows.arm64" "toolbox.exe"
+
+(cd npm/server && npm publish)

--- a/.ci/publish_npm_to_ar.sh
+++ b/.ci/publish_npm_to_ar.sh
@@ -17,8 +17,14 @@
 # to the OSS Exit Gate internal Artifact Registry. The Exit Gate then ships
 # them externally to npmjs.org once trigger_exit_gate.sh uploads the manifest.
 #
-# Required CWD: repo root (so npm/server-*/ paths resolve, and freshly-built
-# binaries toolbox.<os>.<arch> are present in the workspace).
+# Required CWD: repo root (so npm/server-*/ paths resolve).
+#
+# Binaries (toolbox.<os>.<arch>) are picked up from the workspace if present
+# (versioned-release pipeline) and otherwise downloaded by each package's own
+# prepack script from GCS by version (retry pipeline).
+#
+# Each publish is gated by an "already in AR?" check so the script is safe to
+# re-run after a partial failure.
 
 set -eo pipefail
 
@@ -33,9 +39,26 @@ EOF
 
 npx --yes google-artifactregistry-auth
 
+# Publishes the npm package at npm/${pkg} to the Exit Gate AR, unless that
+# exact version is already there (idempotency check makes retries safe).
+publish_pkg() {
+  local pkg="$1"
+  local npm_name="@toolbox-sdk/${pkg}"
+  local version
+  version=$(cd "npm/${pkg}" && node -p "require('./package.json').version")
+
+  if npm view "${npm_name}@${version}" version --registry "${AR_REGISTRY}" 2>/dev/null | grep -q .; then
+    echo "Skipping ${npm_name}@${version}: already in AR"
+    return
+  fi
+
+  (cd "npm/${pkg}" && npm publish)
+}
+
 # Stages a Cloud-Build-produced binary into a platform npm package and publishes
 # it. Copying the binary into bin/ short-circuits the package's prepack
-# download script (it skips when the binary already exists).
+# download script (it skips when the binary already exists). When the binary
+# isn't in the workspace (retry pipeline), prepack downloads it from GCS.
 #
 # Args:
 #   pkg:  npm folder under npm/ (e.g., server-linux-x64)
@@ -43,10 +66,12 @@ npx --yes google-artifactregistry-auth
 #   dest: binary name inside the package's bin/ (toolbox or toolbox.exe)
 publish_platform() {
   local pkg="$1" src="$2" dest="$3"
-  mkdir -p "npm/${pkg}/bin"
-  cp "${src}" "npm/${pkg}/bin/${dest}"
-  chmod +x "npm/${pkg}/bin/${dest}"
-  (cd "npm/${pkg}" && npm publish)
+  if [[ -f "${src}" ]]; then
+    mkdir -p "npm/${pkg}/bin"
+    cp "${src}" "npm/${pkg}/bin/${dest}"
+    chmod +x "npm/${pkg}/bin/${dest}"
+  fi
+  publish_pkg "${pkg}"
 }
 
 publish_platform "server-linux-x64"    "toolbox.linux.amd64"   "toolbox"
@@ -55,4 +80,4 @@ publish_platform "server-darwin-x64"   "toolbox.darwin.amd64"  "toolbox"
 publish_platform "server-win32-x64"    "toolbox.windows.amd64" "toolbox.exe"
 publish_platform "server-win32-arm64"  "toolbox.windows.arm64" "toolbox.exe"
 
-(cd npm/server && npm publish)
+publish_pkg "server"

--- a/.ci/trigger_exit_gate.sh
+++ b/.ci/trigger_exit_gate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Uploads the OSS Exit Gate publishing manifest, which triggers external
+# publication of the npm packages that publish_npm_to_ar.sh pushed to the
+# internal Artifact Registry.
+#
+# Required env vars (supplied by Cloud Build):
+#   BUILD_ID  Cloud Build's auto-provided unique build ID
+
+set -eo pipefail
+
+# OSS Exit Gate constants — owned by Exit Gate, not build configuration.
+readonly EXIT_GATE_PROJECT="mcp-toolbox"
+readonly MANIFEST_BUCKET="oss-exit-gate-prod-projects-bucket"
+
+VERSION="v$(cat ./cmd/version.txt)"
+MANIFEST="${VERSION}-${BUILD_ID}.json"
+
+echo '{"publish_all": true}' > "${MANIFEST}"
+
+gcloud storage cp "${MANIFEST}" \
+  "gs://${MANIFEST_BUCKET}/${EXIT_GATE_PROJECT}/npm/manifests/${MANIFEST}"
+
+echo "Manifest uploaded: gs://${MANIFEST_BUCKET}/${EXIT_GATE_PROJECT}/npm/manifests/${MANIFEST}"
+echo "Exit Gate will email a confirmation when the external publish completes."

--- a/.ci/versioned.release.cloudbuild.yaml
+++ b/.ci/versioned.release.cloudbuild.yaml
@@ -407,6 +407,26 @@ steps:
       export VERSION=v$(cat ./cmd/version.txt)
       gcloud storage cp toolbox.geminicli.windows.arm64 gs://$_BUCKET_NAME/geminicli/$VERSION/windows/arm64/toolbox.exe
 
+  - id: "publish-npm-to-ar"
+    name: node:20
+    waitFor:
+      - "build-linux-amd64"
+      - "build-darwin-arm64"
+      - "build-darwin-amd64"
+      - "build-windows-amd64"
+      - "build-windows-arm64"
+    script: |
+      #!/usr/bin/env bash
+      bash .ci/publish_npm_to_ar.sh
+
+  - id: "trigger-exit-gate"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "publish-npm-to-ar"
+    script: |
+      #!/usr/bin/env bash
+      bash .ci/trigger_exit_gate.sh
+
 images:
   - "${_DOCKER_URI}:latest"
 

--- a/.ci/versioned.release.cloudbuild.yaml
+++ b/.ci/versioned.release.cloudbuild.yaml
@@ -423,6 +423,8 @@ steps:
     name: "gcr.io/cloud-builders/gcloud:latest"
     waitFor:
       - "publish-npm-to-ar"
+    env:
+      - "BUILD_ID=$BUILD_ID"
     script: |
       #!/usr/bin/env bash
       bash .ci/trigger_exit_gate.sh

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -890,7 +890,22 @@ Trigger pull request tests for external contributors by:
 
 ### How-to Release the npm Package
 
-MCP Toolbox is available as an npm package: [@toolbox-sdk/server](https://www.npmjs.com/package/@toolbox-sdk/server). To release a new version, follow these steps:
+MCP Toolbox is available as an npm package: [@toolbox-sdk/server](https://www.npmjs.com/package/@toolbox-sdk/server).
+
+> [!NOTE]
+> npm releases are automated through the **OSS Exit Gate** via the
+> `publish-npm-to-ar` and `trigger-exit-gate` steps in
+> [.ci/versioned.release.cloudbuild.yaml](.ci/versioned.release.cloudbuild.yaml).
+> The versioned release pipeline pushes all six packages to the Exit Gate
+> Artifact Registry (`us-npm.pkg.dev/oss-exit-gate-prod/mcp-toolbox--npm`) and
+> uploads a `publish_all: true` manifest to
+> `gs://oss-exit-gate-prod-projects-bucket/mcp-toolbox/npm/manifests/`, which
+> triggers Exit Gate to publish externally to npmjs.org.
+>
+> The manual procedure below is retained as a fallback for when the automation
+> is broken.
+
+To release a new version manually, follow these steps:
 
 **Pre-requisites**
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -902,6 +902,12 @@ MCP Toolbox is available as an npm package: [@toolbox-sdk/server](https://www.np
 > `gs://oss-exit-gate-prod-projects-bucket/mcp-toolbox/npm/manifests/`, which
 > triggers Exit Gate to publish externally to npmjs.org.
 >
+> If the npm portion fails after the Go binaries are already in GCS, retry
+> just the npm steps without rebuilding binaries via
+> [.ci/npm_retry.cloudbuild.yaml](.ci/npm_retry.cloudbuild.yaml) (invocation
+> instructions are in the file header). The retry is idempotent — already-
+> published packages are skipped.
+>
 > The manual procedure below is retained as a fallback for when the automation
 > is broken.
 


### PR DESCRIPTION
## Description

Automates external publication of the six `@toolbox-sdk` npm packages (5 platform-specific + 1 wrapper) through the OSS Exit Gate, replacing the manual Phase A/B procedure documented in `DEVELOPER.md`.

On each versioned release:
1. New `publish-npm-to-ar` step packs each platform package with its freshly-built binary already staged in `bin/` (which short-circuits the existing `prepack` GCS-download script), authenticates to the Exit Gate Artifact Registry via the Cloud Build SA's ADC, and `npm publish`es the six tarballs to `us-npm.pkg.dev/oss-exit-gate-prod/mcp-toolbox--npm`.
2. New `trigger-exit-gate` step writes a `publish_all: true` manifest and uploads it to `gs://oss-exit-gate-prod-projects-bucket/mcp-toolbox/npm/manifests/`, which signals Exit Gate to pull the tarballs from AR and publish them to npmjs.org.

The bash logic is extracted into `.ci/publish_npm_to_ar.sh` and `.ci/trigger_exit_gate.sh` for testability and readability. The OSS Exit Gate URLs/bucket are hardcoded `readonly` constants in the scripts (Exit Gate-owned values, not build configuration) so no new substitutions land in the Cloud Build YAML.

The manual procedure in `DEVELOPER.md` is retained as a fallback.

## PR Checklist

- [x] Reviewed CONTRIBUTING.md
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (CI-only change, no source code modified)
- [x] Appropriate docs were updated (DEVELOPER.md)
- [x] No breaking changes