### PR TITLE
docs(sdk): redirect Python, JS, and Go SDK pages to API reference sites

### DIFF
--- a/docs/en/documentation/connect-to/toolbox-sdks/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/_index.md
@@ -12,8 +12,8 @@ Whether you are writing a simple script to execute a single query or building a 
 
 By using our SDKs, your application can dynamically request tools, bind parameters, add authentication, and execute commands at runtime. We offer official support and deep framework integrations across three primary languages:
 
-*   **[Python](./python-sdk/_index.md)**: Includes the Core SDK, along with native integrations for popular orchestrators like LangChain, LlamaIndex, and the ADK.
-*   **[JavaScript / TypeScript](./javascript-sdk/_index.md)**: Includes the Node.js Core SDK and integrations for the Agent Development Kit (ADK).
-*   **[Go](./go-sdk/_index.md/)**: Includes the Core SDK, plus dedicated packages for building agents with Genkit (`tbgenkit`) and the ADK.
+*   **[Python](./python-sdk/)**: Includes the Core SDK, along with native integrations for popular orchestrators like LangChain, LlamaIndex, and the ADK.
+*   **[JavaScript / TypeScript](./javascript-sdk/)**: Includes the Node.js Core SDK and integrations for the Agent Development Kit (ADK).
+*   **[Go](./go-sdk/)**: Includes the Core SDK, plus dedicated packages for building agents with Genkit (`tbgenkit`) and the ADK.
 
 Select your preferred language to explore installation instructions, quickstart guides, and framework-specific implementations.

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/_index.md
@@ -4,71 +4,16 @@ type: docs
 weight: 3
 description: >
   Go SDKs to connect to the MCP Toolbox server.
+manualLink: "https://go.mcp-toolbox.dev"
 ---
 
-## Overview
-
-The MCP Toolbox service provides a centralized way to manage and expose tools
-(like API connectors, database query tools, etc.) for use by GenAI applications.
-
-The Go SDK act as clients for that service. They handle the communication needed to:
-
-* Fetch tool definitions from your running Toolbox instance.
-* Provide convenient Go structs representing those tools.
-* Invoke the tools (calling the underlying APIs/services configured in Toolbox).
-* Handle authentication and parameter binding as needed.
-
-By using the SDK, you can easily leverage your Toolbox-managed tools directly
-within your Go applications or AI orchestration frameworks.
-
-## Which Package Should I Use?
-
-Choosing the right package depends on how you are building your application:
-
-- [**`core`**](core/):
-  This is a framework-agnostic way to connect tools to popular frameworks
-  like Google GenAI, LangChain, etc.
-
-- [**`tbadk`**](tbadk/):
-  This package provides a way to connect tools to ADK Go.
-
-- [**`tbgenkit`**](tbgenkit/):
-  This package provides functionality to convert the Tool fetched using the core package
-  into a Genkit Go compatible tool.
-
-## Available Packages
-
-This repository hosts the following Go packages. See the package-specific
-README for detailed installation and usage instructions:
-
-| Package | Target Use Case | Integration | Path | Details (README) |
-| :------ | :----------| :---------- | :---------------------- | :---------- |
-| [`core`](core/) | Framework-agnostic / Custom applications | Use directly / Custom | `core/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/core/README.md) |
-| [`tbadk`](tbadk/) | ADK Go | Use directly | `tbadk/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/tbadk/README.md) |
-| [`tbgenkit`](tbgenkit/) | Genkit Go | Along with core | `tbgenkit/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/tbgenkit/README.md) |
-
-## Getting Started
-
-To get started using Toolbox tools with an application, follow these general steps:
-
-1. **Set up and Run the Toolbox Service:**
-
-    Before using the SDKs, you need the MCP Toolbox server running. Follow
-    the instructions here: [**Toolbox Getting Started
-    Guide**](https://github.com/googleapis/mcp-toolbox?tab=readme-ov-file#getting-started)
-
-2. **Install the Appropriate SDK:**
-
-    Choose the package based on your needs (see "[Which Package Should I Use?](#which-package-should-i-use)" above)
-    Use this command to install the SDK module
-
-    ```bash
-    # For the core, framework-agnostic SDK
-    go get github.com/googleapis/mcp-toolbox-sdk-go
-    ```
-
-{{< notice note >}}
-Source code for [Go-sdk](https://github.com/googleapis/mcp-toolbox-sdk-go)
-{{< /notice >}}
-
-## Explore the Go SDKs
+<html>
+  <head>
+    <title>Redirecting to the Go SDK API reference</title>
+    <link rel="canonical" href="https://go.mcp-toolbox.dev"/>
+    <meta http-equiv="refresh" content="0;url=https://go.mcp-toolbox.dev"/>
+  </head>
+  <body>
+    <p>If you are not automatically redirected, please <a href="https://go.mcp-toolbox.dev">follow this link to the Go SDK API reference</a>.</p>
+  </body>
+</html>

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/_index.md
@@ -4,70 +4,16 @@ type: docs
 weight: 2
 description: >
   Javascript SDKs to connect to the MCP Toolbox server.
+manualLink: "https://js.mcp-toolbox.dev"
 ---
 
-## Overview
-
-The MCP Toolbox service provides a centralized way to manage and expose tools
-(like API connectors, database query tools, etc.) for use by GenAI applications.
-
-These JS SDKs act as clients for that service. They handle the communication needed to:
-
-* Fetch tool definitions from your running Toolbox instance.
-* Provide convenient JS objects or functions representing those tools.
-* Invoke the tools (calling the underlying APIs/services configured in Toolbox).
-* Handle authentication and parameter binding as needed.
-
-By using these SDKs, you can easily leverage your Toolbox-managed tools directly
-within your JS applications or AI orchestration frameworks.
-
-## Which Package Should I Use?
-
-Choosing the right package depends on how you are building your application:
-
-- [`@toolbox-sdk/core`](https://github.com/googleapis/mcp-toolbox-sdk-js/tree/main/packages/toolbox-core):
-  This is a framework agnostic way to connect the tools to popular frameworks
-  like Langchain, LlamaIndex and Genkit.
-- [`@toolbox-sdk/adk`](https://github.com/googleapis/mcp-toolbox-sdk-js/tree/main/packages/toolbox-adk):
-  This package provides a seamless way to connect to [Google ADK TS](https://github.com/google/adk-js).
-
-## Available Packages
-
-This repository hosts the following TS packages. See the package-specific
-README for detailed installation and usage instructions:
-
-| Package | Target Use Case | Integration | Path | Details (README) | Npm Version |
-| :------ | :---------- | :---------- | :---------------------- | :---------- | :---------- |
-| `toolbox-core` | Framework-agnostic / Custom applications | Use directly / Custom | `packages/toolbox-core/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-js/blob/main/packages/toolbox-core/README.md) | ![npm](https://img.shields.io/npm/v/@toolbox-sdk/core) |
-| `toolbox-adk` | ADK applications | ADK | `packages/toolbox-adk/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-js/blob/main/packages/toolbox-adk/README.md) | ![npm](https://img.shields.io/npm/v/@toolbox-sdk/adk) |
-
-
-## Getting Started
-
-To get started using Toolbox tools with an application, follow these general steps:
-
-1. **Set up and Run the Toolbox Service:**
-
-    Before using the SDKs, you need the main MCP Toolbox service running. Follow
-    the instructions here: [**Toolbox Getting Started
-    Guide**](https://github.com/googleapis/mcp-toolbox?tab=readme-ov-file#getting-started)
-
-2. **Install the Appropriate SDK:**
-
-    Choose the package based on your needs (see "[Which Package Should I Use?](#which-package-should-i-use)" above) and install it:
-
-    ```bash
-    # For the core, framework-agnostic SDK
-    npm install @toolbox-sdk/core
-
-    # For ADK applications
-    npm install @toolbox-sdk/adk
-    ```
-
-
-
-{{< notice note >}}
-Source code for [js-sdk](https://github.com/googleapis/mcp-toolbox-sdk-js)
-{{< /notice >}}
-
-## Explore the Javascript SDKs
+<html>
+  <head>
+    <title>Redirecting to the JavaScript SDK API reference</title>
+    <link rel="canonical" href="https://js.mcp-toolbox.dev"/>
+    <meta http-equiv="refresh" content="0;url=https://js.mcp-toolbox.dev"/>
+  </head>
+  <body>
+    <p>If you are not automatically redirected, please <a href="https://js.mcp-toolbox.dev">follow this link to the JavaScript SDK API reference</a>.</p>
+  </body>
+</html>

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/_index.md
@@ -4,99 +4,16 @@ type: docs
 weight: 1
 description: >
   Python SDKs to connect to the MCP Toolbox server.
+manualLink: "https://py.mcp-toolbox.dev"
 ---
 
-
-## Overview
-
-The MCP Toolbox service provides a centralized way to manage and expose tools
-(like API connectors, database query tools, etc.) for use by GenAI applications.
-
-These Python SDKs act as clients for that service. They handle the communication needed to:
-
-* Fetch tool definitions from your running Toolbox instance.
-* Provide convenient Python objects or functions representing those tools.
-* Invoke the tools (calling the underlying APIs/services configured in Toolbox).
-* Handle authentication and parameter binding as needed.
-
-By using these SDKs, you can easily leverage your Toolbox-managed tools directly
-within your Python applications or AI orchestration frameworks.
-
-## Which Package Should I Use?
-
-Choosing the right package depends on how you are building your application:
-
-* [`toolbox-adk`](adk):
-  Use this package if you are building your application using Google ADK (Agent Development Kit).
-  It provides tools that are directly compatible with the
-  Google ADK ecosystem (`BaseTool` / `BaseToolset` interface) handling authentication propagation, header management, and tool wrapping automatically.
-* [`toolbox-core`](core):
-  Use this package if you are not using LangChain/LangGraph or any other
-  orchestration framework, or if you need a framework-agnostic way to interact
-  with Toolbox tools (e.g., for custom orchestration logic or direct use in
-  Python scripts).
-* [`toolbox-langchain`](langchain):
-  Use this package if you are building your application using the LangChain or
-  LangGraph frameworks. It provides tools that are directly compatible with the
-  LangChain ecosystem (`BaseTool` interface), simplifying integration.
-* [`toolbox-llamaindex`](llamaindex):
-  Use this package if you are building your application using the LlamaIndex framework.
-  It provides tools that are directly compatible with the
-  LlamaIndex ecosystem (`BaseTool` interface), simplifying integration.
-
-
-## Available Packages
-
-This repository hosts the following Python packages. See the package-specific
-README for detailed installation and usage instructions:
-
-| Package | Target Use Case | Integration | Path | Details (README) | PyPI Status |
-| :------ | :---------- | :---------- | :---------------------- | :---------- | :--------- 
-| `toolbox-adk` | Google ADK applications | Google ADK | `packages/toolbox-adk/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-python/blob/main/packages/toolbox-adk/README.md) | ![pypi version](https://img.shields.io/pypi/v/toolbox-adk.svg) |
-| `toolbox-core` | Framework-agnostic / Custom applications | Use directly / Custom | `packages/toolbox-core/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-python/blob/main/packages/toolbox-core/README.md) | ![pypi version](https://img.shields.io/pypi/v/toolbox-core.svg) |
-| `toolbox-langchain` | LangChain / LangGraph applications | LangChain / LangGraph | `packages/toolbox-langchain/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-python/blob/main/packages/toolbox-langchain/README.md) | ![pypi version](https://img.shields.io/pypi/v/toolbox-langchain.svg) |
-| `toolbox-llamaindex` | LlamaIndex applications | LlamaIndex | `packages/toolbox-llamaindex/` | 📄 [View README](https://github.com/googleapis/mcp-toolbox-sdk-python/blob/main/packages/toolbox-llamaindex/README.md) | ![pypi version](https://img.shields.io/pypi/v/toolbox-llamaindex.svg) |
-
-
-## Getting Started
-
-To get started using Toolbox tools with an application, follow these general steps:
-
-1. **Set up and Run the Toolbox Service:**
-
-    Before using the SDKs, you need the main MCP Toolbox service running. Follow
-    the instructions here: [**Toolbox Getting Started
-    Guide**](https://github.com/googleapis/mcp-toolbox?tab=readme-ov-file#getting-started)
-
-2. **Install the Appropriate SDK:**
-
-    Choose the package based on your needs (see "[Which Package Should I Use?](#which-package-should-i-use)" above) and install it:
-
-    ```bash
-    # For the Google ADK Integration
-    pip install google-adk[toolbox]
-
-    # OR
-    
-    # For the core, framework-agnostic SDK
-    pip install toolbox-core
-
-    # OR
-
-    # For LangChain/LangGraph integration
-    pip install toolbox-langchain
-
-    # OR
-
-    # For the LlamaIndex integration
-    pip install toolbox-llamaindex
-    ```
-
-
-
-{{< notice note >}}
-Source code for [python-sdk](https://github.com/googleapis/mcp-toolbox-sdk-python)
-{{< /notice >}}
-
-
-## Explore the Python SDKs
+<html>
+  <head>
+    <title>Redirecting to the Python SDK API reference</title>
+    <link rel="canonical" href="https://py.mcp-toolbox.dev"/>
+    <meta http-equiv="refresh" content="0;url=https://py.mcp-toolbox.dev"/>
+  </head>
+  <body>
+    <p>If you are not automatically redirected, please <a href="https://py.mcp-toolbox.dev">follow this link to the Python SDK API reference</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
Redirects the Python, JavaScript, and Go SDK landing pages (Connect to Toolbox → Toolbox SDKs) to their API reference sites: py/js/go.mcp-toolbox.dev. Uses the existing redirect pattern (`manualLink` + meta-refresh), same tab. Java is unchanged; child usage guides are kept. Also fixes the malformed Go link in the top-level SDKs index.