### PR TITLE
fix(deps): bump fast-uri to 3.1.2 to fix path normalization bypass

### DIFF
--- a/docs/en/documentation/configuration/pre-post-processing/js/adk/package-lock.json
+++ b/docs/en/documentation/configuration/pre-post-processing/js/adk/package-lock.json
@@ -3876,9 +3876,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Description
  Bumps `fast-uri` from `3.1.0` to `3.1.2` in `docs/en/documentation/configuration/pre-post-processing/js/adk/package-lock.json`.
  
  `fast-uri` <= 3.1.0 decodes percent-encoded path separators (`%2F`) and dot segments (`%2E`) before applying dot-segment removal in
  `normalize()` and `equal()`. This causes distinct URIs to collapse onto the same normalized path (e.g.
  `http://example.com/public/%2e%2e/admin` normalizes to `http://example.com/admin`), allowing path-based policy checks on attacker-controlled
   URLs to be bypassed. Fixed in `fast-uri >= 3.1.1`.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<402>

  ## Issue Reference
  Fixes https://github.com/googleapis/mcp-toolbox/security/dependabot/402 🦕
