### PR TITLE
fix: handle JSON-RPC null request ids

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -787,15 +787,19 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 	}
 
 	// Set request ID
-	if baseMessage.Id != nil {
-		span.SetAttributes(attribute.String("jsonrpc.request.id", fmt.Sprintf("%v", baseMessage.Id)))
+	if baseMessage.HasId {
+		idStr := "null"
+		if baseMessage.Id != nil {
+			idStr = fmt.Sprintf("%v", baseMessage.Id)
+		}
+		span.SetAttributes(attribute.String("jsonrpc.request.id", idStr))
 	}
 
 	// Set toolset name
 	span.SetAttributes(attribute.String("toolset.name", toolsetName))
 
 	// Check if message is a notification
-	if baseMessage.Id == nil {
+	if !baseMessage.HasId {
 		err := mcp.NotificationHandler(ctx, body)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())

--- a/internal/server/mcp/jsonrpc/jsonrpc.go
+++ b/internal/server/mcp/jsonrpc/jsonrpc.go
@@ -14,6 +14,11 @@
 
 package jsonrpc
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 // JSONRPC_VERSION is the version of JSON-RPC used by MCP.
 const JSONRPC_VERSION = "2.0"
 
@@ -138,6 +143,34 @@ type BaseMessage struct {
 	Jsonrpc string    `json:"jsonrpc"`
 	Method  string    `json:"method"`
 	Id      RequestId `json:"id,omitempty"`
+	HasId   bool      `json:"-"`
+}
+
+// UnmarshalJSON records whether the id field was present so explicit
+// JSON-RPC null ids can be distinguished from notifications.
+func (m *BaseMessage) UnmarshalJSON(data []byte) error {
+	type baseMessageAlias BaseMessage
+	var raw struct {
+		baseMessageAlias
+		Id json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*m = BaseMessage(raw.baseMessageAlias)
+	if raw.Id == nil {
+		return nil
+	}
+	m.HasId = true
+	if bytes.Equal(raw.Id, []byte("null")) {
+		m.Id = nil
+		return nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw.Id))
+	decoder.UseNumber()
+	return decoder.Decode(&m.Id)
 }
 
 // NewError is the standard JSONRPC response sent back when an error has been encountered.

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -560,9 +560,9 @@ func TestMcpEndpoint(t *testing.T) {
 				{
 					name: "basic notification",
 					url:  "/",
-					body: jsonrpc.JSONRPCRequest{
+					body: jsonrpc.JSONRPCNotification{
 						Jsonrpc: jsonrpcVersion,
-						Request: jsonrpc.Request{
+						Notification: jsonrpc.Notification{
 							Method: "notification",
 						},
 					},
@@ -599,6 +599,50 @@ func TestMcpEndpoint(t *testing.T) {
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "tools-list",
+						"result": map[string]any{
+							"tools": []any{
+								map[string]any{
+									"name":        "no_params",
+									"inputSchema": basicInputSchema,
+								},
+								map[string]any{
+									"name":        "some_params",
+									"inputSchema": tool2InputSchema,
+								},
+								map[string]any{
+									"name":        "array_param",
+									"description": "some description",
+									"inputSchema": tool3InputSchema,
+								},
+								map[string]any{
+									"name":        "unauthorized_tool",
+									"inputSchema": basicInputSchema,
+								},
+								map[string]any{
+									"name":        "require_client_auth_tool",
+									"inputSchema": basicInputSchema,
+								},
+								map[string]any{
+									"name":        "url_binding_tool",
+									"description": "A tool for testing URL param binding",
+									"inputSchema": urlBindingToolInputSchema,
+								},
+							},
+						},
+					},
+				},
+				{
+					name: "tools/list with null id",
+					url:  "/",
+					body: map[string]any{
+						"jsonrpc": jsonrpcVersion,
+						"id":      nil,
+						"method":  "tools/list",
+					},
+					wantStatusCode: http.StatusOK,
+					want: map[string]any{
+						"jsonrpc": "2.0",
+						"id":      nil,
 						"result": map[string]any{
 							"tools": []any{
 								map[string]any{


### PR DESCRIPTION
## Description

Tracks JSON-RPC request-id presence separately from the decoded id value so an explicit `"id": null` is treated as a request, not as a notification.

This preserves existing notification behavior when the `id` member is absent, while allowing `id: null` requests to return a JSON-RPC response with `"id": null` as required by JSON-RPC 2.0.

## PR Checklist

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

## Testing

- `go test ./internal/server/mcp/jsonrpc ./internal/tools/mysql/mysqllisttables -count=1`
- `go test ./internal/server -run 'TestMcpEndpoint$|TestMcpEndpointWithoutInitialized|TestStdioSession' -count=1`

AI disclosure: this PR was prepared by Codex (GPT-5) acting as an AI coding agent on behalf of @luohui1.

Fixes #3464