### PR TITLE
feat(tool/cloud-storage): support configurable parameters

### DIFF
--- a/docs/en/integrations/cloud-storage/tools/cloud-storage-create-bucket.md
+++ b/docs/en/integrations/cloud-storage/tools/cloud-storage-create-bucket.md
@@ -3,14 +3,20 @@ title: "cloud-storage-create-bucket"
 type: docs
 weight: 2
 description: >
-  A "cloud-storage-create-bucket" tool creates a Cloud Storage bucket in the configured source project.
+  A "cloud-storage-create-bucket" tool creates a Cloud Storage bucket in a configured or runtime-selected project.
 ---
 
 ## About
 
-A `cloud-storage-create-bucket` tool creates a new Cloud Storage bucket in the
-project configured on the Cloud Storage source. Use it when an agent needs to
-provision a bucket before writing objects or building a data workflow.
+A `cloud-storage-create-bucket` tool creates a new Cloud Storage bucket. By
+default, it creates the bucket in the project configured on the Cloud Storage
+source. You can pass the optional `project` parameter to create buckets in a
+different project that the same credentials can access.
+
+You can also set `project`, `location`, or `uniform_bucket_level_access` in the
+tool configuration. When set, that field is removed from the runtime parameter
+schema and the configured value is always used. Set `project` to an empty string
+to hide the parameter while using the source's configured project.
 
 [gcs-buckets]: https://cloud.google.com/storage/docs/buckets
 
@@ -20,7 +26,7 @@ provision a bucket before writing objects or building a data workflow.
 
 ## Requirements
 
-The Cloud Storage credentials must be able to create buckets in the configured
+The Cloud Storage credentials must be able to create buckets in the target
 project. Bucket names are globally unique and must satisfy Cloud Storage bucket
 naming rules.
 
@@ -29,6 +35,7 @@ naming rules.
 | **parameter** | **type** | **required** | **description** |
 |---------------|:--------:|:------------:|-----------------|
 | bucket | string | true | Name of the Cloud Storage bucket to create. |
+| project | string | false | Project ID to create the bucket in. When empty, the source's configured project is used. |
 | location | string | false | Location for the bucket, e.g. "US", "EU", or "us-central1". Omit to use the Cloud Storage service default. |
 | uniform_bucket_level_access | boolean | false | Whether to enable uniform bucket-level access on the bucket. Defaults to false. |
 
@@ -40,6 +47,17 @@ name: create_bucket
 type: cloud-storage-create-bucket
 source: my-gcs-source
 description: Use this tool to create Cloud Storage buckets.
+```
+
+```yaml
+kind: tool
+name: create_us_bucket
+type: cloud-storage-create-bucket
+source: my-gcs-source
+description: Use this tool to create Cloud Storage buckets in the US location.
+project: ""
+location: US
+uniform_bucket_level_access: true
 ```
 
 ## Output Format
@@ -59,3 +77,6 @@ The tool returns a JSON object with:
 | type | string | true | Must be "cloud-storage-create-bucket". |
 | source | string | true | Name of the Cloud Storage source to create buckets from. |
 | description | string | true | Description of the tool that is passed to the LLM. |
+| project | string | false | Project ID to always use. When set, the runtime `project` parameter is hidden. An empty string uses the source's configured project. |
+| location | string | false | Bucket location to always use. When set, the runtime `location` parameter is hidden. |
+| uniform_bucket_level_access | boolean | false | Uniform bucket-level access setting to always use. When set, the runtime `uniform_bucket_level_access` parameter is hidden. |

--- a/docs/en/integrations/cloud-storage/tools/cloud-storage-get-bucket-iam-policy.md
+++ b/docs/en/integrations/cloud-storage/tools/cloud-storage-get-bucket-iam-policy.md
@@ -12,6 +12,10 @@ A `cloud-storage-get-bucket-iam-policy` tool returns the IAM policy bindings for
 a Cloud Storage bucket. Use it to inspect which principals have roles on a
 bucket without modifying access.
 
+You can set `bucket` in the tool configuration. When set, `bucket` is removed
+from the runtime parameter schema and the configured bucket is always used. A
+configured `bucket` must be a non-empty string.
+
 ## Compatible Sources
 
 {{< compatible-sources >}}
@@ -37,6 +41,15 @@ source: my-gcs-source
 description: Use this tool to inspect IAM bindings for a Cloud Storage bucket.
 ```
 
+```yaml
+kind: tool
+name: get_app_bucket_iam_policy
+type: cloud-storage-get-bucket-iam-policy
+source: my-gcs-source
+description: Use this tool to inspect IAM bindings for the application bucket.
+bucket: my-app-bucket
+```
+
 ## Output Format
 
 The tool returns a JSON object with:
@@ -53,3 +66,4 @@ The tool returns a JSON object with:
 | type | string | true | Must be "cloud-storage-get-bucket-iam-policy". |
 | source | string | true | Name of the Cloud Storage source to get bucket IAM policies from. |
 | description | string | true | Description of the tool that is passed to the LLM. |
+| bucket | string | false | Bucket whose IAM policy is always returned. When set, the runtime `bucket` parameter is hidden. Must not be empty. |

--- a/docs/en/integrations/cloud-storage/tools/cloud-storage-get-bucket-metadata.md
+++ b/docs/en/integrations/cloud-storage/tools/cloud-storage-get-bucket-metadata.md
@@ -14,6 +14,10 @@ class, labels, lifecycle configuration, or uniform bucket-level access status.
 
 The response is the bucket metadata structure returned by the Cloud Storage API.
 
+You can set `bucket` in the tool configuration. When set, `bucket` is removed
+from the runtime parameter schema and the configured bucket is always used. A
+configured `bucket` must be a non-empty string.
+
 ## Compatible Sources
 
 {{< compatible-sources >}}
@@ -39,6 +43,15 @@ source: my-gcs-source
 description: Use this tool to inspect metadata for a Cloud Storage bucket.
 ```
 
+```yaml
+kind: tool
+name: get_app_bucket_metadata
+type: cloud-storage-get-bucket-metadata
+source: my-gcs-source
+description: Use this tool to inspect metadata for the application bucket.
+bucket: my-app-bucket
+```
+
 ## Output Format
 
 The tool returns bucket metadata from the Cloud Storage API, including fields
@@ -52,3 +65,4 @@ such as `Name`, `Location`, `StorageClass`, `Created`, `Labels`,
 | type | string | true | Must be "cloud-storage-get-bucket-metadata". |
 | source | string | true | Name of the Cloud Storage source to get bucket metadata from. |
 | description | string | true | Description of the tool that is passed to the LLM. |
+| bucket | string | false | Bucket to always inspect. When set, the runtime `bucket` parameter is hidden. Must not be empty. |

--- a/docs/en/integrations/cloud-storage/tools/cloud-storage-get-object-metadata.md
+++ b/docs/en/integrations/cloud-storage/tools/cloud-storage-get-object-metadata.md
@@ -15,6 +15,10 @@ or custom metadata without reading the object's content.
 
 The response is the object metadata structure returned by the Cloud Storage API.
 
+You can set `bucket` in the tool configuration. When set, `bucket` is removed
+from the runtime parameter schema and the configured bucket is always used. A
+configured `bucket` must be a non-empty string.
+
 [gcs-objects]: https://cloud.google.com/storage/docs/objects
 
 ## Compatible Sources
@@ -38,6 +42,15 @@ source: my-gcs-source
 description: Use this tool to inspect metadata for a Cloud Storage object.
 ```
 
+```yaml
+kind: tool
+name: get_app_object_metadata
+type: cloud-storage-get-object-metadata
+source: my-gcs-source
+description: Use this tool to inspect metadata for objects in the application bucket.
+bucket: my-app-bucket
+```
+
 ## Output Format
 
 The tool returns object metadata from the Cloud Storage API, including fields
@@ -51,3 +64,4 @@ such as `Name`, `Bucket`, `Size`, `ContentType`, `Updated`, `StorageClass`,
 | type        |  string  |     true     | Must be "cloud-storage-get-object-metadata".                |
 | source      |  string  |     true     | Name of the Cloud Storage source to get object metadata from. |
 | description |  string  |     true     | Description of the tool that is passed to the LLM.          |
+| bucket      |  string  |    false     | Bucket to always inspect objects from. When set, the runtime `bucket` parameter is hidden. Must not be empty. |

--- a/docs/en/integrations/cloud-storage/tools/cloud-storage-list-buckets.md
+++ b/docs/en/integrations/cloud-storage/tools/cloud-storage-list-buckets.md
@@ -13,6 +13,11 @@ project. By default, it uses the project configured on the source. You can pass
 the optional `project` parameter to list buckets in a different project that
 the same credentials can access.
 
+You can also set `project` or `prefix` in the tool configuration. When set,
+that field is removed from the runtime parameter schema and the configured value
+is always used. Set `project` to an empty string to hide the parameter while
+using the source's configured project.
+
 The response is a JSON object with `buckets` (bucket metadata returned by the
 Cloud Storage API) and `nextPageToken` (empty when there are no more pages).
 
@@ -41,6 +46,16 @@ source: my-gcs-source
 description: Use this tool to list Cloud Storage buckets in the project.
 ```
 
+```yaml
+kind: tool
+name: list_log_buckets
+type: cloud-storage-list-buckets
+source: my-gcs-source
+description: Use this tool to list log buckets in the configured project.
+project: ""
+prefix: logs-
+```
+
 ## Output Format
 
 The tool returns a JSON object with:
@@ -57,3 +72,5 @@ The tool returns a JSON object with:
 | type        |  string  |     true     | Must be "cloud-storage-list-buckets".                   |
 | source      |  string  |     true     | Name of the Cloud Storage source to list buckets from.  |
 | description |  string  |     true     | Description of the tool that is passed to the LLM.      |
+| project     |  string  |    false     | Project ID to always use. When set, the runtime `project` parameter is hidden. An empty string uses the source's configured project. |
+| prefix      |  string  |    false     | Bucket name prefix to always use. When set, the runtime `prefix` parameter is hidden. |

--- a/docs/en/integrations/cloud-storage/tools/cloud-storage-list-objects.md
+++ b/docs/en/integrations/cloud-storage/tools/cloud-storage-list-objects.md
@@ -21,6 +21,10 @@ returned by the Cloud Storage API — fields such as `Name`, `Size`, `ContentTyp
 `Updated`, `StorageClass`, `MD5`, etc.), `prefixes` (the common prefixes when
 `delimiter` is set), and `nextPageToken` (empty when there are no more pages).
 
+You can set `bucket`, `prefix`, or `delimiter` in the tool configuration. When
+set, that field is removed from the runtime parameter schema and the configured
+value is always used. A configured `bucket` must be a non-empty string.
+
 [gcs-buckets]: https://cloud.google.com/storage/docs/buckets
 
 ## Compatible Sources
@@ -47,6 +51,17 @@ source: my-gcs-source
 description: Use this tool to list objects in a Cloud Storage bucket.
 ```
 
+```yaml
+kind: tool
+name: list_log_objects
+type: cloud-storage-list-objects
+source: my-gcs-source
+description: Use this tool to list log objects in a Cloud Storage bucket.
+bucket: my-log-bucket
+prefix: logs/
+delimiter: /
+```
+
 ## Reference
 
 | **field**   | **type** | **required** | **description**                                         |
@@ -54,3 +69,6 @@ description: Use this tool to list objects in a Cloud Storage bucket.
 | type        |  string  |     true     | Must be "cloud-storage-list-objects".                   |
 | source      |  string  |     true     | Name of the Cloud Storage source to list objects from.  |
 | description |  string  |     true     | Description of the tool that is passed to the LLM.      |
+| bucket      |  string  |    false     | Bucket to always list from. When set, the runtime `bucket` parameter is hidden. Must not be empty. |
+| prefix      |  string  |    false     | Object prefix to always use. When set, the runtime `prefix` parameter is hidden. |
+| delimiter   |  string  |    false     | Delimiter to always use. When set, the runtime `delimiter` parameter is hidden. |

--- a/docs/en/integrations/cloud-storage/tools/cloud-storage-read-object.md
+++ b/docs/en/integrations/cloud-storage/tools/cloud-storage-read-object.md
@@ -25,6 +25,10 @@ This tool is intended for small-to-medium textual content an LLM can process
 directly. For bulk downloads of large files to the local filesystem, use
 `cloud-storage-download-object`.
 
+You can set `bucket` in the tool configuration. When set, `bucket` is removed
+from the runtime parameter schema and the configured bucket is always used. A
+configured `bucket` must be a non-empty string.
+
 [gcs-objects]: https://cloud.google.com/storage/docs/objects
 
 ## Compatible Sources
@@ -49,6 +53,15 @@ source: my-gcs-source
 description: Use this tool to read the content of a Cloud Storage object.
 ```
 
+```yaml
+kind: tool
+name: read_app_object
+type: cloud-storage-read-object
+source: my-gcs-source
+description: Use this tool to read text objects from the application bucket.
+bucket: my-app-bucket
+```
+
 ## Reference
 
 | **field**   | **type** | **required** | **description**                                         |
@@ -56,3 +69,4 @@ description: Use this tool to read the content of a Cloud Storage object.
 | type        |  string  |     true     | Must be "cloud-storage-read-object".                    |
 | source      |  string  |     true     | Name of the Cloud Storage source to read the object from. |
 | description |  string  |     true     | Description of the tool that is passed to the LLM.      |
+| bucket      |  string  |    false     | Bucket to always read from. When set, the runtime `bucket` parameter is hidden. Must not be empty. |

--- a/internal/sources/cloudstorage/cloudstorage.go
+++ b/internal/sources/cloudstorage/cloudstorage.go
@@ -273,12 +273,15 @@ func (s *Source) ListBuckets(ctx context.Context, project, prefix string, maxRes
 	}, nil
 }
 
-// CreateBucket creates a Cloud Storage bucket in the source project and returns
-// its freshly-read metadata. When location is empty, Cloud Storage applies its
-// service default.
-func (s *Source) CreateBucket(ctx context.Context, bucket, location string, uniformBucketLevelAccess bool) (map[string]any, error) {
+// CreateBucket creates a Cloud Storage bucket and returns its freshly-read
+// metadata. When project is empty, the source's configured project is used.
+// When location is empty, Cloud Storage applies its service default.
+func (s *Source) CreateBucket(ctx context.Context, bucket, project, location string, uniformBucketLevelAccess bool) (map[string]any, error) {
 	if err := s.validateBucket(bucket); err != nil {
 		return nil, err
+	}
+	if project == "" {
+		project = s.Project
 	}
 	attrs := &storage.BucketAttrs{Location: location}
 	if uniformBucketLevelAccess {
@@ -286,8 +289,8 @@ func (s *Source) CreateBucket(ctx context.Context, bucket, location string, unif
 	}
 
 	bkt := s.client.Bucket(bucket)
-	if err := bkt.Create(ctx, s.Project, attrs); err != nil {
-		return nil, fmt.Errorf("failed to create bucket %q in project %q: %w", bucket, s.Project, err)
+	if err := bkt.Create(ctx, project, attrs); err != nil {
+		return nil, fmt.Errorf("failed to create bucket %q in project %q: %w", bucket, project, err)
 	}
 
 	createdAttrs, err := bkt.Attrs(ctx)

--- a/internal/tools/cloudstorage/cloudstoragecommon/params.go
+++ b/internal/tools/cloudstorage/cloudstoragecommon/params.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudstoragecommon
+
+func ResolveString(cfgVal *string, params map[string]any, key string) string {
+	if cfgVal != nil {
+		return *cfgVal
+	}
+	val, _ := params[key].(string)
+	return val
+}
+
+func ResolveBool(cfgVal *bool, params map[string]any, key string) bool {
+	if cfgVal != nil {
+		return *cfgVal
+	}
+	val, _ := params[key].(bool)
+	return val
+}

--- a/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
+++ b/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
@@ -29,6 +29,7 @@ import (
 const resourceType string = "cloud-storage-create-bucket"
 
 const (
+	projectKey                  = "project"
 	bucketKey                   = "bucket"
 	locationKey                 = "location"
 	uniformBucketLevelAccessKey = "uniform_bucket_level_access"
@@ -49,14 +50,17 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
-	CreateBucket(ctx context.Context, bucket, location string, uniformBucketLevelAccess bool) (map[string]any, error)
+	CreateBucket(ctx context.Context, bucket, project, location string, uniformBucketLevelAccess bool) (map[string]any, error)
 }
 
 type Config struct {
-	tools.ConfigBase `yaml:",inline"`
-	Type             string                 `yaml:"type" validate:"required"`
-	Source           string                 `yaml:"source" validate:"required"`
-	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	tools.ConfigBase         `yaml:",inline"`
+	Type                     string                 `yaml:"type" validate:"required"`
+	Source                   string                 `yaml:"source" validate:"required"`
+	Annotations              *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Project                  *string                `yaml:"project,omitempty"`
+	Location                 *string                `yaml:"location,omitempty"`
+	UniformBucketLevelAccess *bool                  `yaml:"uniform_bucket_level_access,omitempty"`
 }
 
 var _ tools.ToolConfig = Config{}
@@ -71,9 +75,16 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	}
 
 	bucketParam := parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket to create.")
-	locationParam := parameters.NewStringParameter(locationKey, "Location for the bucket, e.g. 'US', 'EU', or 'us-central1'. Omit to use the Cloud Storage service default.", parameters.WithStringRequired(false))
-	uniformAccessParam := parameters.NewBooleanParameter(uniformBucketLevelAccessKey, "Whether to enable uniform bucket-level access on the bucket.", parameters.WithBooleanDefault(false))
-	allParameters := parameters.Parameters{bucketParam, locationParam, uniformAccessParam}
+	allParameters := parameters.Parameters{bucketParam}
+	if cfg.Project == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(projectKey, "Project ID to create the bucket in. When empty, the source's configured project is used.", parameters.WithStringDefault("")))
+	}
+	if cfg.Location == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(locationKey, "Location for the bucket, e.g. 'US', 'EU', or 'us-central1'. Omit to use the Cloud Storage service default.", parameters.WithStringRequired(false)))
+	}
+	if cfg.UniformBucketLevelAccess == nil {
+		allParameters = append(allParameters, parameters.NewBooleanParameter(uniformBucketLevelAccessKey, "Whether to enable uniform bucket-level access on the bucket.", parameters.WithBooleanDefault(false)))
+	}
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
@@ -106,10 +117,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	if !ok || bucket == "" {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a non-empty string", bucketKey), nil)
 	}
-	location, _ := mapParams[locationKey].(string)
-	uniformBucketLevelAccess, _ := mapParams[uniformBucketLevelAccessKey].(bool)
+	project := cloudstoragecommon.ResolveString(t.Cfg.Project, mapParams, projectKey)
+	location := cloudstoragecommon.ResolveString(t.Cfg.Location, mapParams, locationKey)
+	uniformBucketLevelAccess := cloudstoragecommon.ResolveBool(t.Cfg.UniformBucketLevelAccess, mapParams, uniformBucketLevelAccessKey)
 
-	resp, err := source.CreateBucket(ctx, bucket, location, uniformBucketLevelAccess)
+	resp, err := source.CreateBucket(ctx, bucket, project, location, uniformBucketLevelAccess)
 	if err != nil {
 		return nil, cloudstoragecommon.ProcessGCSError(err)
 	}

--- a/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket_test.go
+++ b/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket_test.go
@@ -83,6 +83,33 @@ func TestParseFromYamlCloudStorageCreateBucket(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with configurable parameters",
+			in: `
+			kind: tool
+			name: configured_create_bucket
+			type: cloud-storage-create-bucket
+			source: prod-gcs
+			description: Create configured bucket
+			project: baked-project
+			location: US
+			uniform_bucket_level_access: true
+			`,
+			want: server.ToolConfigs{
+				"configured_create_bucket": cloudstoragecreatebucket.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "configured_create_bucket",
+						Description:  "Create configured bucket",
+						AuthRequired: []string{},
+					},
+					Type:                     "cloud-storage-create-bucket",
+					Source:                   "prod-gcs",
+					Project:                  strPtr("baked-project"),
+					Location:                 strPtr("US"),
+					UniformBucketLevelAccess: boolPtr(true),
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -97,17 +124,27 @@ func TestParseFromYamlCloudStorageCreateBucket(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 type mockSource struct {
 	sources.Source
 	called                      bool
 	gotBucket                   string
+	gotProject                  string
 	gotLocation                 string
 	gotUniformBucketLevelAccess bool
 }
 
-func (m *mockSource) CreateBucket(ctx context.Context, bucket, location string, uniformBucketLevelAccess bool) (map[string]any, error) {
+func (m *mockSource) CreateBucket(ctx context.Context, bucket, project, location string, uniformBucketLevelAccess bool) (map[string]any, error) {
 	m.called = true
 	m.gotBucket = bucket
+	m.gotProject = project
 	m.gotLocation = location
 	m.gotUniformBucketLevelAccess = uniformBucketLevelAccess
 	return map[string]any{"bucket": bucket, "created": true}, nil
@@ -143,17 +180,19 @@ func TestInvokeValidationAndForwarding(t *testing.T) {
 	tcs := []struct {
 		desc        string
 		bucket      any
+		project     any
 		location    any
 		uniform     any
 		wantErr     bool
 		wantCalled  bool
 		wantBucket  string
+		wantProject string
 		wantLoc     string
 		wantUniform bool
 		wantSubstr  string
 	}{
 		{desc: "missing bucket", bucket: "", location: "US", uniform: false, wantErr: true, wantSubstr: "bucket"},
-		{desc: "happy path", bucket: "b", location: "EU", uniform: true, wantCalled: true, wantBucket: "b", wantLoc: "EU", wantUniform: true},
+		{desc: "happy path", bucket: "b", project: "override-project", location: "EU", uniform: true, wantCalled: true, wantBucket: "b", wantProject: "override-project", wantLoc: "EU", wantUniform: true},
 		{desc: "omitted location", bucket: "b", uniform: false, wantCalled: true, wantBucket: "b"},
 	}
 	for _, tc := range tcs {
@@ -163,6 +202,7 @@ func TestInvokeValidationAndForwarding(t *testing.T) {
 			resourceMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{
 				{Name: "bucket", Value: tc.bucket},
+				{Name: "project", Value: tc.project},
 				{Name: "uniform_bucket_level_access", Value: tc.uniform},
 			}
 			if tc.location != nil {
@@ -190,9 +230,92 @@ func TestInvokeValidationAndForwarding(t *testing.T) {
 			if src.called != tc.wantCalled {
 				t.Errorf("called = %v, want %v", src.called, tc.wantCalled)
 			}
-			if src.gotBucket != tc.wantBucket || src.gotLocation != tc.wantLoc || src.gotUniformBucketLevelAccess != tc.wantUniform {
-				t.Errorf("forwarded params = (%q, %q, %v)", src.gotBucket, src.gotLocation, src.gotUniformBucketLevelAccess)
+			if src.gotBucket != tc.wantBucket || src.gotProject != tc.wantProject || src.gotLocation != tc.wantLoc || src.gotUniformBucketLevelAccess != tc.wantUniform {
+				t.Errorf("forwarded params = (%q, %q, %q, %v)", src.gotBucket, src.gotProject, src.gotLocation, src.gotUniformBucketLevelAccess)
 			}
 		})
 	}
+}
+
+func TestConfiguredParametersHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragecreatebucket.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "create_bucket_tool",
+			Description: "Create bucket",
+		},
+		Type:                     "cloud-storage-create-bucket",
+		Source:                   "my-gcs",
+		Project:                  strPtr("baked-project"),
+		Location:                 strPtr("US"),
+		UniformBucketLevelAccess: boolPtr(true),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+
+	src := &mockSource{}
+	params := parameters.ParamValues{{Name: "bucket", Value: "b"}}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotProject != "baked-project" || src.gotLocation != "US" || !src.gotUniformBucketLevelAccess {
+		t.Fatalf("forwarded project/location/uniform = %q/%q/%v, want baked-project/US/true", src.gotProject, src.gotLocation, src.gotUniformBucketLevelAccess)
+	}
+}
+
+func TestUnsetParametersRemainVisible(t *testing.T) {
+	tool := initTool(t)
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket", "project", "location", "uniform_bucket_level_access"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmptyConfiguredProjectHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragecreatebucket.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "create_bucket_tool",
+			Description: "Create bucket",
+		},
+		Type:    "cloud-storage-create-bucket",
+		Source:  "my-gcs",
+		Project: strPtr(""),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket", "location", "uniform_bucket_level_access"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+
+	src := &mockSource{}
+	params := parameters.ParamValues{
+		{Name: "bucket", Value: "b"},
+		{Name: "location", Value: ""},
+		{Name: "uniform_bucket_level_access", Value: false},
+	}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotProject != "" {
+		t.Fatalf("project forwarded = %q, want empty source fallback marker", src.gotProject)
+	}
+}
+
+func manifestParamNames(params []parameters.ParameterManifest) []string {
+	names := make([]string, 0, len(params))
+	for _, p := range params {
+		names = append(names, p.Name)
+	}
+	return names
 }

--- a/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
@@ -53,6 +53,7 @@ type Config struct {
 	Type             string                 `yaml:"type" validate:"required"`
 	Source           string                 `yaml:"source" validate:"required"`
 	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Bucket           *string                `yaml:"bucket,omitempty"`
 }
 
 var _ tools.ToolConfig = Config{}
@@ -65,9 +66,14 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}
+	if cfg.Bucket != nil && *cfg.Bucket == "" {
+		return nil, fmt.Errorf("bucket cannot be empty for tool %q", cfg.Name)
+	}
 
-	bucketParam := parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket whose IAM policy should be returned.")
-	allParameters := parameters.Parameters{bucketParam}
+	allParameters := parameters.Parameters{}
+	if cfg.Bucket == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket whose IAM policy should be returned."))
+	}
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
@@ -96,8 +102,8 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	mapParams := params.AsMap()
-	bucket, ok := mapParams[bucketKey].(string)
-	if !ok || bucket == "" {
+	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
+	if bucket == "" {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a non-empty string", bucketKey), nil)
 	}
 

--- a/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy_test.go
@@ -83,6 +83,29 @@ func TestParseFromYamlCloudStorageGetBucketIAMPolicy(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with configurable bucket",
+			in: `
+			kind: tool
+			name: configured_bucket_iam
+			type: cloud-storage-get-bucket-iam-policy
+			source: prod-gcs
+			description: Get configured bucket IAM policy
+			bucket: baked-bucket
+			`,
+			want: server.ToolConfigs{
+				"configured_bucket_iam": cloudstoragegetbucketiampolicy.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "configured_bucket_iam",
+						Description:  "Get configured bucket IAM policy",
+						AuthRequired: []string{},
+					},
+					Type:   "cloud-storage-get-bucket-iam-policy",
+					Source: "prod-gcs",
+					Bucket: strPtr("baked-bucket"),
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -95,6 +118,10 @@ func TestParseFromYamlCloudStorageGetBucketIAMPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func strPtr(s string) *string {
+	return &s
 }
 
 type mockSource struct {
@@ -171,4 +198,75 @@ func TestInvokeValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragegetbucketiampolicy.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "bucket_iam_tool",
+			Description: "Get bucket IAM policy",
+		},
+		Type:   "cloud-storage-get-bucket-iam-policy",
+		Source: "my-gcs",
+		Bucket: strPtr("baked-bucket"),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	if len(gotNames) != 0 {
+		t.Fatalf("manifest parameters = %v, want none", gotNames)
+	}
+
+	src := &mockSource{}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, nil, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotBucket != "baked-bucket" {
+		t.Fatalf("bucket forwarded = %q, want baked-bucket", src.gotBucket)
+	}
+}
+
+func TestUnsetBucketRemainsVisible(t *testing.T) {
+	cfg := cloudstoragegetbucketiampolicy.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "bucket_iam_tool",
+			Description: "Get bucket IAM policy",
+		},
+		Type:   "cloud-storage-get-bucket-iam-policy",
+		Source: "my-gcs",
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmptyConfiguredBucketRejected(t *testing.T) {
+	cfg := cloudstoragegetbucketiampolicy.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "bucket_iam_tool",
+			Description: "Get bucket IAM policy",
+		},
+		Type:   "cloud-storage-get-bucket-iam-policy",
+		Source: "my-gcs",
+		Bucket: strPtr(""),
+	}
+	if _, err := cfg.Initialize(context.Background()); err == nil || !strings.Contains(err.Error(), "bucket") {
+		t.Fatalf("Initialize() error = %v, want bucket error", err)
+	}
+}
+
+func manifestParamNames(params []parameters.ParameterManifest) []string {
+	names := make([]string, 0, len(params))
+	for _, p := range params {
+		names = append(names, p.Name)
+	}
+	return names
 }

--- a/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
@@ -54,6 +54,7 @@ type Config struct {
 	Type             string                 `yaml:"type" validate:"required"`
 	Source           string                 `yaml:"source" validate:"required"`
 	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Bucket           *string                `yaml:"bucket,omitempty"`
 }
 
 var _ tools.ToolConfig = Config{}
@@ -66,9 +67,14 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}
+	if cfg.Bucket != nil && *cfg.Bucket == "" {
+		return nil, fmt.Errorf("bucket cannot be empty for tool %q", cfg.Name)
+	}
 
-	bucketParam := parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket to inspect.")
-	allParameters := parameters.Parameters{bucketParam}
+	allParameters := parameters.Parameters{}
+	if cfg.Bucket == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket to inspect."))
+	}
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
@@ -97,8 +103,8 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	mapParams := params.AsMap()
-	bucket, ok := mapParams[bucketKey].(string)
-	if !ok || bucket == "" {
+	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
+	if bucket == "" {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a non-empty string", bucketKey), nil)
 	}
 

--- a/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata_test.go
@@ -84,6 +84,29 @@ func TestParseFromYamlCloudStorageGetBucketMetadata(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with configurable bucket",
+			in: `
+			kind: tool
+			name: configured_bucket_metadata
+			type: cloud-storage-get-bucket-metadata
+			source: prod-gcs
+			description: Get configured bucket metadata
+			bucket: baked-bucket
+			`,
+			want: server.ToolConfigs{
+				"configured_bucket_metadata": cloudstoragegetbucketmetadata.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "configured_bucket_metadata",
+						Description:  "Get configured bucket metadata",
+						AuthRequired: []string{},
+					},
+					Type:   "cloud-storage-get-bucket-metadata",
+					Source: "prod-gcs",
+					Bucket: strPtr("baked-bucket"),
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -96,6 +119,10 @@ func TestParseFromYamlCloudStorageGetBucketMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func strPtr(s string) *string {
+	return &s
 }
 
 type mockSource struct {
@@ -172,4 +199,75 @@ func TestInvokeValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragegetbucketmetadata.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "bucket_metadata_tool",
+			Description: "Get bucket metadata",
+		},
+		Type:   "cloud-storage-get-bucket-metadata",
+		Source: "my-gcs",
+		Bucket: strPtr("baked-bucket"),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	if len(gotNames) != 0 {
+		t.Fatalf("manifest parameters = %v, want none", gotNames)
+	}
+
+	src := &mockSource{}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, nil, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotBucket != "baked-bucket" {
+		t.Fatalf("bucket forwarded = %q, want baked-bucket", src.gotBucket)
+	}
+}
+
+func TestUnsetBucketRemainsVisible(t *testing.T) {
+	cfg := cloudstoragegetbucketmetadata.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "bucket_metadata_tool",
+			Description: "Get bucket metadata",
+		},
+		Type:   "cloud-storage-get-bucket-metadata",
+		Source: "my-gcs",
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmptyConfiguredBucketRejected(t *testing.T) {
+	cfg := cloudstoragegetbucketmetadata.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "bucket_metadata_tool",
+			Description: "Get bucket metadata",
+		},
+		Type:   "cloud-storage-get-bucket-metadata",
+		Source: "my-gcs",
+		Bucket: strPtr(""),
+	}
+	if _, err := cfg.Initialize(context.Background()); err == nil || !strings.Contains(err.Error(), "bucket") {
+		t.Fatalf("Initialize() error = %v, want bucket error", err)
+	}
+}
+
+func manifestParamNames(params []parameters.ParameterManifest) []string {
+	names := make([]string, 0, len(params))
+	for _, p := range params {
+		names = append(names, p.Name)
+	}
+	return names
 }

--- a/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
@@ -57,6 +57,7 @@ type Config struct {
 	Type             string                 `yaml:"type" validate:"required"`
 	Source           string                 `yaml:"source" validate:"required"`
 	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Bucket           *string                `yaml:"bucket,omitempty"`
 }
 
 // validate interface
@@ -70,10 +71,16 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}
+	if cfg.Bucket != nil && *cfg.Bucket == "" {
+		return nil, fmt.Errorf("bucket cannot be empty for tool %q", cfg.Name)
+	}
 
-	bucketParam := parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket containing the object.")
 	objectParam := parameters.NewStringParameter(objectKey, "Full object name (path) within the bucket, e.g. 'path/to/file.txt'.")
-	allParameters := parameters.Parameters{bucketParam, objectParam}
+	allParameters := parameters.Parameters{}
+	if cfg.Bucket == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket containing the object."))
+	}
+	allParameters = append(allParameters, objectParam)
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
@@ -103,8 +110,8 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	mapParams := params.AsMap()
-	bucket, ok := mapParams[bucketKey].(string)
-	if !ok || bucket == "" {
+	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
+	if bucket == "" {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a non-empty string", bucketKey), nil)
 	}
 	object, ok := mapParams[objectKey].(string)

--- a/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata_test.go
@@ -84,6 +84,29 @@ func TestParseFromYamlCloudStorageGetObjectMetadata(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with configurable bucket",
+			in: `
+			kind: tool
+			name: configured_metadata
+			type: cloud-storage-get-object-metadata
+			source: prod-gcs
+			description: Get configured metadata
+			bucket: baked-bucket
+			`,
+			want: server.ToolConfigs{
+				"configured_metadata": cloudstoragegetobjectmetadata.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "configured_metadata",
+						Description:  "Get configured metadata",
+						AuthRequired: []string{},
+					},
+					Type:   "cloud-storage-get-object-metadata",
+					Source: "prod-gcs",
+					Bucket: strPtr("baked-bucket"),
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -98,13 +121,21 @@ func TestParseFromYamlCloudStorageGetObjectMetadata(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
 type mockSource struct {
 	sources.Source
-	called bool
+	called    bool
+	gotBucket string
+	gotObject string
 }
 
 func (m *mockSource) GetObjectMetadata(ctx context.Context, bucket, object string) (*storage.ObjectAttrs, error) {
 	m.called = true
+	m.gotBucket = bucket
+	m.gotObject = object
 	return &storage.ObjectAttrs{Bucket: bucket, Name: object, ContentType: "text/plain", Size: 11}, nil
 }
 
@@ -175,4 +206,77 @@ func TestInvokeValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragegetobjectmetadata.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "metadata_tool",
+			Description: "Get object metadata",
+		},
+		Type:   "cloud-storage-get-object-metadata",
+		Source: "my-gcs",
+		Bucket: strPtr("baked-bucket"),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"object"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+
+	src := &mockSource{}
+	params := parameters.ParamValues{{Name: "object", Value: "o"}}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotBucket != "baked-bucket" || src.gotObject != "o" {
+		t.Fatalf("forwarded bucket/object = %q/%q, want baked-bucket/o", src.gotBucket, src.gotObject)
+	}
+}
+
+func TestUnsetBucketRemainsVisible(t *testing.T) {
+	cfg := cloudstoragegetobjectmetadata.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "metadata_tool",
+			Description: "Get object metadata",
+		},
+		Type:   "cloud-storage-get-object-metadata",
+		Source: "my-gcs",
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket", "object"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmptyConfiguredBucketRejected(t *testing.T) {
+	cfg := cloudstoragegetobjectmetadata.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "metadata_tool",
+			Description: "Get object metadata",
+		},
+		Type:   "cloud-storage-get-object-metadata",
+		Source: "my-gcs",
+		Bucket: strPtr(""),
+	}
+	if _, err := cfg.Initialize(context.Background()); err == nil || !strings.Contains(err.Error(), "bucket") {
+		t.Fatalf("Initialize() error = %v, want bucket error", err)
+	}
+}
+
+func manifestParamNames(params []parameters.ParameterManifest) []string {
+	names := make([]string, 0, len(params))
+	for _, p := range params {
+		names = append(names, p.Name)
+	}
+	return names
 }

--- a/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
+++ b/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
@@ -62,6 +62,8 @@ type Config struct {
 	Type             string                 `yaml:"type" validate:"required"`
 	Source           string                 `yaml:"source" validate:"required"`
 	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Project          *string                `yaml:"project,omitempty"`
+	Prefix           *string                `yaml:"prefix,omitempty"`
 }
 
 // validate interface
@@ -76,11 +78,16 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}
 
-	projectParam := parameters.NewStringParameter(projectKey, "Project ID to list buckets in. When empty, the source's configured project is used.", parameters.WithStringDefault(""))
-	prefixParam := parameters.NewStringParameter(prefixKey, "Filter results to buckets whose names begin with this prefix.", parameters.WithStringDefault(""))
 	maxResultsParam := parameters.NewIntParameter(maxResultsKey, "Maximum number of buckets to return per page. A value of 0 uses the API default (1000); negative values and values above 1000 are rejected.", parameters.WithIntDefault(0))
 	pageTokenParam := parameters.NewStringParameter(pageTokenKey, "A previously-returned page token for retrieving the next page of results.", parameters.WithStringDefault(""))
-	allParameters := parameters.Parameters{projectParam, prefixParam, maxResultsParam, pageTokenParam}
+	allParameters := parameters.Parameters{}
+	if cfg.Project == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(projectKey, "Project ID to list buckets in. When empty, the source's configured project is used.", parameters.WithStringDefault("")))
+	}
+	if cfg.Prefix == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(prefixKey, "Filter results to buckets whose names begin with this prefix.", parameters.WithStringDefault("")))
+	}
+	allParameters = append(allParameters, maxResultsParam, pageTokenParam)
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
@@ -110,8 +117,8 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	mapParams := params.AsMap()
-	project, _ := mapParams[projectKey].(string)
-	prefix, _ := mapParams[prefixKey].(string)
+	project := cloudstoragecommon.ResolveString(t.Cfg.Project, mapParams, projectKey)
+	prefix := cloudstoragecommon.ResolveString(t.Cfg.Prefix, mapParams, prefixKey)
 	pageToken, _ := mapParams[pageTokenKey].(string)
 	maxResults, _ := mapParams[maxResultsKey].(int)
 	if maxResults < 0 {

--- a/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets_test.go
+++ b/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets_test.go
@@ -83,6 +83,31 @@ func TestParseFromYamlCloudStorageListBuckets(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with configurable parameters",
+			in: `
+			kind: tool
+			name: configured_list_buckets
+			type: cloud-storage-list-buckets
+			source: prod-gcs
+			description: List configured buckets
+			project: baked-project
+			prefix: logs-
+			`,
+			want: server.ToolConfigs{
+				"configured_list_buckets": cloudstoragelistbuckets.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "configured_list_buckets",
+						Description:  "List configured buckets",
+						AuthRequired: []string{},
+					},
+					Type:    "cloud-storage-list-buckets",
+					Source:  "prod-gcs",
+					Project: strPtr("baked-project"),
+					Prefix:  strPtr("logs-"),
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -97,15 +122,21 @@ func TestParseFromYamlCloudStorageListBuckets(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
 type mockSource struct {
 	sources.Source
 	gotProject string
+	gotPrefix  string
 	listCalled bool
 }
 
 func (m *mockSource) ListBuckets(ctx context.Context, project, prefix string, maxResults int, pageToken string) (map[string]any, error) {
 	m.listCalled = true
 	m.gotProject = project
+	m.gotPrefix = prefix
 	return map[string]any{"buckets": []any{}, "nextPageToken": ""}, nil
 }
 
@@ -208,4 +239,90 @@ func TestInvokeProjectPassthrough(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfiguredParametersHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragelistbuckets.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "list_buckets_tool",
+			Description: "List buckets",
+		},
+		Type:    "cloud-storage-list-buckets",
+		Source:  "my-gcs",
+		Project: strPtr("baked-project"),
+		Prefix:  strPtr("logs-"),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"max_results", "page_token"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+
+	src := &mockSource{}
+	params := parameters.ParamValues{
+		{Name: "max_results", Value: 0},
+		{Name: "page_token", Value: ""},
+	}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotProject != "baked-project" || src.gotPrefix != "logs-" {
+		t.Fatalf("forwarded project/prefix = %q/%q, want baked-project/logs-", src.gotProject, src.gotPrefix)
+	}
+}
+
+func TestUnsetParametersRemainVisible(t *testing.T) {
+	tool := initTool(t)
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"project", "prefix", "max_results", "page_token"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmptyConfiguredProjectHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragelistbuckets.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "list_buckets_tool",
+			Description: "List buckets",
+		},
+		Type:    "cloud-storage-list-buckets",
+		Source:  "my-gcs",
+		Project: strPtr(""),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"prefix", "max_results", "page_token"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+
+	src := &mockSource{}
+	params := parameters.ParamValues{
+		{Name: "prefix", Value: ""},
+		{Name: "max_results", Value: 0},
+		{Name: "page_token", Value: ""},
+	}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotProject != "" {
+		t.Fatalf("project forwarded = %q, want empty source fallback marker", src.gotProject)
+	}
+}
+
+func manifestParamNames(params []parameters.ParameterManifest) []string {
+	names := make([]string, 0, len(params))
+	for _, p := range params {
+		names = append(names, p.Name)
+	}
+	return names
 }

--- a/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
+++ b/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
@@ -63,6 +63,9 @@ type Config struct {
 	Type             string                 `yaml:"type" validate:"required"`
 	Source           string                 `yaml:"source" validate:"required"`
 	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Bucket           *string                `yaml:"bucket,omitempty"`
+	Prefix           *string                `yaml:"prefix,omitempty"`
+	Delimiter        *string                `yaml:"delimiter,omitempty"`
 }
 
 // validate interface
@@ -76,13 +79,23 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}
+	if cfg.Bucket != nil && *cfg.Bucket == "" {
+		return nil, fmt.Errorf("bucket cannot be empty for tool %q", cfg.Name)
+	}
 
-	bucketParam := parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket to list objects from.")
-	prefixParam := parameters.NewStringParameter(prefixKey, "Filter results to objects whose names begin with this prefix.", parameters.WithStringDefault(""))
-	delimiterParam := parameters.NewStringParameter(delimiterKey, "Delimiter used to group object names (typically '/'). When set, common prefixes are returned as 'prefixes'.", parameters.WithStringDefault(""))
 	maxResultsParam := parameters.NewIntParameter(maxResultsKey, "Maximum number of objects to return per page. A value of 0 uses the API default (1000); negative values and values above 1000 are rejected.", parameters.WithIntDefault(0))
 	pageTokenParam := parameters.NewStringParameter(pageTokenKey, "A previously-returned page token for retrieving the next page of results.", parameters.WithStringDefault(""))
-	allParameters := parameters.Parameters{bucketParam, prefixParam, delimiterParam, maxResultsParam, pageTokenParam}
+	allParameters := parameters.Parameters{}
+	if cfg.Bucket == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket to list objects from."))
+	}
+	if cfg.Prefix == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(prefixKey, "Filter results to objects whose names begin with this prefix.", parameters.WithStringDefault("")))
+	}
+	if cfg.Delimiter == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(delimiterKey, "Delimiter used to group object names (typically '/'). When set, common prefixes are returned as 'prefixes'.", parameters.WithStringDefault("")))
+	}
+	allParameters = append(allParameters, maxResultsParam, pageTokenParam)
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
@@ -112,12 +125,12 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	mapParams := params.AsMap()
-	bucket, ok := mapParams[bucketKey].(string)
-	if !ok || bucket == "" {
+	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
+	if bucket == "" {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a non-empty string", bucketKey), nil)
 	}
-	prefix, _ := mapParams[prefixKey].(string)
-	delimiter, _ := mapParams[delimiterKey].(string)
+	prefix := cloudstoragecommon.ResolveString(t.Cfg.Prefix, mapParams, prefixKey)
+	delimiter := cloudstoragecommon.ResolveString(t.Cfg.Delimiter, mapParams, delimiterKey)
 	pageToken, _ := mapParams[pageTokenKey].(string)
 	maxResults, _ := mapParams[maxResultsKey].(int)
 	if maxResults < 0 {

--- a/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects_test.go
+++ b/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects_test.go
@@ -84,6 +84,33 @@ func TestParseFromYamlCloudStorageListObjects(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with configurable parameters",
+			in: `
+			kind: tool
+			name: configured_list_objects
+			type: cloud-storage-list-objects
+			source: prod-gcs
+			description: List configured objects
+			bucket: baked-bucket
+			prefix: logs/
+			delimiter: /
+			`,
+			want: server.ToolConfigs{
+				"configured_list_objects": cloudstoragelistobjects.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "configured_list_objects",
+						Description:  "List configured objects",
+						AuthRequired: []string{},
+					},
+					Type:      "cloud-storage-list-objects",
+					Source:    "prod-gcs",
+					Bucket:    strPtr("baked-bucket"),
+					Prefix:    strPtr("logs/"),
+					Delimiter: strPtr("/"),
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -98,13 +125,23 @@ func TestParseFromYamlCloudStorageListObjects(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
 type mockSource struct {
 	sources.Source
-	listCalled bool
+	listCalled   bool
+	gotBucket    string
+	gotPrefix    string
+	gotDelimiter string
 }
 
 func (m *mockSource) ListObjects(ctx context.Context, bucket, prefix, delimiter string, maxResults int, pageToken string) (map[string]any, error) {
 	m.listCalled = true
+	m.gotBucket = bucket
+	m.gotPrefix = prefix
+	m.gotDelimiter = delimiter
 	return map[string]any{"objects": []any{}, "prefixes": []string{}, "nextPageToken": ""}, nil
 }
 
@@ -169,4 +206,82 @@ func TestInvokeMaxResultsValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfiguredParametersHiddenAndForwarded(t *testing.T) {
+	cfg := cloudstoragelistobjects.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "list_objects_tool",
+			Description: "List objects",
+		},
+		Type:      "cloud-storage-list-objects",
+		Source:    "my-gcs",
+		Bucket:    strPtr("baked-bucket"),
+		Prefix:    strPtr("logs/"),
+		Delimiter: strPtr("/"),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"max_results", "page_token"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+
+	src := &mockSource{}
+	params := parameters.ParamValues{
+		{Name: "max_results", Value: 0},
+		{Name: "page_token", Value: ""},
+	}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotBucket != "baked-bucket" || src.gotPrefix != "logs/" || src.gotDelimiter != "/" {
+		t.Fatalf("forwarded bucket/prefix/delimiter = %q/%q/%q, want baked-bucket/logs//", src.gotBucket, src.gotPrefix, src.gotDelimiter)
+	}
+}
+
+func TestUnsetParametersRemainVisible(t *testing.T) {
+	cfg := cloudstoragelistobjects.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "list_objects_tool",
+			Description: "List objects",
+		},
+		Type:   "cloud-storage-list-objects",
+		Source: "my-gcs",
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket", "prefix", "delimiter", "max_results", "page_token"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmptyConfiguredBucketRejected(t *testing.T) {
+	cfg := cloudstoragelistobjects.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "list_objects_tool",
+			Description: "List objects",
+		},
+		Type:   "cloud-storage-list-objects",
+		Source: "my-gcs",
+		Bucket: strPtr(""),
+	}
+	if _, err := cfg.Initialize(context.Background()); err == nil || !strings.Contains(err.Error(), "bucket") {
+		t.Fatalf("Initialize() error = %v, want bucket error", err)
+	}
+}
+
+func manifestParamNames(params []parameters.ParameterManifest) []string {
+	names := make([]string, 0, len(params))
+	for _, p := range params {
+		names = append(names, p.Name)
+	}
+	return names
 }

--- a/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
+++ b/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
@@ -59,6 +59,7 @@ type Config struct {
 	Type             string                 `yaml:"type" validate:"required"`
 	Source           string                 `yaml:"source" validate:"required"`
 	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+	Bucket           *string                `yaml:"bucket,omitempty"`
 }
 
 // validate interface
@@ -72,11 +73,17 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	if cfg.Description == "" {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}
+	if cfg.Bucket != nil && *cfg.Bucket == "" {
+		return nil, fmt.Errorf("bucket cannot be empty for tool %q", cfg.Name)
+	}
 
-	bucketParam := parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket containing the object.")
 	objectParam := parameters.NewStringParameter(objectKey, "Full object name (path) within the bucket, e.g. 'path/to/file.txt'.")
 	rangeParam := parameters.NewStringParameter(rangeKey, "Optional HTTP byte range, e.g. 'bytes=0-999' (first 1000 bytes), 'bytes=-500' (last 500 bytes), or 'bytes=500-' (from byte 500 to end). Empty reads the full object.", parameters.WithStringDefault(""))
-	allParameters := parameters.Parameters{bucketParam, objectParam, rangeParam}
+	allParameters := parameters.Parameters{}
+	if cfg.Bucket == nil {
+		allParameters = append(allParameters, parameters.NewStringParameter(bucketKey, "Name of the Cloud Storage bucket containing the object."))
+	}
+	allParameters = append(allParameters, objectParam, rangeParam)
 
 	return Tool{
 		BaseTool: tools.NewBaseTool(
@@ -106,8 +113,8 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	mapParams := params.AsMap()
-	bucket, ok := mapParams[bucketKey].(string)
-	if !ok || bucket == "" {
+	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
+	if bucket == "" {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a non-empty string", bucketKey), nil)
 	}
 	object, ok := mapParams[objectKey].(string)

--- a/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject_test.go
@@ -15,12 +15,16 @@
 package cloudstoragereadobject
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
 func TestParseFromYamlCloudStorageReadObject(t *testing.T) {
@@ -77,6 +81,29 @@ func TestParseFromYamlCloudStorageReadObject(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with configurable bucket",
+			in: `
+			kind: tool
+			name: configured_read_object
+			type: cloud-storage-read-object
+			source: prod-gcs
+			description: Read configured object
+			bucket: baked-bucket
+			`,
+			want: server.ToolConfigs{
+				"configured_read_object": Config{
+					ConfigBase: tools.ConfigBase{
+						Name:         "configured_read_object",
+						Description:  "Read configured object",
+						AuthRequired: []string{},
+					},
+					Type:   "cloud-storage-read-object",
+					Source: "prod-gcs",
+					Bucket: strPtr("baked-bucket"),
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -89,6 +116,113 @@ func TestParseFromYamlCloudStorageReadObject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+type mockSource struct {
+	sources.Source
+	called    bool
+	gotBucket string
+	gotObject string
+	gotOffset int64
+	gotLength int64
+}
+
+func (m *mockSource) ReadObject(ctx context.Context, bucket, object string, offset, length int64) (map[string]any, error) {
+	m.called = true
+	m.gotBucket = bucket
+	m.gotObject = object
+	m.gotOffset = offset
+	m.gotLength = length
+	return map[string]any{"content": "hello", "contentType": "text/plain", "size": 5}, nil
+}
+
+type mockSourceProvider struct {
+	tools.SourceProvider
+	source *mockSource
+}
+
+func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
+	return m.source, true
+}
+
+func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
+	cfg := Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "read_object_tool",
+			Description: "Read object",
+		},
+		Type:   "cloud-storage-read-object",
+		Source: "my-gcs",
+		Bucket: strPtr("baked-bucket"),
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"object", "range"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+
+	src := &mockSource{}
+	params := parameters.ParamValues{
+		{Name: "object", Value: "o"},
+		{Name: "range", Value: "bytes=5-9"},
+	}
+	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src.gotBucket != "baked-bucket" || src.gotObject != "o" || src.gotOffset != 5 || src.gotLength != 5 {
+		t.Fatalf("forwarded bucket/object/range = %q/%q/%d/%d, want baked-bucket/o/5/5", src.gotBucket, src.gotObject, src.gotOffset, src.gotLength)
+	}
+}
+
+func TestUnsetBucketRemainsVisible(t *testing.T) {
+	cfg := Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "read_object_tool",
+			Description: "Read object",
+		},
+		Type:   "cloud-storage-read-object",
+		Source: "my-gcs",
+	}
+	tool, err := cfg.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+	gotNames := manifestParamNames(tool.StaticManifest().Parameters)
+	wantNames := []string{"bucket", "object", "range"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("manifest parameters mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmptyConfiguredBucketRejected(t *testing.T) {
+	cfg := Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "read_object_tool",
+			Description: "Read object",
+		},
+		Type:   "cloud-storage-read-object",
+		Source: "my-gcs",
+		Bucket: strPtr(""),
+	}
+	if _, err := cfg.Initialize(context.Background()); err == nil || !strings.Contains(err.Error(), "bucket") {
+		t.Fatalf("Initialize() error = %v, want bucket error", err)
+	}
+}
+
+func manifestParamNames(params []parameters.ParameterManifest) []string {
+	names := make([]string, 0, len(params))
+	for _, p := range params {
+		names = append(names, p.Name)
+	}
+	return names
 }
 
 func TestParseRange(t *testing.T) {

--- a/tests/cloudstorage/cloud_storage_integration_test.go
+++ b/tests/cloudstorage/cloud_storage_integration_test.go
@@ -83,7 +83,7 @@ func TestCloudStorageToolEndpoints(t *testing.T) {
 	teardown := setupCloudStorageTestData(t, ctx, client, CloudStorageProject, bucketName)
 	defer teardown(t)
 
-	toolsFile := getCloudStorageToolsConfig(sourceConfig)
+	toolsFile := getCloudStorageToolsConfig(sourceConfig, bucketName)
 
 	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, "--enable-api")
 	if err != nil {
@@ -235,6 +235,14 @@ func TestCloudStorageToolEndpoints(t *testing.T) {
 						"name":         "bucket",
 						"required":     true,
 						"type":         "string",
+					},
+					map[string]any{
+						"authServices": []any{},
+						"description":  "Project ID to create the bucket in. When empty, the source's configured project is used.",
+						"name":         "project",
+						"required":     false,
+						"type":         "string",
+						"default":      "",
 					},
 					map[string]any{
 						"authServices": []any{},
@@ -541,10 +549,144 @@ func TestCloudStorageToolEndpoints(t *testing.T) {
 		},
 	)
 
+	// Tools with parameters baked into their config drop those parameters from
+	// the schema exposed to the LLM. The assertions below confirm each
+	// configured parameter is absent from the manifest.
+	tests.RunToolGetTestByName(t, "my_list_objects_configured",
+		map[string]any{
+			"my_list_objects_configured": map[string]any{
+				"description":  "List objects in a configured Cloud Storage bucket.",
+				"authRequired": []any{},
+				"parameters": []any{
+					map[string]any{
+						"authServices": []any{},
+						"description":  "Maximum number of objects to return per page. A value of 0 uses the API default (1000); negative values and values above 1000 are rejected.",
+						"name":         "max_results",
+						"required":     false,
+						"type":         "integer",
+						"default":      float64(0),
+					},
+					map[string]any{
+						"authServices": []any{},
+						"description":  "A previously-returned page token for retrieving the next page of results.",
+						"name":         "page_token",
+						"required":     false,
+						"type":         "string",
+						"default":      "",
+					},
+				},
+			},
+		},
+	)
+	tests.RunToolGetTestByName(t, "my_list_buckets_configured",
+		map[string]any{
+			"my_list_buckets_configured": map[string]any{
+				"description":  "List Cloud Storage buckets in a configured project.",
+				"authRequired": []any{},
+				"parameters": []any{
+					map[string]any{
+						"authServices": []any{},
+						"description":  "Maximum number of buckets to return per page. A value of 0 uses the API default (1000); negative values and values above 1000 are rejected.",
+						"name":         "max_results",
+						"required":     false,
+						"type":         "integer",
+						"default":      float64(0),
+					},
+					map[string]any{
+						"authServices": []any{},
+						"description":  "A previously-returned page token for retrieving the next page of results.",
+						"name":         "page_token",
+						"required":     false,
+						"type":         "string",
+						"default":      "",
+					},
+				},
+			},
+		},
+	)
+	tests.RunToolGetTestByName(t, "my_read_object_configured",
+		map[string]any{
+			"my_read_object_configured": map[string]any{
+				"description":  "Read an object from a configured Cloud Storage bucket.",
+				"authRequired": []any{},
+				"parameters": []any{
+					map[string]any{
+						"authServices": []any{},
+						"description":  "Full object name (path) within the bucket, e.g. 'path/to/file.txt'.",
+						"name":         "object",
+						"required":     true,
+						"type":         "string",
+					},
+					map[string]any{
+						"authServices": []any{},
+						"description":  "Optional HTTP byte range, e.g. 'bytes=0-999' (first 1000 bytes), 'bytes=-500' (last 500 bytes), or 'bytes=500-' (from byte 500 to end). Empty reads the full object.",
+						"name":         "range",
+						"required":     false,
+						"type":         "string",
+						"default":      "",
+					},
+				},
+			},
+		},
+	)
+	tests.RunToolGetTestByName(t, "my_get_object_metadata_configured",
+		map[string]any{
+			"my_get_object_metadata_configured": map[string]any{
+				"description":  "Get object metadata from a configured Cloud Storage bucket.",
+				"authRequired": []any{},
+				"parameters": []any{
+					map[string]any{
+						"authServices": []any{},
+						"description":  "Full object name (path) within the bucket, e.g. 'path/to/file.txt'.",
+						"name":         "object",
+						"required":     true,
+						"type":         "string",
+					},
+				},
+			},
+		},
+	)
+	tests.RunToolGetTestByName(t, "my_get_bucket_metadata_configured",
+		map[string]any{
+			"my_get_bucket_metadata_configured": map[string]any{
+				"description":  "Get metadata for a configured Cloud Storage bucket.",
+				"authRequired": []any{},
+				"parameters":   []any{},
+			},
+		},
+	)
+	tests.RunToolGetTestByName(t, "my_get_bucket_iam_policy_configured",
+		map[string]any{
+			"my_get_bucket_iam_policy_configured": map[string]any{
+				"description":  "Get the IAM policy for a configured Cloud Storage bucket.",
+				"authRequired": []any{},
+				"parameters":   []any{},
+			},
+		},
+	)
+	tests.RunToolGetTestByName(t, "my_create_bucket_configured",
+		map[string]any{
+			"my_create_bucket_configured": map[string]any{
+				"description":  "Create a Cloud Storage bucket with configured settings.",
+				"authRequired": []any{},
+				"parameters": []any{
+					map[string]any{
+						"authServices": []any{},
+						"description":  "Name of the Cloud Storage bucket to create.",
+						"name":         "bucket",
+						"required":     true,
+						"type":         "string",
+					},
+				},
+			},
+		},
+	)
+
 	runCloudStorageListObjectsTest(t, bucketName)
 	runCloudStorageReadObjectTest(t, bucketName)
 	runCloudStorageListBucketsTest(t, bucketName)
 	runCloudStorageGetObjectMetadataTest(t, bucketName)
+	runCloudStorageConfiguredParamsTest(ctx, t, client, bucketName)
 	bucketToolName := "toolbox-it-bucket-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:17]
 	defer cleanupGCSBucket(ctx, t, client, bucketToolName)
 	runCloudStorageCreateBucketTest(ctx, t, client, bucketToolName)
@@ -559,7 +701,7 @@ func TestCloudStorageToolEndpoints(t *testing.T) {
 	runCloudStorageDeleteObjectTest(ctx, t, client, bucketName)
 }
 
-func getCloudStorageToolsConfig(sourceConfig map[string]any) map[string]any {
+func getCloudStorageToolsConfig(sourceConfig map[string]any, bucketName string) map[string]any {
 	return map[string]any{
 		"sources": map[string]any{
 			"my_instance": sourceConfig,
@@ -634,6 +776,56 @@ func getCloudStorageToolsConfig(sourceConfig map[string]any) map[string]any {
 				"type":        "cloud-storage-delete-object",
 				"source":      "my_instance",
 				"description": "Delete a Cloud Storage object.",
+			},
+			// Configured variants bake static parameter values into the tool
+			// config so those parameters are removed from the schema and the
+			// configured values are used at invocation time.
+			"my_list_objects_configured": map[string]any{
+				"type":        "cloud-storage-list-objects",
+				"source":      "my_instance",
+				"description": "List objects in a configured Cloud Storage bucket.",
+				"bucket":      bucketName,
+				"prefix":      "seed/",
+				"delimiter":   "",
+			},
+			"my_list_buckets_configured": map[string]any{
+				"type":        "cloud-storage-list-buckets",
+				"source":      "my_instance",
+				"description": "List Cloud Storage buckets in a configured project.",
+				"project":     CloudStorageProject,
+				"prefix":      "toolbox-it-",
+			},
+			"my_read_object_configured": map[string]any{
+				"type":        "cloud-storage-read-object",
+				"source":      "my_instance",
+				"description": "Read an object from a configured Cloud Storage bucket.",
+				"bucket":      bucketName,
+			},
+			"my_get_object_metadata_configured": map[string]any{
+				"type":        "cloud-storage-get-object-metadata",
+				"source":      "my_instance",
+				"description": "Get object metadata from a configured Cloud Storage bucket.",
+				"bucket":      bucketName,
+			},
+			"my_get_bucket_metadata_configured": map[string]any{
+				"type":        "cloud-storage-get-bucket-metadata",
+				"source":      "my_instance",
+				"description": "Get metadata for a configured Cloud Storage bucket.",
+				"bucket":      bucketName,
+			},
+			"my_get_bucket_iam_policy_configured": map[string]any{
+				"type":        "cloud-storage-get-bucket-iam-policy",
+				"source":      "my_instance",
+				"description": "Get the IAM policy for a configured Cloud Storage bucket.",
+				"bucket":      bucketName,
+			},
+			"my_create_bucket_configured": map[string]any{
+				"type":                        "cloud-storage-create-bucket",
+				"source":                      "my_instance",
+				"description":                 "Create a Cloud Storage bucket with configured settings.",
+				"project":                     CloudStorageProject,
+				"location":                    "US",
+				"uniform_bucket_level_access": true,
 			},
 		},
 	}
@@ -1180,6 +1372,105 @@ func runCloudStorageGetObjectMetadataTest(t *testing.T, bucket string) {
 			}
 		})
 	}
+}
+
+// runCloudStorageConfiguredParamsTest exercises the tool variants that bake
+// parameter values into their config. Each invocation omits the configured
+// parameters (they are absent from the schema) and relies on the configured
+// values instead. The seeded `bucket` is the configured bucket for the
+// bucket-scoped tools.
+func runCloudStorageConfiguredParamsTest(ctx context.Context, t *testing.T, client *storage.Client, bucket string) {
+	t.Run("list_objects uses configured bucket and prefix", func(t *testing.T) {
+		result, status := invokeTool(t, "my_list_objects_configured", `{}`)
+		if status != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", status, result)
+		}
+		for _, want := range []string{helloObject, jsonObject} {
+			if !strings.Contains(result, want) {
+				t.Errorf("expected result to contain %q, got %s", want, result)
+			}
+		}
+	})
+
+	t.Run("list_buckets uses configured project and prefix", func(t *testing.T) {
+		result, status := invokeTool(t, "my_list_buckets_configured", `{}`)
+		if status != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", status, result)
+		}
+		if !strings.Contains(result, bucket) {
+			t.Errorf("expected result to contain configured bucket %q, got %s", bucket, result)
+		}
+	})
+
+	t.Run("read_object uses configured bucket", func(t *testing.T) {
+		body := fmt.Sprintf(`{"object": %q}`, helloObject)
+		result, status := invokeTool(t, "my_read_object_configured", body)
+		if status != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", status, result)
+		}
+		if !strings.Contains(result, helloBody) {
+			t.Errorf("expected result to contain %q, got %s", helloBody, result)
+		}
+	})
+
+	t.Run("get_object_metadata uses configured bucket", func(t *testing.T) {
+		body := fmt.Sprintf(`{"object": %q}`, helloObject)
+		result, status := invokeTool(t, "my_get_object_metadata_configured", body)
+		if status != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", status, result)
+		}
+		if !strings.Contains(result, `"ContentType":"text/plain"`) {
+			t.Errorf("expected result to contain content type, got %s", result)
+		}
+	})
+
+	t.Run("get_bucket_metadata uses configured bucket", func(t *testing.T) {
+		result, status := invokeTool(t, "my_get_bucket_metadata_configured", `{}`)
+		if status != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", status, result)
+		}
+		if !strings.Contains(result, `"Name":"`+bucket+`"`) {
+			t.Errorf("expected result to contain bucket name %q, got %s", bucket, result)
+		}
+	})
+
+	t.Run("get_bucket_iam_policy uses configured bucket", func(t *testing.T) {
+		result, status := invokeTool(t, "my_get_bucket_iam_policy_configured", `{}`)
+		if status != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", status, result)
+		}
+		for _, want := range []string{`"bucket":"` + bucket + `"`, `"bindings"`} {
+			if !strings.Contains(result, want) {
+				t.Errorf("expected result to contain %q, got %s", want, result)
+			}
+		}
+	})
+
+	t.Run("create_bucket uses configured project, location and uniform access", func(t *testing.T) {
+		newBucket := "toolbox-it-cfg-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:17]
+		defer cleanupGCSBucket(ctx, t, client, newBucket)
+
+		body := fmt.Sprintf(`{"bucket": %q}`, newBucket)
+		result, status := invokeTool(t, "my_create_bucket_configured", body)
+		if status != http.StatusOK {
+			t.Fatalf("unexpected status %d: %s", status, result)
+		}
+		for _, want := range []string{newBucket, `"created":true`} {
+			if !strings.Contains(result, want) {
+				t.Errorf("expected result to contain %q, got %s", want, result)
+			}
+		}
+		attrs, err := client.Bucket(newBucket).Attrs(ctx)
+		if err != nil {
+			t.Fatalf("expected created bucket to exist: %v", err)
+		}
+		if attrs.Location != "US" {
+			t.Errorf("bucket location = %q, want US", attrs.Location)
+		}
+		if !attrs.UniformBucketLevelAccess.Enabled {
+			t.Errorf("expected uniform bucket-level access to be enabled")
+		}
+	})
 }
 
 func runCloudStorageDownloadObjectTest(t *testing.T, bucket string) {


### PR DESCRIPTION
## Description
Adds optional tool-level config fields for the first Cloud Storage tools so configured values are hidden from runtime parameter schemas and used during invocation. Also adds project support to create-bucket and updates docs/tests.

This change has been communicated internally.

## PR Checklist
- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involves a breaking change

## Issue Reference
N/A