### PR TITLE
fix(deps): bump picomatch to 4.0.4 to fix regex method injection

### DIFF
--- a/docs/en/documentation/configuration/pre-post-processing/js/adk/package-lock.json
+++ b/docs/en/documentation/configuration/pre-post-processing/js/adk/package-lock.json
@@ -7649,9 +7649,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Description
  Bumps the transitive `picomatch` dependency from `4.0.3` to `4.0.4` in
`docs/en/documentation/configuration/pre-post-processing/js/adk/package-lock.json` (pulled in via `@google/adk` / `@toolbox-sdk/adk` → tinyglobby).

`picomatch` >= 4.0.0, < 4.0.4 is vulnerable to a method injection vulnerability (CWE-1321) in the `POSIX_REGEX_SOURCE` object. Because the object inherits from `Object.prototype`, crafted POSIX bracket expressions (e.g. `[[:constructor:]]`) can reference inherited method names that get coerced to strings and injected into the generated regular expression, causing incorrect glob matching. Fixed in `picomatch` 4.0.4 (and 3.0.2 / 2.3.2).

## Security Issue
Fixes https://github.com/googleapis/mcp-toolbox/security/dependabot/161 🦕

## PR Checklist

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change