### PR TITLE
feat(source/looker): honor proxy environment variables

### DIFF
--- a/docs/LOOKER_README.md
+++ b/docs/LOOKER_README.md
@@ -36,6 +36,22 @@ You'll now be able to see all enabled tools in the "Tools" tab.
 > [!NOTE]
 > If you encounter issues with Windows Defender blocking the execution, you may need to configure an allowlist. See [Configure exclusions for Microsoft Defender Antivirus](https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/configure-exclusions-microsoft-defender-antivirus?view=o365-worldwide) for more details.
 
+### Connecting through a proxy
+
+If your network requires outbound traffic to go through an HTTP/HTTPS proxy,
+the Looker server honors the standard proxy environment variables. Set them in
+the MCP server's environment (e.g. in the `env` block of your MCP client config):
+
+```bash
+export HTTPS_PROXY="http://proxy.example.com:3128"
+export HTTP_PROXY="http://proxy.example.com:3128"
+export NO_PROXY="localhost,127.0.0.1"  # Optional, hosts that should bypass the proxy
+```
+
+This applies to both authentication modes (service-account credentials and
+end-user OAuth tokens). TLS verification is unaffected and continues to follow
+`LOOKER_VERIFY_SSL`.
+
 ## Usage
 
 Once configured, the MCP server will automatically provide Looker capabilities to your AI assistant. You can:

--- a/internal/sources/looker/looker.go
+++ b/internal/sources/looker/looker.go
@@ -127,7 +127,17 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 		if r.ClientId == "" || r.ClientSecret == "" {
 			return nil, fmt.Errorf("client_id and client_secret need to be specified")
 		}
-		s.Client = v4.NewLookerSDK(rtl.NewAuthSession(cfg))
+		// The SDK's default auth session uses an http.Transport that does not
+		// honor proxy environment variables, so a custom transport is supplied
+		// to route requests through a proxy (HTTP_PROXY/HTTPS_PROXY/NO_PROXY)
+		// when one is configured. TLS verification continues to follow VerifySsl.
+		saTransport := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: !cfg.VerifySsl,
+			},
+		}
+		s.Client = v4.NewLookerSDK(rtl.NewAuthSessionWithTransport(cfg, saTransport))
 		resp, err := s.Client.Me("", s.ApiSettings)
 		if err != nil {
 			return nil, fmt.Errorf("incorrect settings: %w", err)
@@ -236,8 +246,11 @@ func (s *Source) GetLookerSDK(ctx context.Context, accessToken string) (*v4.Look
 		clientIP, _ := util.ClientIPFromContext(ctx)
 
 		session := rtl.NewAuthSession(*s.LookerApiSettings())
-		// Configure base transport with TLS
+		// Configure base transport with TLS. Proxy is read from the environment
+		// (HTTP_PROXY/HTTPS_PROXY/NO_PROXY) so end-user-token requests can be
+		// routed through a proxy when one is configured.
 		transport := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: !s.LookerApiSettings().VerifySsl,
 			},

--- a/internal/sources/looker/looker_test.go
+++ b/internal/sources/looker/looker_test.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -266,4 +268,108 @@ func TestGetLookerSDKProxyTransport(t *testing.T) {
 	if base.TLSClientConfig == nil || base.TLSClientConfig.InsecureSkipVerify {
 		t.Errorf("expected TLS verification to be enabled when SslVerification is true")
 	}
+}
+
+// TestInitializeServiceAccountProxyTransport verifies that the SDK built for the
+// service-account auth path (UseClientOAuth: "false") is configured with a
+// transport that honors proxy environment variables. Initialize validates the
+// settings by calling Me(), so a local server stands in for the Looker instance,
+// answering the login and current-user requests.
+//
+// As with the end-user-token test, the proxy is asserted structurally rather
+// than via env vars + a live request, because http.ProxyFromEnvironment caches
+// the environment process-wide on first use.
+func TestInitializeServiceAccountProxyTransport(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/login"):
+			if _, err := w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`)); err != nil {
+				t.Errorf("failed to write login response: %v", err)
+			}
+		case strings.HasSuffix(r.URL.Path, "/user"):
+			if _, err := w.Write([]byte(`{"first_name":"Test","last_name":"User"}`)); err != nil {
+				t.Errorf("failed to write user response: %v", err)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	logger, err := toolboxlog.NewStdLogger(io.Discard, io.Discard, "DEBUG")
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	ctx = util.WithLogger(ctx, logger)
+	ctx = util.WithUserAgent(ctx, "test-agent")
+
+	cfg := Config{
+		Name:            "test-looker",
+		Type:            SourceType,
+		BaseURL:         ts.URL,
+		ClientId:        "test-client-id",
+		ClientSecret:    "test-client-secret",
+		UseClientOAuth:  "false",
+		Timeout:         "5s",
+		SslVerification: true,
+	}
+
+	src, err := cfg.Initialize(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to initialize source: %v", err)
+	}
+	lookerSrc, ok := src.(*Source)
+	if !ok {
+		t.Fatalf("source is not of type *looker.Source")
+	}
+	if lookerSrc.Client == nil {
+		t.Fatalf("expected service-account SDK client to be set")
+	}
+
+	authSession, ok := lookerSrc.Client.AuthSession.(*rtl.AuthSession)
+	if !ok {
+		t.Fatalf("SDK session is not *rtl.AuthSession, got %T", lookerSrc.Client.AuthSession)
+	}
+	// The SDK wraps our transport in oauth2.Transport -> rtl.transportWithHeaders,
+	// so walk the exported Base fields down to the underlying *http.Transport.
+	base := baseHTTPTransport(authSession.Client.Transport)
+	if base == nil {
+		t.Fatalf("could not find *http.Transport in client transport chain")
+	}
+	if base.Proxy == nil {
+		t.Errorf("expected base transport Proxy to be set so proxy env vars are honored, got nil")
+	}
+	// VerifySsl is true, so TLS verification should remain enabled.
+	if base.TLSClientConfig == nil || base.TLSClientConfig.InsecureSkipVerify {
+		t.Errorf("expected TLS verification to be enabled when SslVerification is true")
+	}
+}
+
+// baseHTTPTransport walks a chain of RoundTrippers via their exported "Base"
+// field and returns the underlying *http.Transport, or nil if none is found.
+func baseHTTPTransport(rt http.RoundTripper) *http.Transport {
+	for i := 0; i < 10 && rt != nil; i++ {
+		if ht, ok := rt.(*http.Transport); ok {
+			return ht
+		}
+		v := reflect.ValueOf(rt)
+		if v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+		if v.Kind() != reflect.Struct {
+			return nil
+		}
+		f := v.FieldByName("Base")
+		if !f.IsValid() || !f.CanInterface() {
+			return nil
+		}
+		next, ok := f.Interface().(http.RoundTripper)
+		if !ok {
+			return nil
+		}
+		rt = next
+	}
+	return nil
 }

--- a/internal/sources/looker/looker_test.go
+++ b/internal/sources/looker/looker_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package looker_test
+package looker
 
 import (
 	"context"
@@ -25,7 +25,6 @@ import (
 	toolboxlog "github.com/googleapis/mcp-toolbox/internal/log"
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
-	"github.com/googleapis/mcp-toolbox/internal/sources/looker"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/looker-open-source/sdk-codegen/go/rtl"
@@ -48,9 +47,9 @@ func TestParseFromYamlLooker(t *testing.T) {
 			client_secret: sdakl;jgflkasdfkfg
 			`,
 			want: map[string]sources.SourceConfig{
-				"my-looker-instance": looker.Config{
+				"my-looker-instance": Config{
 					Name:               "my-looker-instance",
-					Type:               looker.SourceType,
+					Type:               SourceType,
 					BaseURL:            "http://example.looker.com/",
 					ClientId:           "jasdl;k;tjl",
 					ClientSecret:       "sdakl;jgflkasdfkfg",
@@ -138,7 +137,7 @@ func TestGetLookerSDK_ClientIPPropagation(t *testing.T) {
 	defer ts.Close()
 
 	// 2. Construct looker Config with UseClientOAuth = "true" pointing to the local test server
-	cfg := looker.Config{
+	cfg := Config{
 		Name:            "test-looker",
 		Type:            "looker",
 		BaseURL:         ts.URL,
@@ -162,7 +161,7 @@ func TestGetLookerSDK_ClientIPPropagation(t *testing.T) {
 		t.Fatalf("failed to initialize source: %v", err)
 	}
 
-	lookerSrc, ok := src.(*looker.Source)
+	lookerSrc, ok := src.(*Source)
 	if !ok {
 		t.Fatalf("source is not of type *looker.Source")
 	}
@@ -204,5 +203,67 @@ func TestGetLookerSDK_ClientIPPropagation(t *testing.T) {
 	}
 	if gotAuth := serverReceivedHeaders.Get("Authorization"); gotAuth != "mock-token-123" {
 		t.Errorf("expected Authorization header to be %q, got %q", "mock-token-123", gotAuth)
+	}
+}
+
+// TestGetLookerSDKProxyTransport verifies that the SDK returned for end-user
+// token requests is configured with a transport that honors proxy environment
+// variables (Proxy is wired to http.ProxyFromEnvironment). It reaches into the
+// unexported transportWithAuthHeader, so it lives in the internal test package.
+//
+// Behavior is asserted structurally rather than by setting proxy env vars and
+// issuing a request: http.ProxyFromEnvironment caches the environment the first
+// time it is invoked for the lifetime of the process, which makes env-based
+// proxy assertions order-dependent and flaky.
+func TestGetLookerSDKProxyTransport(t *testing.T) {
+	ctx := context.Background()
+	logger, err := toolboxlog.NewStdLogger(io.Discard, io.Discard, "DEBUG")
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	ctx = util.WithLogger(ctx, logger)
+	ctx = util.WithUserAgent(ctx, "test-agent")
+
+	cfg := Config{
+		Name:            "test-looker",
+		Type:            SourceType,
+		BaseURL:         "https://example.looker.com/",
+		UseClientOAuth:  "true",
+		Timeout:         "5s",
+		SslVerification: true,
+	}
+
+	src, err := cfg.Initialize(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to initialize source: %v", err)
+	}
+	lookerSrc, ok := src.(*Source)
+	if !ok {
+		t.Fatalf("source is not of type *looker.Source")
+	}
+
+	sdk, err := lookerSrc.GetLookerSDK(ctx, "mock-token-123")
+	if err != nil {
+		t.Fatalf("GetLookerSDK failed: %v", err)
+	}
+
+	authSession, ok := sdk.AuthSession.(*rtl.AuthSession)
+	if !ok {
+		t.Fatalf("SDK session is not *rtl.AuthSession")
+	}
+	wrapped, ok := authSession.Client.Transport.(*transportWithAuthHeader)
+	if !ok {
+		t.Fatalf("client transport is not *transportWithAuthHeader, got %T", authSession.Client.Transport)
+	}
+	base, ok := wrapped.Base.(*http.Transport)
+	if !ok {
+		t.Fatalf("base transport is not *http.Transport, got %T", wrapped.Base)
+	}
+	if base.Proxy == nil {
+		t.Errorf("expected base transport Proxy to be set so proxy env vars are honored, got nil")
+	}
+	// VerifySsl is true, so TLS verification should remain enabled.
+	if base.TLSClientConfig == nil || base.TLSClientConfig.InsecureSkipVerify {
+		t.Errorf("expected TLS verification to be enabled when SslVerification is true")
 	}
 }


### PR DESCRIPTION
## Description

Routes Looker SDK HTTP requests through an HTTP/HTTPS proxy when one is configured via the standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` environment variables, so Toolbox can reach a Looker instance from networks that require an egress proxy. Previously these variables were silently ignored because the Looker SDK's default transport does not consult the proxy environment.

What changed:
- Build the service-account auth SDK with a custom transport via `rtl.NewAuthSessionWithTransport(...)`, with `Proxy: http.ProxyFromEnvironment` set (the default `NewAuthSession` does not honor proxy env vars).
- Set `Proxy: http.ProxyFromEnvironment` on the end-user-token transport in `GetLookerSDK`.
- TLS verification is unchanged and continues to follow `SslVerification` / `VerifySsl`, so the change is purely additive — default behavior (no proxy env set) is unaffected.
- Add a unit test verifying the proxy is wired onto the SDK transport while TLS verification still tracks `SslVerification`.
- Document proxy configuration under "Install & Configuration" in `docs/LOOKER_README.md`.

Tests run:
`go test -race -v ./internal/sources/looker -count=1`

## PR Checklist

- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involves a breaking change

Fixes #3447 🦕

🤖 Generated with [Claude Code](https://claude.com/claude-code)