### PR TITLE
test(datalineage): widen search index poll timeout to 3m

### DIFF
--- a/tests/datalineage/datalineage_integration_test.go
+++ b/tests/datalineage/datalineage_integration_test.go
@@ -164,7 +164,7 @@ func TestDatalineageToolEndpoints(t *testing.T) {
 	sourceConfig := getDatalineageVars(t)
 	project := sourceConfig["project"].(string)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	defer cancel()
 
 	args := []string{"--enable-api"}
@@ -207,10 +207,11 @@ func TestDatalineageToolEndpoints(t *testing.T) {
 		"direction": "UPSTREAM",
 	}
 	t.Log("Polling search lineage index for the new link with exponential backoff...")
-	// Poll up to 90 seconds for eventual consistency
-	links, err := pollSearchLineage(t, "my-datalineage-search-tool", reqBody, sourceFQN, targetFQN, 90*time.Second)
+	// Poll up to 3 minutes for eventual consistency
+	pollTimeout := 3 * time.Minute
+	links, err := pollSearchLineage(t, "my-datalineage-search-tool", reqBody, sourceFQN, targetFQN, pollTimeout)
 	if err != nil {
-		t.Fatalf("failed to find the link in search index within 90s timeout: %v", err)
+		t.Fatalf("failed to find the link in search index within %s timeout: %v", pollTimeout, err)
 	}
 
 	runDatalineageSearchUpstreamTest(t, links, sourceFQN, targetFQN)


### PR DESCRIPTION
## Description

Nightly `TestDatalineageToolEndpoints` is failing because the Data Lineage search index is eventually consistent and can take longer than the previous 90s poll window to surface a newly created link:

```
failed to find the link in search index within 90s timeout: timeout waiting for lineage link ...
--- FAIL: TestDatalineageToolEndpoints (93.33s)
```

This widens the poll timeout from 90s to 3m (the exponential backoff already caps at 30s/poll) and grows the parent test context from 5m to 6m so it can accommodate the longer poll alongside resource setup and server start. No production code changes.

Fixes https://github.com/googleapis/mcp-toolbox/issues/3409, https://github.com/googleapis/mcp-toolbox/issues/3400