### PR TITLE
fix: pass original value to ParseTypeError in ArrayParameter and MapParameter

### DIFF
--- a/internal/util/parameters/parameters.go
+++ b/internal/util/parameters/parameters.go
@@ -1349,7 +1349,7 @@ func (p *ArrayParameter) IsExcludedValues(v []any) bool {
 func (p *ArrayParameter) Parse(v any) (any, error) {
 	arrVal, ok := v.([]any)
 	if !ok {
-		return nil, &ParseTypeError{p.Name, p.Type, arrVal}
+		return nil, &ParseTypeError{p.Name, p.Type, v}
 	}
 	if !p.IsAllowedValues(arrVal) {
 		return nil, fmt.Errorf("%s is not an allowed value", arrVal)
@@ -1574,7 +1574,7 @@ func (p *MapParameter) IsExcludedValues(v map[string]any) bool {
 func (p *MapParameter) Parse(v any) (any, error) {
 	m, ok := v.(map[string]any)
 	if !ok {
-		return nil, &ParseTypeError{p.Name, p.Type, m}
+		return nil, &ParseTypeError{p.Name, p.Type, v}
 	}
 	if !p.IsAllowedValues(m) {
 		return nil, fmt.Errorf("%s is not an allowed value", m)

--- a/internal/util/parameters/parameters_test.go
+++ b/internal/util/parameters/parameters_test.go
@@ -2324,3 +2324,31 @@ func TestCheckParamRequired(t *testing.T) {
 		})
 	}
 }
+
+// TestParseTypeErrorIncludesValue verifies that ArrayParameter.Parse and
+// MapParameter.Parse report the original input value in the error message, not
+// the zero value of the assertion target (nil) that is produced when a Go
+// two-result type assertion fails.
+func TestParseTypeErrorIncludesValue(t *testing.T) {
+	t.Run("ArrayParameter", func(t *testing.T) {
+		p := parameters.NewArrayParameter("arr", "test array", parameters.NewStringParameter("s", "item"))
+		_, err := p.Parse("not-an-array")
+		if err == nil {
+			t.Fatal("expected an error for wrong type, got nil")
+		}
+		if !strings.Contains(err.Error(), "not-an-array") {
+			t.Errorf("error should include the original value; got: %q", err.Error())
+		}
+	})
+
+	t.Run("MapParameter", func(t *testing.T) {
+		p := parameters.NewMapParameter("m", "test map", "string")
+		_, err := p.Parse("bad")
+		if err == nil {
+			t.Fatal("expected an error for wrong type, got nil")
+		}
+		if !strings.Contains(err.Error(), "bad") {
+			t.Errorf("error should include the original value; got: %q", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
In Go, a two-result type assertion like `x, ok := v.(T)` sets `x` to the zero value of `T` when the assertion fails — `nil` for slice and map types. Both `ArrayParameter.Parse` and `MapParameter.Parse` were passing this zero value to `ParseTypeError` instead of the original argument `v`, so a caller would see an error like:

```
<nil> not type "array"
```

instead of something useful that identifies what was actually passed in.

The five other `Parse` methods in the same file — `StringParameter`, `IntParameter`, `FloatParameter`, `BoolParameter`, and the integer sub-case — all correctly pass `v` to `ParseTypeError`. This PR brings `ArrayParameter` and `MapParameter` in line with that pattern.

Changed lines:

```go
// Before
return nil, &ParseTypeError{p.Name, p.Type, arrVal}  // arrVal is nil on failed assertion
return nil, &ParseTypeError{p.Name, p.Type, m}        // m is nil on failed assertion

// After
return nil, &ParseTypeError{p.Name, p.Type, v}
return nil, &ParseTypeError{p.Name, p.Type, v}
```

Two regression tests are added in `TestParseTypeErrorIncludesValue`: one for `ArrayParameter.Parse("not-an-array")` and one for `MapParameter.Parse("bad")`, each asserting the error message contains the original input value. Both tests fail before this fix and pass after.
