### PR TITLE
fix(util/parameters): report integer type in IntParameter allowed/excluded constructors

### DIFF
--- a/internal/util/parameters/int_parameter_type_test.go
+++ b/internal/util/parameters/int_parameter_type_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/util/parameters/int_parameter_type_test.go
+++ b/internal/util/parameters/int_parameter_type_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parameters_test
+
+import (
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+// TestIntParameterAllowedExcludedReportIntegerType guards against the int
+// constructors reporting the wrong parameter type. The allowed/excluded value
+// variants previously copied the string constructor and set Type to "string".
+func TestIntParameterAllowedExcludedReportIntegerType(t *testing.T) {
+	for _, p := range []parameters.Parameter{
+		parameters.NewIntParameterWithAllowedValues("my_int", "an int param", []any{1}),
+		parameters.NewIntParameterWithExcludedValues("my_int", "an int param", []any{1}),
+	} {
+		if got := p.GetType(); got != parameters.TypeInt {
+			t.Errorf("GetType() = %q, want %q", got, parameters.TypeInt)
+		}
+		if got := p.Manifest().Type; got != parameters.TypeInt {
+			t.Errorf("Manifest().Type = %q, want %q", got, parameters.TypeInt)
+		}
+	}
+}

--- a/internal/util/parameters/parameters.go
+++ b/internal/util/parameters/parameters.go
@@ -825,7 +825,7 @@ func NewIntParameterWithAllowedValues(name string, desc string, allowedValues []
 	return &IntParameter{
 		CommonParameter: CommonParameter{
 			Name:          name,
-			Type:          TypeString,
+			Type:          TypeInt,
 			Desc:          desc,
 			AllowedValues: allowedValues,
 			AuthServices:  nil,
@@ -838,7 +838,7 @@ func NewIntParameterWithExcludedValues(name string, desc string, excludedValues 
 	return &IntParameter{
 		CommonParameter: CommonParameter{
 			Name:           name,
-			Type:           TypeString,
+			Type:           TypeInt,
 			Desc:           desc,
 			ExcludedValues: excludedValues,
 			AuthServices:   nil,


### PR DESCRIPTION
## Description

`NewIntParameterWithAllowedValues` and `NewIntParameterWithExcludedValues` set their `Type` to `TypeString` instead of `TypeInt`. They were clearly copied from the string constructors and the type field was never updated, so an int parameter created with an allowed/excluded list reports itself as a string everywhere `GetType()` / `Manifest().Type` is consumed (manifests, validation, docs).

Every other int constructor uses `TypeInt`, and the float allowed/excluded constructors correctly use `TypeFloat`, so these two are the odd ones out.

## Fix

Flip both lines from `TypeString` to `TypeInt`. That is the whole change.

## Verification

Added a focused test in `internal/util/parameters`. On current `main` it fails:

```
GetType()="string" want integer
Manifest().Type="string" want integer
```

After the fix `go test ./internal/util/parameters/` passes with no regressions.
