### PR TITLE
docs: add SEP-2663 compliance tests and update protocol versioning documentation

### DIFF
--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
@@ -104,7 +104,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `core.MCP` | **(Default)** Alias for the latest supported MCP version (currently `v2025-06-18`). |
+| `core.MCP` | **(Default)** Alias for the default MCP version (currently `v2025-11-25`). |
+| `core.MCPLatest` | Alias for the latest stable MCP version (currently `v2025-11-25`). |
+| `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `v2026-draft`). |
+| `core.MCPv2026Draft` | MCP Protocol draft version v2026-draft. |
 | `core.MCPv20251125` | MCP Protocol version 2025-11-25. |
 | `core.MCPv20250618` | MCP Protocol version 2025-06-18. |
 | `core.MCPv20250326` | MCP Protocol version 2025-03-26. |
@@ -112,7 +115,7 @@ We currently support different versions of the MCP protocol.
 
 ### Example
 
-// Initialize with the default MCP protocol (2025-06-18)
+// Initialize with the default MCP protocol (2025-11-25)
 
 ```go
 import "github.com/googleapis/mcp-toolbox-sdk-go/core"

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
@@ -125,7 +125,7 @@ client, err := core.NewToolboxClient(
 )
 ```
 
-If you want to pin the MCP Version 2025-03-26:
+If you want to set the preferred starting protocol to 2025-03-26 (allowing fallback negotiation if the server doesn't support it):
 
 ```go
 import "github.com/googleapis/mcp-toolbox-sdk-go/core"
@@ -136,16 +136,23 @@ client, err := core.NewToolboxClient(
 )
 ```
 
-You can also provide a custom array of supported protocols to restrict negotiation to specific versions. The client will attempt to negotiate the first protocol in the list that the server supports:
+To restrict negotiation to a specific subset of versions, you can pass an array of supported protocols using `WithSupportedProtocols`:
 
 ```go
 import "github.com/googleapis/mcp-toolbox-sdk-go/core"
 
 client, err := core.NewToolboxClient(
     "http://localhost:5000",
-    core.WithSupportedProtocols([]core.Protocol{core.MCPLatest, core.MCPDraft}),
+    core.WithSupportedProtocols([]core.Protocol{
+        core.MCPLatest,
+        core.MCPv20250618,
+    }),
 )
 ```
+
+{{< notice tip >}}
+If you want to strictly pin the version and disable protocol fallback, you must pass an array containing just one value using `WithSupportedProtocols`: `core.WithSupportedProtocols([]core.Protocol{core.MCPDraft})`
+{{< /notice >}}
 
 ## Loading Tools
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
@@ -100,7 +100,7 @@ You can explicitly select a protocol using the `core.WithProtocol` option during
 
 ### Supported Protocols
 
-We currently support different versions of the MCP protocol.
+We currently support different versions of the MCP protocol. For a complete and up-to-date list, see the [`Protocol` type definition on GitHub](https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/core/protocol.go).
 
 | Constant | Description |
 | :--- | :--- |
@@ -133,6 +133,17 @@ import "github.com/googleapis/mcp-toolbox-sdk-go/core"
 client, err := core.NewToolboxClient(
     "http://localhost:5000",
     core.WithProtocol(core.MCPv20250326),
+)
+```
+
+You can also provide a custom array of supported protocols to restrict negotiation to specific versions. The client will attempt to negotiate the first protocol in the list that the server supports:
+
+```go
+import "github.com/googleapis/mcp-toolbox-sdk-go/core"
+
+client, err := core.NewToolboxClient(
+    "http://localhost:5000",
+    core.WithSupportedProtocols([]core.Protocol{core.MCPLatest, core.MCPDraft}),
 )
 ```
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
@@ -107,7 +107,6 @@ We currently support different versions of the MCP protocol. For a complete and 
 | `core.MCP` | **(Default)** Alias for the default MCP version (currently `v2025-11-25`). |
 | `core.MCPLatest` | Alias for the latest stable MCP version (currently `v2025-11-25`). |
 | `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `v2026-draft`). |
-| `core.MCPv2026Draft` | MCP Protocol draft version v2026-draft. |
 | `core.MCPv20251125` | MCP Protocol version 2025-11-25. |
 | `core.MCPv20250618` | MCP Protocol version 2025-06-18. |
 | `core.MCPv20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
@@ -104,7 +104,6 @@ We currently support different versions of the MCP protocol.
 | `core.MCP` | **(Default)** Alias for the default MCP version (currently `v2025-11-25`). |
 | `core.MCPLatest` | Alias for the latest stable MCP version (currently `v2025-11-25`). |
 | `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `v2026-draft`). |
-| `core.MCPv2026Draft` | MCP Protocol draft version v2026-draft. |
 | `core.MCPv20251125` | MCP Protocol version 2025-11-25. |
 | `core.MCPv20250618` | MCP Protocol version 2025-06-18. |
 | `core.MCPv20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
@@ -101,7 +101,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `core.MCP` | **(Default)** Alias for the latest supported MCP version (currently `v2025-06-18`). |
+| `core.MCP` | **(Default)** Alias for the default MCP version (currently `v2025-11-25`). |
+| `core.MCPLatest` | Alias for the latest stable MCP version (currently `v2025-11-25`). |
+| `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `v2026-draft`). |
+| `core.MCPv2026Draft` | MCP Protocol draft version v2026-draft. |
 | `core.MCPv20251125` | MCP Protocol version 2025-11-25. |
 | `core.MCPv20250618` | MCP Protocol version 2025-06-18. |
 | `core.MCPv20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/adk/index.md
@@ -89,7 +89,10 @@ The SDK supports multiple transport protocols to communicate with the Toolbox se
 
 We currently support different versions of the MCP protocol.
 
-- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20250618`).
+- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20251125`).
+- `Protocol.MCP_LATEST`: Alias for the latest stable MCP version (currently aliases to `MCP_v20251125`).
+- `Protocol.MCP_DRAFT`: Alias for the upcoming draft MCP version (currently aliases to `MCP_v2026_DRAFT`).
+- `Protocol.MCP_v2026_DRAFT`: Draft version 2026.
 - `Protocol.MCP_v20241105`: Use this for compatibility with older MCP servers (November 2024 version).
 - `Protocol.MCP_v20250326`: March 2025 version.
 - `Protocol.MCP_v20250618`: June 2025 version.

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
@@ -89,7 +89,10 @@ The SDK supports multiple transport protocols to communicate with the Toolbox se
 
 We currently support different versions of the MCP protocol.
 
-- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20250618`).
+- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20251125`).
+- `Protocol.MCP_LATEST`: Alias for the latest stable MCP version (currently aliases to `MCP_v20251125`).
+- `Protocol.MCP_DRAFT`: Alias for the upcoming draft MCP version (currently aliases to `MCP_v2026_DRAFT`).
+- `Protocol.MCP_v2026_DRAFT`: Draft version 2026.
 - `Protocol.MCP_v20241105`: Use this for compatibility with older MCP servers (November 2024 version).
 - `Protocol.MCP_v20250326`: March 2025 version.
 - `Protocol.MCP_v20250618`: June 2025 version.

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
@@ -87,7 +87,8 @@ The SDK supports multiple transport protocols to communicate with the Toolbox se
 
 ### Available Protocols
 
-We currently support different versions of the MCP protocol.
+We currently support different versions of the MCP protocol. For a complete and up-to-date list, see the [`Protocol` enum definition on GitHub](https://github.com/googleapis/mcp-toolbox-sdk-js/blob/main/packages/toolbox-core/src/toolbox_core/protocol.ts).
+
 
 - `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20251125`).
 - `Protocol.MCP_LATEST`: Alias for the latest stable MCP version (currently aliases to `MCP_v20251125`).
@@ -109,6 +110,19 @@ const URL = 'http://127.0.0.1:5000';
 
 // Initialize with a specific protocol version
 const client = new ToolboxClient(URL, null, null, Protocol.MCP_v20241105);
+
+const tools = await client.loadToolset();
+```
+
+You can also provide a custom array of supported protocols to restrict negotiation to specific versions. The client will attempt to negotiate the first protocol in the list that the server supports:
+
+```javascript
+import { ToolboxClient, Protocol } from '@toolbox-sdk/core';
+
+const URL = 'http://127.0.0.1:5000';
+
+// Initialize with a custom array of protocols
+const client = new ToolboxClient(URL, null, null, [Protocol.MCP_LATEST, Protocol.MCP_DRAFT]);
 
 const tools = await client.loadToolset();
 ```

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
@@ -101,31 +101,35 @@ We currently support different versions of the MCP protocol. For a complete and 
 
 ### Specifying a Protocol
 
-You can explicitly set the protocol by passing the `protocol` argument to the `ToolboxClient` constructor.
+You can explicitly set the preferred starting protocol by passing the `protocol` argument to the `ToolboxClient` constructor (allowing fallback negotiation if the server doesn't support it):
 
 ```javascript
 import { ToolboxClient, Protocol } from '@toolbox-sdk/core';
 
 const URL = 'http://127.0.0.1:5000';
 
-// Initialize with a specific protocol version
+// Initialize with a specific preferred protocol version
 const client = new ToolboxClient(URL, null, null, Protocol.MCP_v20241105);
 
 const tools = await client.loadToolset();
 ```
 
-You can also provide a custom array of supported protocols to restrict negotiation to specific versions. The client will attempt to negotiate the first protocol in the list that the server supports:
+To restrict negotiation to a specific subset of versions, you can pass an array of supported protocols as the fourth argument:
 
 ```javascript
 import { ToolboxClient, Protocol } from '@toolbox-sdk/core';
 
 const URL = 'http://127.0.0.1:5000';
 
-// Initialize with a custom array of protocols
-const client = new ToolboxClient(URL, null, null, [Protocol.MCP_LATEST, Protocol.MCP_DRAFT]);
+// Restrict negotiation to specific protocol versions
+const client = new ToolboxClient(URL, undefined, undefined, [Protocol.MCP_LATEST, Protocol.MCP_v20250618]);
 
 const tools = await client.loadToolset();
 ```
+
+{{< notice tip >}}
+If you want to strictly pin the version and disable protocol fallback, you must pass an array containing just one value: `[Protocol.MCP_DRAFT]`
+{{< /notice >}}
 
 ## Loading Tools
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
@@ -53,7 +53,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-06-18`). |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
+| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
 | `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
@@ -99,7 +99,7 @@ You can explicitly select a protocol using the `protocol` option during client i
 
 ### Supported Protocols
 
-We currently support different versions of the MCP protocol.
+We currently support different versions of the MCP protocol. For a complete and up-to-date list, see the [`Protocol` enum definition on GitHub](https://github.com/googleapis/mcp-toolbox-sdk-python/blob/main/packages/toolbox-core/src/toolbox_core/protocol.py).
 
 | Constant | Description |
 | :--- | :--- |
@@ -130,6 +130,17 @@ from toolbox_core import ToolboxClient
 from toolbox_core.protocol import Protocol
 
 async with ToolboxClient("http://127.0.0.1:5000", protocol=Protocol.MCP_v20250326) as toolbox:
+    # Use client
+    pass
+```
+
+You can also provide a custom list of supported protocols to restrict negotiation to specific versions. The client will attempt to negotiate the first protocol in the list that the server supports:
+
+```py
+from toolbox_core import ToolboxClient
+from toolbox_core.protocol import Protocol
+
+async with ToolboxClient("http://127.0.0.1:5000", protocol=[Protocol.MCP_LATEST, Protocol.MCP_DRAFT]) as toolbox:
     # Use client
     pass
 ```

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
@@ -123,7 +123,7 @@ async with ToolboxClient("http://127.0.0.1:5000", protocol=Protocol.MCP) as tool
     pass
 ```
 
-If you want to pin the MCP Version 2025-03-26:
+If you want to set the preferred starting protocol to 2025-03-26 (allowing fallback negotiation if the server doesn't support it):
 
 ```py
 from toolbox_core import ToolboxClient
@@ -134,16 +134,23 @@ async with ToolboxClient("http://127.0.0.1:5000", protocol=Protocol.MCP_v2025032
     pass
 ```
 
-You can also provide a custom list of supported protocols to restrict negotiation to specific versions. The client will attempt to negotiate the first protocol in the list that the server supports:
+To restrict negotiation to a specific subset of versions, you can pass a list of supported protocols to the `protocol` parameter:
 
 ```py
 from toolbox_core import ToolboxClient
 from toolbox_core.protocol import Protocol
 
-async with ToolboxClient("http://127.0.0.1:5000", protocol=[Protocol.MCP_LATEST, Protocol.MCP_DRAFT]) as toolbox:
+async with ToolboxClient(
+    "http://127.0.0.1:5000", 
+    protocol=[Protocol.MCP_LATEST, Protocol.MCP_v20250618]
+) as toolbox:
     # Use client
     pass
 ```
+
+{{< notice tip >}}
+If you want to strictly pin the version and disable protocol fallback, you must pass an array containing just one value: `protocol=[Protocol.MCP_DRAFT]`
+{{< /notice >}}
 
 ## Loading Tools
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
@@ -103,9 +103,13 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-06-18`). |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
+| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
+| `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |
 | `Protocol.MCP_v20241105` | MCP Protocol version 2024-11-05. |
 
 ### Example

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/langchain/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/langchain/index.md
@@ -71,7 +71,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-06-18`). |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
+| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
 | `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/llamaindex/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/llamaindex/index.md
@@ -79,7 +79,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-06-18`). |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
+| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
 | `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |


### PR DESCRIPTION
## Description
This PR introduces compliance tests and documentation for the new SEP-2663 task extension, while significantly updating the SDK documentation regarding MCP protocol version management.

### Changes
  * Updates the default MCP protocol version to `2025-11-25` across the SDKs.
  * Adds documentation for new `latest` and `draft` protocol constants.
  * Updates SDK documentation to explain and support protocol version subset negotiation and strict version pinning.
