### PR TITLE
fix(prebuilt/alloydb-omni): require password env var explicitly

### DIFF
--- a/internal/prebuiltconfigs/tools/alloydb-omni.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-omni.yaml
@@ -19,7 +19,7 @@ host: ${ALLOYDB_OMNI_HOST:localhost}
 port: ${ALLOYDB_OMNI_PORT:5432}
 database: ${ALLOYDB_OMNI_DATABASE}
 user: ${ALLOYDB_OMNI_USER}
-password: ${ALLOYDB_OMNI_PASSWORD:}
+password: ${ALLOYDB_OMNI_PASSWORD}
 queryParams: ${ALLOYDB_OMNI_QUERY_PARAMS:}
 ---
 kind: tool


### PR DESCRIPTION
## Description

The `alloydb-omni` prebuilt config declared `password: ${ALLOYDB_OMNI_PASSWORD:}` (empty default), but the underlying `postgres` source marks `Password` as `validate:"required"`. An unset `ALLOYDB_OMNI_PASSWORD` therefore resolves to `""` → `null` and fails config validation anyway — the empty default was misleading.

This drops the empty default and declares the var bare-required (`${ALLOYDB_OMNI_PASSWORD}`), matching the adjacent `user` field. Behavior is unchanged for the served path (an unset password already failed); it just makes the requirement honest and lets offline tooling substitute the placeholder.

Stacked on #3388.