### PR TITLE
feat(skills): tolerate missing env vars during offline skills-generate

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -45,6 +45,14 @@ type ConfigParser struct {
 	EnvVars         map[string]string
 	OptionalEnvVars []string
 	requiredEnvVars []string
+
+	// AllowMissingEnvVars, when true, substitutes the variable name for an unset
+	// required ${VAR} placeholder instead of erroring. Used by offline flows like
+	// skills-generate, where source env vars are needed only to satisfy config
+	// parsing/validation, never to connect. A non-empty placeholder is used (not
+	// "") so required string fields still pass validation. The served path leaves
+	// this false so missing config still fails fast.
+	AllowMissingEnvVars bool
 }
 
 // parseEnv replaces environment variables ${ENV_NAME} with their values.
@@ -89,6 +97,10 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 			value := parts[3]
 			p.EnvVars[variableName] = value
 			return value
+		}
+		if p.AllowMissingEnvVars {
+			p.EnvVars[variableName] = variableName
+			return variableName
 		}
 		err = fmt.Errorf("environment variable not found: %q", variableName)
 		return ""

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -45,6 +45,7 @@ func TestParseEnv(t *testing.T) {
 		err          bool
 		errString    string
 		wantOptional []string
+		lenient      bool
 	}{
 		{
 			desc:      "without default without env",
@@ -52,6 +53,19 @@ func TestParseEnv(t *testing.T) {
 			want:      "",
 			err:       true,
 			errString: `environment variable not found: "FOO"`,
+		},
+		{
+			desc:    "without default without env, lenient",
+			in:      "${FOO}",
+			want:    "FOO",
+			lenient: true,
+		},
+		{
+			desc:    "missing required mixed with env, lenient",
+			in:      "project: ${PROJECT}, region: ${REGION}",
+			env:     map[string]string{"REGION": "us-central1"},
+			want:    "project: PROJECT, region: us-central1",
+			lenient: true,
 		},
 		{
 			desc: "without default with env",
@@ -108,7 +122,7 @@ func TestParseEnv(t *testing.T) {
 					t.Setenv(k, v)
 				}
 			}
-			parser := &ConfigParser{}
+			parser := &ConfigParser{AllowMissingEnvVars: tc.lenient}
 			got, err := parser.parseEnv(tc.in)
 			if tc.err {
 				if err == nil {

--- a/cmd/internal/skills/command.go
+++ b/cmd/internal/skills/command.go
@@ -83,7 +83,9 @@ func run(cmd *skillsCmd, opts *internal.ToolboxOptions) error {
 		_ = shutdown(ctx)
 	}()
 
-	parser := internal.ConfigParser{}
+	// skills-generate runs offline: source env vars are needed only to make the
+	// config YAML parse, never to connect, so unset placeholders resolve to "".
+	parser := internal.ConfigParser{AllowMissingEnvVars: true}
 	_, err = opts.LoadConfig(ctx, &parser)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

`skills-generate` runs offline (no live source connection), but config parsing still substitutes `${VAR}` placeholders and validates required source fields.

These `${VAR}` placeholders come from the prebuilt config files (`internal/prebuiltconfigs/tools/*.yaml`), whose source sections template connection fields from env vars (e.g. `bigquery.yaml` has `project: ${BIGQUERY_PROJECT}`). `parseEnv` errors on any unset required one, so users had to set every referenced var just to generate skill docs, even though offline generation never connects.

This adds `ConfigParser.AllowMissingEnvVars`. When set (only by `skills-generate`), an unset bare-required `${VAR}` resolves to the variable name instead of erroring. A non-empty placeholder is used so required string fields still pass `validate:"required"`. The served path leaves this off and still fails fast on missing config.