### PR TITLE
ci: ungroup npm major updates into per-dependency PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,6 +71,15 @@
       ],
     },
     {
+      matchManagers: [
+        'npm',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      groupName: '{{depName}}',
+    },
+    {
       groupName: 'Pip',
       matchManagers: [
         'pip_requirements',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -77,7 +77,7 @@
       matchUpdateTypes: [
         'major',
       ],
-      groupName: '{{depName}}',
+      groupName: null,
     },
     {
       groupName: 'Pip',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,15 +69,10 @@
       matchManagers: [
         'npm',
       ],
-    },
-    {
-      matchManagers: [
-        'npm',
-      ],
       matchUpdateTypes: [
-        'major',
+        'minor',
+        'patch',
       ],
-      groupName: null,
     },
     {
       groupName: 'Pip',


### PR DESCRIPTION
## Description

Renovate bundles all npm major updates into one shared PR (the `major-node` group).  (https://github.com/googleapis/mcp-toolbox/pull/2511)

This scopes the `Node` group to npm `minor`/`patch` updates only. Major updates no longer match a group rule, so they fall through to Renovate's default — one individual PR per dependency. Minor/patch updates stay grouped as before.

Validated with `renovate-config-validator` (config passes).