### PR TITLE
fix: support string parameter options

### DIFF
--- a/internal/util/parameters/parameters.go
+++ b/internal/util/parameters/parameters.go
@@ -595,8 +595,58 @@ type ParamAuthService struct {
 	Field string `yaml:"field"`
 }
 
+// StringParameterOption configures a StringParameter.
+type StringParameterOption func(*StringParameter)
+
+func applyStringParameterOptions(p *StringParameter, opts ...StringParameterOption) *StringParameter {
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func WithStringParameterRequired(required bool) StringParameterOption {
+	return func(p *StringParameter) {
+		p.Required = &required
+	}
+}
+
+func WithStringParameterDefault(defaultV string) StringParameterOption {
+	return func(p *StringParameter) {
+		p.Default = &defaultV
+	}
+}
+
+func WithStringParameterEscape(escape string) StringParameterOption {
+	return func(p *StringParameter) {
+		p.Escape = &escape
+	}
+}
+
+func WithStringParameterAuth(authServices []ParamAuthService) StringParameterOption {
+	return func(p *StringParameter) {
+		p.AuthServices = authServices
+	}
+}
+
+func WithStringParameterAllowedValues(allowedValues []any) StringParameterOption {
+	return func(p *StringParameter) {
+		p.AllowedValues = allowedValues
+	}
+}
+
+func WithStringParameterExcludedValues(excludedValues []any) StringParameterOption {
+	return func(p *StringParameter) {
+		p.ExcludedValues = excludedValues
+	}
+}
+
 // NewStringParameter is a convenience function for initializing a StringParameter.
-func NewStringParameter(name string, desc string) *StringParameter {
+func NewStringParameter(name string, desc string, opts ...StringParameterOption) *StringParameter {
+	return applyStringParameterOptions(newStringParameter(name, desc), opts...)
+}
+
+func newStringParameter(name string, desc string) *StringParameter {
 	return &StringParameter{
 		CommonParameter: CommonParameter{
 			Name:         name,
@@ -608,80 +658,45 @@ func NewStringParameter(name string, desc string) *StringParameter {
 }
 
 // NewStringParameterWithDefault is a convenience function for initializing a StringParameter with default value.
-func NewStringParameterWithDefault(name string, defaultV, desc string) *StringParameter {
-	return &StringParameter{
-		CommonParameter: CommonParameter{
-			Name:         name,
-			Type:         TypeString,
-			Desc:         desc,
-			AuthServices: nil,
-		},
-		Default: &defaultV,
-	}
+func NewStringParameterWithDefault(name string, defaultV, desc string, opts ...StringParameterOption) *StringParameter {
+	p := newStringParameter(name, desc)
+	p.Default = &defaultV
+	return applyStringParameterOptions(p, opts...)
 }
 
 // NewStringParameterWithEscape is a convenience function for initializing a StringParameter.
-func NewStringParameterWithEscape(name, desc, escape string) *StringParameter {
-	return &StringParameter{
-		CommonParameter: CommonParameter{
-			Name:         name,
-			Type:         TypeString,
-			Desc:         desc,
-			AuthServices: nil,
-		},
-		Escape: &escape,
-	}
+func NewStringParameterWithEscape(name, desc, escape string, opts ...StringParameterOption) *StringParameter {
+	p := newStringParameter(name, desc)
+	p.Escape = &escape
+	return applyStringParameterOptions(p, opts...)
 }
 
 // NewStringParameterWithRequired is a convenience function for initializing a StringParameter.
-func NewStringParameterWithRequired(name string, desc string, required bool) *StringParameter {
-	return &StringParameter{
-		CommonParameter: CommonParameter{
-			Name:         name,
-			Type:         TypeString,
-			Desc:         desc,
-			Required:     &required,
-			AuthServices: nil,
-		},
-	}
+func NewStringParameterWithRequired(name string, desc string, required bool, opts ...StringParameterOption) *StringParameter {
+	p := newStringParameter(name, desc)
+	p.Required = &required
+	return applyStringParameterOptions(p, opts...)
 }
 
 // NewStringParameterWithAuth is a convenience function for initializing a StringParameter with a list of ParamAuthService.
-func NewStringParameterWithAuth(name string, desc string, authServices []ParamAuthService) *StringParameter {
-	return &StringParameter{
-		CommonParameter: CommonParameter{
-			Name:         name,
-			Type:         TypeString,
-			Desc:         desc,
-			AuthServices: authServices,
-		},
-	}
+func NewStringParameterWithAuth(name string, desc string, authServices []ParamAuthService, opts ...StringParameterOption) *StringParameter {
+	p := newStringParameter(name, desc)
+	p.AuthServices = authServices
+	return applyStringParameterOptions(p, opts...)
 }
 
 // NewStringParameterWithAllowedValues is a convenience function for initializing a StringParameter with a list of allowedValues
-func NewStringParameterWithAllowedValues(name string, desc string, allowedValues []any) *StringParameter {
-	return &StringParameter{
-		CommonParameter: CommonParameter{
-			Name:          name,
-			Type:          TypeString,
-			Desc:          desc,
-			AllowedValues: allowedValues,
-			AuthServices:  nil,
-		},
-	}
+func NewStringParameterWithAllowedValues(name string, desc string, allowedValues []any, opts ...StringParameterOption) *StringParameter {
+	p := newStringParameter(name, desc)
+	p.AllowedValues = allowedValues
+	return applyStringParameterOptions(p, opts...)
 }
 
 // NewStringParameterWithExcludedValues is a convenience function for initializing a StringParameter with a list of excludedValues
-func NewStringParameterWithExcludedValues(name string, desc string, excludedValues []any) *StringParameter {
-	return &StringParameter{
-		CommonParameter: CommonParameter{
-			Name:           name,
-			Type:           TypeString,
-			Desc:           desc,
-			ExcludedValues: excludedValues,
-			AuthServices:   nil,
-		},
-	}
+func NewStringParameterWithExcludedValues(name string, desc string, excludedValues []any, opts ...StringParameterOption) *StringParameter {
+	p := newStringParameter(name, desc)
+	p.ExcludedValues = excludedValues
+	return applyStringParameterOptions(p, opts...)
 }
 
 var _ Parameter = &StringParameter{}

--- a/internal/util/parameters/parameters_test.go
+++ b/internal/util/parameters/parameters_test.go
@@ -742,6 +742,36 @@ func TestParametersParse(t *testing.T) {
 			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: "foo"}},
 		},
 		{
+			name: "optional string allowed via option",
+			params: parameters.Parameters{
+				parameters.NewStringParameterWithRequired(
+					"my_string",
+					"this param is a string",
+					false,
+					parameters.WithStringParameterAllowedValues([]any{"foo", "bar"}),
+				),
+			},
+			in: map[string]any{
+				"my_string": "bar",
+			},
+			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: "bar"}},
+		},
+		{
+			name: "string default allowed via option",
+			params: parameters.Parameters{
+				parameters.NewStringParameterWithDefault(
+					"my_string",
+					"foo",
+					"this param is a string",
+					parameters.WithStringParameterAllowedValues([]any{"foo"}),
+				),
+			},
+			in: map[string]any{
+				"my_string": "foo",
+			},
+			want: parameters.ParamValues{parameters.ParamValue{Name: "my_string", Value: "foo"}},
+		},
+		{
 			name: "string not allowed",
 			params: parameters.Parameters{
 				parameters.NewStringParameterWithAllowedValues("my_string", "this param is a string", []any{"foo"}),
@@ -1717,6 +1747,16 @@ func TestParamManifest(t *testing.T) {
 		{
 			name: "string not required",
 			in:   parameters.NewStringParameterWithRequired("foo-string", "bar", false),
+			want: parameters.ParameterManifest{Name: "foo-string", Type: "string", Required: false, Description: "bar", AuthServices: []string{}},
+		},
+		{
+			name: "string not required with allowed values",
+			in: parameters.NewStringParameterWithRequired(
+				"foo-string",
+				"bar",
+				false,
+				parameters.WithStringParameterAllowedValues([]any{"foo", "bar"}),
+			),
 			want: parameters.ParameterManifest{Name: "foo-string", Type: "string", Required: false, Description: "bar", AuthServices: []string{}},
 		},
 		{


### PR DESCRIPTION
## Summary
- add a small functional-options layer for string parameters
- keep the existing string parameter constructors source-compatible
- allow combinations such as optional string parameters with allowed values

Fixes #3311.

## To verify
- go test ./internal/util/parameters -run 'TestParametersParse|TestParamManifest' -count=1 -v
- go test ./internal/util/parameters -count=1
- git diff --check