### PR TITLE
docs: document execute_sql least privilege

### DIFF
--- a/docs/en/documentation/configuration/prebuilt-configs/_index.md
+++ b/docs/en/documentation/configuration/prebuilt-configs/_index.md
@@ -25,6 +25,22 @@ You can load a specific toolset from a prebuilt configuration by appending a `/`
 See [Usage Examples](../../../reference/cli.md#usage-examples).
 {{< /notice >}}
 
+## Security for dynamic SQL tools
+
+Some prebuilt configs expose dynamic `execute_sql`-style tools where the agent
+supplies raw SQL. Tool annotations and MCP client confirmations are useful UX
+guardrails, but they are not a database security boundary.
+
+Run these tools with a dedicated database identity that only has the privileges
+the agent should exercise. For exploratory agents, this usually means
+`SELECT`-only access to the specific schemas, tables, or views the agent may
+read. Avoid owner, admin, migration, or application-write accounts.
+
+Prefer custom parameterized tools for fixed workflows. Use dynamic SQL tools for
+trusted exploratory read-only access, and rely on database-native permissions or
+read-only session controls where the engine supports them. Do not rely on regex
+keyword blacklists to make an arbitrary SQL endpoint safe.
+
 ## Available Prebuilt Configs
 
 {{< list-prebuilt-configs >}}


### PR DESCRIPTION
Closes #3405.\n\nThis documents the security boundary for prebuilt dynamic execute_sql-style tools: use a dedicated least-privilege database identity, prefer SELECT-only access for exploratory agents, and do not rely on regex keyword blacklists for arbitrary SQL endpoints.\n\nValidation:\n- git diff --check\n- Select-String for execute_sql / SELECT / regex / database-native terms in the updated doc