### PR TITLE
fix(auth/google): require clientId when mcpEnabled is false

### DIFF
--- a/internal/auth/google/google.go
+++ b/internal/auth/google/google.go
@@ -30,6 +30,12 @@ import (
 
 const AuthServiceType string = "google"
 
+// validateIDToken validates a Google-issued ID token against the expected
+// audience. It is a package-level indirection over idtoken.Validate so tests
+// can substitute a fake validator and exercise the audience-binding logic
+// without performing live network calls to Google's certificate endpoint.
+var validateIDToken = idtoken.Validate
+
 // validate interface
 var _ auth.AuthServiceConfig = Config{}
 
@@ -59,6 +65,16 @@ func (cfg Config) Initialize() (auth.AuthService, error) {
 			return nil, fmt.Errorf("`audience` or `clientId` is required when `mcpEnabled` is true")
 		}
 	} else {
+		// In non-MCP mode the only audience binding available for ID token
+		// validation in GetClaimsFromHeader is clientId. If it is empty,
+		// idtoken.Validate is called with an empty audience and skips the
+		// audience check entirely, silently accepting any Google-signed ID
+		// token regardless of which OAuth client it was minted for. Fail
+		// closed by requiring clientId, matching the documented behavior
+		// ("Required for validating ID tokens in non-MCP web apps").
+		if cfg.ClientID == "" {
+			return nil, fmt.Errorf("`clientId` is required when `mcpEnabled` is false")
+		}
 		if cfg.Audience != "" {
 			return nil, fmt.Errorf("`audience` is not allowed when `mcpEnabled` is false")
 		}
@@ -123,7 +139,7 @@ func (a AuthService) GetAuthorizationServer() string {
 // Verifies Google ID token and return claims
 func (a AuthService) GetClaimsFromHeader(ctx context.Context, h http.Header) (map[string]any, error) {
 	if token := h.Get(a.Name + "_token"); token != "" {
-		payload, err := idtoken.Validate(ctx, token, a.ClientID)
+		payload, err := validateIDToken(ctx, token, a.ClientID)
 		if err != nil {
 			return nil, fmt.Errorf("google ID token verification failure: %w", err)
 		}
@@ -154,7 +170,7 @@ func (a AuthService) ValidateMCPAuth(ctx context.Context, h http.Header) (map[st
 		if aud == "" {
 			return nil, &auth.MCPAuthError{Code: http.StatusUnauthorized, Message: "audience or client ID is required for ID token validation", ScopesRequired: a.ScopesRequired}
 		}
-		payload, err := idtoken.Validate(ctx, tokenStr, aud)
+		payload, err := validateIDToken(ctx, tokenStr, aud)
 		if err != nil {
 			return nil, &auth.MCPAuthError{Code: http.StatusUnauthorized, Message: fmt.Sprintf("Google ID token verification failure: %v", err), ScopesRequired: a.ScopesRequired}
 		}

--- a/internal/auth/google/google_test.go
+++ b/internal/auth/google/google_test.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"google.golang.org/api/idtoken"
 )
 
 func TestInitialize_Validation(t *testing.T) {
@@ -102,13 +104,17 @@ func TestInitialize_Validation(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "neither clientID nor audience, mcpEnabled false",
+			// Without clientId in non-MCP mode, GetClaimsFromHeader would
+			// validate ID tokens with an empty audience, which makes
+			// idtoken.Validate skip the audience check and accept any
+			// Google-signed token. Initialize must now reject this config.
+			name: "neither clientID nor audience, mcpEnabled false (disallowed)",
 			config: Config{
 				Name:       "google-auth",
 				Type:       "google",
 				McpEnabled: false,
 			},
-			wantError: false,
+			wantError: true,
 		},
 		{
 			name: "neither clientID nor audience, mcpEnabled true (disallowed)",
@@ -126,6 +132,71 @@ func TestInitialize_Validation(t *testing.T) {
 			_, err := tc.config.Initialize()
 			if (err != nil) != tc.wantError {
 				t.Fatalf("Initialize() returned error: %v, wantError: %v", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestGetClaimsFromHeader_NoToken(t *testing.T) {
+	a := AuthService{Config: Config{Name: "google-auth", ClientID: "my-client-id"}}
+
+	claims, err := a.GetClaimsFromHeader(context.Background(), make(http.Header))
+	if err != nil {
+		t.Fatalf("GetClaimsFromHeader() with no token returned error: %v", err)
+	}
+	if claims != nil {
+		t.Fatalf("GetClaimsFromHeader() with no token returned claims: %v, want nil", claims)
+	}
+}
+
+func TestGetClaimsFromHeader_AudienceBinding(t *testing.T) {
+	const tokenAud = "111-token.apps.googleusercontent.com"
+
+	// Substitute a fake validator that models idtoken.Validate's audience
+	// check (signature verification is assumed to pass). The real library
+	// performs `if audience != "" && payload.Audience != audience`, so an
+	// empty audience means no audience check is enforced.
+	orig := validateIDToken
+	t.Cleanup(func() { validateIDToken = orig })
+	validateIDToken = func(_ context.Context, _ string, audience string) (*idtoken.Payload, error) {
+		if audience != "" && audience != tokenAud {
+			return nil, fmt.Errorf("idtoken: audience provided does not match aud claim in the JWT")
+		}
+		return &idtoken.Payload{
+			Audience: tokenAud,
+			Claims:   map[string]any{"aud": tokenAud, "email": "user@example.com"},
+		}, nil
+	}
+
+	tests := []struct {
+		name      string
+		clientID  string
+		wantError bool
+	}{
+		{
+			name:      "configured clientId matches token aud",
+			clientID:  tokenAud,
+			wantError: false,
+		},
+		{
+			name:      "configured clientId does not match token aud",
+			clientID:  "999-other.apps.googleusercontent.com",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := AuthService{Config: Config{Name: "google-auth", ClientID: tc.clientID}}
+			header := make(http.Header)
+			header.Set("google-auth_token", "eyJ.fake.token")
+
+			claims, err := a.GetClaimsFromHeader(context.Background(), header)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("GetClaimsFromHeader() returned error: %v, wantError: %v", err, tc.wantError)
+			}
+			if !tc.wantError && claims["aud"] != tokenAud {
+				t.Fatalf("GetClaimsFromHeader() aud claim = %v, want %q", claims["aud"], tokenAud)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

In non-MCP mode the Google auth service validates ID tokens in `GetClaimsFromHeader` with:

```go
payload, err := idtoken.Validate(ctx, token, a.ClientID)
```

When `clientId` is left empty, `idtoken.Validate` is called with an **empty audience**. The library only enforces the audience claim when the audience argument is non-empty:

```go
// google.golang.org/api/idtoken@v0.283.0 validate.go
// "If audience is not empty the audience claim of the Token is validated."
if audience != "" && payload.Audience != audience {
    return nil, fmt.Errorf("idtoken: audience provided does not match aud claim in the JWT")
}
```

So a deployment that configures a `google` auth service without `clientId` (with `mcpEnabled: false`) silently accepts **any** Google-signed ID token — for any OAuth client / any audience — for Authenticated Parameters, instead of only tokens minted for the configured client.

`Config.Initialize()` already fails closed for the MCP path (`audience` or `clientId` required when `mcpEnabled` is true, added in #3450), and `ValidateMCPAuth` refuses to validate when no audience is resolvable. The non-MCP branch had no equivalent guard.

The reference docs already document `clientId` as **"Required for validating ID tokens in non-MCP web apps (`GetClaimsFromHeader`)"**, but the code never enforced it — a code-vs-docs divergence.

## Change

- `Initialize()`: when `mcpEnabled` is false, return an error if `clientId` is empty (fail-closed config validation, mirroring the existing `mcpEnabled` guard).
- Introduce a small package-level `validateIDToken = idtoken.Validate` indirection so the audience-binding behaviour can be unit-tested hermetically, without live calls to Google's certificate endpoint. Both ID-token validation paths now go through it.

## Tests

- `TestInitialize_Validation`: asserts `Initialize()` fails on empty `clientId` in non-MCP mode (the previously-passing "neither clientId nor audience, mcpEnabled false" case now expects an error).
- `TestGetClaimsFromHeader_AudienceBinding`: with a configured `clientId`, a token whose `aud` matches is accepted and a token whose `aud` differs is rejected.
- `TestGetClaimsFromHeader_NoToken`: a missing token header is a no-op (returns `nil, nil`).

`go test ./internal/auth/google/...` passes; `gofmt -l` and `go vet` are clean.

## Compatibility

This is a hardening / fail-closed change, not a report of active exploitation. It is a behavioural change: a `google` auth service configured with `mcpEnabled: false` and **no** `clientId` was previously accepted at startup and will now fail to initialize with a clear error. That configuration provided no audience binding (insecure by default), so failing fast surfaces the misconfiguration rather than silently accepting unintended tokens. Happy to adjust the message or soften to a startup warning if maintainers prefer.
