### PR TITLE
test(alloydbainl): bump integration test context timeout to 2 minutes

### DIFF
--- a/tests/alloydbainl/alloydb_ai_nl_integration_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_integration_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestAlloyDBAINLToolEndpoints(t *testing.T) {
 	sourceConfig := getAlloyDBAINLVars(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	args := []string{"--enable-api"}

--- a/tests/alloydbainl/alloydb_ai_nl_mcp_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_mcp_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestAlloyDBAINLListTools(t *testing.T) {
 	sourceConfig := getAlloyDBAINLVars(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	toolsFile := getAINLToolsConfig(sourceConfig)
@@ -102,7 +102,7 @@ func TestAlloyDBAINLListTools(t *testing.T) {
 
 func TestAlloyDBAINLCallTool(t *testing.T) {
 	sourceConfig := getAlloyDBAINLVars(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	toolsFile := getAINLToolsConfig(sourceConfig)


### PR DESCRIPTION
## Description

Bumps the parent context timeout in the AlloyDB AI NL integration tests from `time.Minute` to `2*time.Minute` across three call sites (`alloydb_ai_nl_integration_test.go`, `alloydb_ai_nl_mcp_test.go`).

The tests wrap the toolbox server's lifetime in the parent context, so when it expires the server is torn down mid-suite and every remaining subtest fails with `dial tcp 127.0.0.1:5000: connect: connection refused`. Because the tests rely on real LLM-backed NL→SQL calls with per-invocation latency in the 5–32s range, three slow calls in a row reliably blow the 1-minute budget — a recent CI run hit 63.98s and cascaded multiple false failures. The new 2-minute budget matches what the sibling `tests/alloydb` suites already use.
