### PR TITLE
test(dataplex): widen TestDataplexToolEndpoints timeout to 5m

### DIFF
--- a/tests/dataplex/dataplex_integration_test.go
+++ b/tests/dataplex/dataplex_integration_test.go
@@ -210,7 +210,7 @@ func initDataplexDataScanConnection(ctx context.Context) (*dataplex.DataScanClie
 
 func TestDataplexToolEndpoints(t *testing.T) {
 	sourceConfig := getDataplexVars(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	args := []string{"--enable-api"}


### PR DESCRIPTION
## Description

`TestDataplexToolEndpoints` is flaky and fails repeatedly in CI. The root cause is the test's context budget.

A single 3-minute `ctx` governs the entire test: client setup, resource creation, a fixed `time.Sleep(2 * time.Minute)` ingestion wait, the toolbox server process (`StartCmd(ctx, ...)`), all subtests, and teardown. The 2-minute sleep alone consumes two-thirds of the budget, leaving ~1 minute for everything else.