### PR TITLE
feat: support MCP 2026 draft specs

### DIFF
--- a/cmd/internal/flags.go
+++ b/cmd/internal/flags.go
@@ -75,4 +75,5 @@ func ServeFlags(flags *pflag.FlagSet, opts *ToolboxOptions) {
 	flags.StringSliceVar(&opts.Cfg.AllowedOrigins, "allowed-origins", []string{"*"}, "Specifies a list of origins permitted to access this server. Defaults to '*'.")
 	flags.StringSliceVar(&opts.Cfg.AllowedHosts, "allowed-hosts", []string{"*"}, "Specifies a list of hosts permitted to access this server. Defaults to '*'.")
 	flags.Int64Var(&opts.Cfg.HttpMaxRequestBytes, "http-max-request-bytes", server.DefaultHTTPMaxRequestBytes, "Maximum MCP HTTP request body size in bytes.")
+	flags.BoolVar(&opts.Cfg.EnableDraftSpecs, "enable-draft-specs", false, "Opt-in and test upcoming draft MCP specifications.")
 }

--- a/docs/en/documentation/introduction/_index.md
+++ b/docs/en/documentation/introduction/_index.md
@@ -762,3 +762,46 @@ For more detailed instructions on using the Toolbox Go SDK, see the
 [README](https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/core/README.md).
 
 For more details, see the [Agent Skills guide](https://mcp-toolbox.dev/documentation/configuration/skills/).
+
+## Supported MCP Version
+
+Toolbox is fully compatible with the Model Context Protocol (MCP) and maintains support for multiple protocol revisions to ensure seamless integration with most MCP clients.
+
+### Stable Releases
+The following official MCP specification versions are currently supported for production use:
+
+* `2025-11-25`
+* `2025-06-18`
+* `2025-03-26`
+* `2024-11-05`
+
+{{< notice note >}}
+If no protocol version is negotiated or provided, the Toolbox server defaults to
+the legacy custom transport protocol established on `2024-11-05`, which does not
+require initialization.
+{{< /notice >}}
+
+### Draft Specifications
+We actively develop against upcoming protocol specifications. You can opt-in to
+test these forthcoming revisions before their official release using the
+`--enable-draft-specs` flag during server startup.
+
+To test these draft specifications, enable the startup flag and use this version
+string during negotiation:
+* `DRAFT-2026-v1`
+
+Description: Enables experimental support for upcoming draft MCP specifications,
+allowing you to test new schema standards and transport adjustments before they
+become stable.
+
+{{< notice note >}}
+Once the draft specification is finalized and released as a stable version, the
+draft implementation will be permanently removed. The flag itself will not be
+removed, but its functionality will remain dormant (having no effect on the
+server) until a new draft specification becomes available.
+
+There will be no automatic redirects or backwards compatibility from the draft
+spec to the stable release. Developers must manually migrate their clients to
+the stable version once it is available. Do not use this flag in production
+environments.
+{{< /notice >}}

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -14,7 +14,7 @@ description: >
 |              | `--disable-reload`         | Disables dynamic reloading config.                                                                                                                                        |             |
 | `-h`         | `--help`                   | help for toolbox                                                                                                                                                          |             |
 |              | `--http-max-request-bytes` | Maximum MCP HTTP request body size in bytes.                                                                                                                              | `10485760`  |
-|              | `--ignore-unknown-tools`   | Log warnings and skip unknown/unsupported tool types instead of failing to start.                                                                                          |             |
+|              | `--ignore-unknown-tools`   | Log warnings and skip unknown/unsupported tool types instead of failing to start.                                                                                         |             |
 |              | `--log-level`              | Specify the minimum level logged. Allowed: 'DEBUG', 'INFO', 'WARN', 'ERROR'.                                                                                              | `info`      |
 |              | `--logging-format`         | Specify logging format to use. Allowed: 'standard' or 'JSON'.                                                                                                             | `standard`  |
 |              | `--mcp-prm-file`           | Path to a manual Protected Resource Metadata (PRM) JSON file. If provided, overrides auto-generation for MCP Server-Wide Authentication.                                  |             |
@@ -36,6 +36,7 @@ description: >
 |              | `--allowed-hosts`          | Specifies a list of hosts permitted to access this server to prevent DNS rebinding attacks.                                                                               | `*`         |
 |              | `--user-agent-metadata`    | Appends additional metadata to the User-Agent.                                                                                                                            |             |
 |              | `--poll-interval`          | Specifies the polling frequency (seconds) for configuration file updates.                                                                                                 | `0`         |
+|              | `--enable-draft-specs`     | Opt-in and test upcoming draft MCP specifications.                                                                                                                        | `false`     |
 | `-v`         | `--version`                | version for toolbox                                                                                                                                                       |             |
 
 ## Sub Commands

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -143,3 +143,9 @@ func withHTTPMaxRequestBytes(limit int64) func(*Server) {
 		s.httpMaxRequestBytes = limit
 	}
 }
+
+func withEnableDraftSpecs() func(*Server) {
+	return func(s *Server) {
+		s.enableDraftSpecs = true
+	}
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -99,6 +99,8 @@ type ServerConfig struct {
 	PollInterval int
 	// HttpMaxRequestBytes caps MCP HTTP request bodies. Zero uses the default.
 	HttpMaxRequestBytes int64
+	// EnableDraftSpecs allow users to opt-in and test upcoming draft MCP specs.
+	EnableDraftSpecs bool
 }
 
 type logFormat string

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -837,7 +837,7 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			version = mcputil.LATEST_PROTOCOL_VERSION
 		}
 
-		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
+		result, err := mcp.ProcessMethod(ctx, s.enableDraftSpecs, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			if rpcErr, ok := result.(jsonrpc.JSONRPCError); ok {
@@ -867,7 +867,7 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			span.SetAttributes(attribute.String("error.type", metricErrorType))
 			return "", rpcErr, err
 		}
-		result, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, promptset, s.ResourceMgr, body, header)
+		result, err := mcp.ProcessMethod(ctx, s.enableDraftSpecs, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, promptset, s.ResourceMgr, body, header)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			// Set error.type based on JSON-RPC error code

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -270,7 +270,7 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 			// if protocol version was found in meta, it takes precedence
 			// the metaProtocolVersion does not replace existing protocol
 			// version if initialize method took place
-			if metaProtocolVersion != "" {
+			if protocol == "" && metaProtocolVersion != "" {
 				protocol = metaProtocolVersion
 			}
 
@@ -815,6 +815,7 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 	// Add instrumentation and toolbox version to context for use in method handlers
 	ctx = util.WithInstrumentation(ctx, s.instrumentation)
 	ctx = util.WithToolboxVersionKey(ctx, s.version)
+	ctx = util.WithEnableDraftSpecs(ctx, s.enableDraftSpecs)
 	// Process the method
 	switch baseMessage.Method {
 	// This is only used for <v2026
@@ -831,13 +832,13 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 
 		var version string
 		v := initReq.Params.ProtocolVersion
-		if slices.Contains(mcputil.SUPPORTED_PROTOCOL_VERSIONS, v) {
+		if slices.Contains(mcputil.GetSupportedVersions(s.enableDraftSpecs), v) {
 			version = v
 		} else {
-			version = mcputil.LATEST_PROTOCOL_VERSION
+			version = mcputil.GetLatestSupportedVersion(s.enableDraftSpecs)
 		}
 
-		result, err := mcp.ProcessMethod(ctx, s.enableDraftSpecs, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
+		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			if rpcErr, ok := result.(jsonrpc.JSONRPCError); ok {
@@ -867,7 +868,7 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			span.SetAttributes(attribute.String("error.type", metricErrorType))
 			return "", rpcErr, err
 		}
-		result, err := mcp.ProcessMethod(ctx, s.enableDraftSpecs, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, promptset, s.ResourceMgr, body, header)
+		result, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, toolset, promptset, s.ResourceMgr, body, header)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			// Set error.type based on JSON-RPC error code

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -151,19 +151,20 @@ func (c traceContextCarrier) Keys() []string {
 
 // extractMeta parses params._meta from the request body in a single pass,
 // extracting both W3C Trace Context and client telemetry attributes.
-func extractMeta(ctx context.Context, body []byte) context.Context {
+func extractMeta(ctx context.Context, body []byte) (string, context.Context) {
 	var req struct {
 		Params struct {
 			Meta struct {
-				Traceparent    string            `json:"traceparent,omitempty"`
-				Tracestate     string            `json:"tracestate,omitempty"`
-				TelemetryAttrs map[string]string `json:"dev.mcp-toolbox/telemetry,omitempty"`
+				Traceparent     string            `json:"traceparent,omitempty"`
+				Tracestate      string            `json:"tracestate,omitempty"`
+				TelemetryAttrs  map[string]string `json:"dev.mcp-toolbox/telemetry,omitempty"`
+				ProtocolVersion string            `json:"io.modelcontextprotocol/protocolVersion"`
 			} `json:"_meta,omitempty"`
 		} `json:"params,omitempty"`
 	}
 
 	if err := json.Unmarshal(body, &req); err != nil {
-		return ctx
+		return "", ctx
 	}
 
 	// Extract W3C Trace Context
@@ -189,7 +190,7 @@ func extractMeta(ctx context.Context, body []byte) context.Context {
 		ctx = util.WithTelemetryAttributes(ctx, ta)
 	}
 
-	return ctx
+	return req.Params.Meta.ProtocolVersion, ctx
 }
 
 func NewStdioSession(s *Server, stdin io.Reader, stdout io.Writer) *stdioSession {
@@ -257,7 +258,7 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 
 		if err := func() error {
 			// This ensures the transport span becomes a child of the client span
-			msgCtx := extractMeta(ctx, []byte(line))
+			metaProtocolVersion, msgCtx := extractMeta(ctx, []byte(line))
 
 			// Create span for STDIO transport
 			msgCtx, span := s.server.instrumentation.Tracer.Start(msgCtx, "toolbox/server/mcp/stdio",
@@ -265,9 +266,17 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 			)
 			defer span.End()
 
+			protocol := s.protocol
+			// if protocol version was found in meta, it takes precedence
+			// the metaProtocolVersion does not replace existing protocol
+			// version if initialize method took place
+			if metaProtocolVersion != "" {
+				protocol = metaProtocolVersion
+			}
+
 			var v string
 			var res any
-			v, res, err = processMcpMessage(msgCtx, []byte(line), s.server, s.protocol, "", "", nil, "")
+			v, res, err = processMcpMessage(msgCtx, []byte(line), s.server, protocol, "", "", nil, "")
 			if err != nil {
 				// errors during the processing of message will generate a valid MCP Error response.
 				// server can continue to run.
@@ -528,7 +537,8 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// This ensures the transport span becomes a child of the client span
-	ctx = extractMeta(ctx, body)
+	// _meta.ProtocolVersion is not checked here for http transport.
+	_, ctx = extractMeta(ctx, body)
 
 	// Create span for HTTP transport
 	ctx, span := s.instrumentation.Tracer.Start(ctx, "toolbox/server/mcp/http",
@@ -566,11 +576,6 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	// Only supported for v2025-06-18+.
 	headerProtocolVersion := r.Header.Get("Mcp-Protocol-Version")
 	if headerProtocolVersion != "" {
-		if !mcp.VerifyProtocolVersion(headerProtocolVersion) {
-			err := fmt.Errorf("invalid protocol version: %s", headerProtocolVersion)
-			_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
-			return
-		}
 		protocolVersion = headerProtocolVersion
 	}
 
@@ -645,6 +650,10 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
 			}
+		case jsonrpc.METHOD_NOT_FOUND:
+			w.WriteHeader(http.StatusNotFound)
+		case jsonrpc.HEADER_MISMATCH, jsonrpc.UNSUPPORTED_PROTOCOL_VERSION:
+			w.WriteHeader(http.StatusBadRequest)
 		}
 	}
 
@@ -803,11 +812,12 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 		return "", nil, err
 	}
 
-	// Add instrumentation to context for use in method handlers
+	// Add instrumentation and toolbox version to context for use in method handlers
 	ctx = util.WithInstrumentation(ctx, s.instrumentation)
-
+	ctx = util.WithToolboxVersionKey(ctx, s.version)
 	// Process the method
 	switch baseMessage.Method {
+	// This is only used for <v2026
 	case "initialize":
 		var initReq struct {
 			Params struct {
@@ -827,7 +837,6 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			version = mcputil.LATEST_PROTOCOL_VERSION
 		}
 
-		ctx = util.WithToolboxVersionKey(ctx, s.version)
 		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())

--- a/internal/server/mcp/jsonrpc/jsonrpc.go
+++ b/internal/server/mcp/jsonrpc/jsonrpc.go
@@ -159,7 +159,7 @@ func NewError(id RequestId, code int, message string, data any) JSONRPCError {
 	}
 }
 
-func NewUnsupportedProtocolVersionError(id RequestId, v string) (JSONRPCError, error) {
+func NewUnsupportedProtocolVersionError(id RequestId, v string, enableDraft bool) (JSONRPCError, error) {
 	err := fmt.Errorf("unsupported protocol version")
 	return JSONRPCError{
 		Jsonrpc: JSONRPC_VERSION,
@@ -171,7 +171,7 @@ func NewUnsupportedProtocolVersionError(id RequestId, v string) (JSONRPCError, e
 				Supported []string `json:"supported"`
 				Requested string   `json:"requested"`
 			}{
-				Supported: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
+				Supported: mcputil.GetSupportedVersions(enableDraft),
 				Requested: v,
 			},
 		},

--- a/internal/server/mcp/jsonrpc/jsonrpc.go
+++ b/internal/server/mcp/jsonrpc/jsonrpc.go
@@ -14,20 +14,29 @@
 
 package jsonrpc
 
+import (
+	"fmt"
+
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
+)
+
 // JSONRPC_VERSION is the version of JSON-RPC used by MCP.
 const JSONRPC_VERSION = "2.0"
 
 const (
 	// Standard JSON-RPC error codes
-	PARSE_ERROR      = -32700
-	INVALID_REQUEST  = -32600
-	METHOD_NOT_FOUND = -32601
-	INVALID_PARAMS   = -32602
-	INTERNAL_ERROR   = -32603
+	PARSE_ERROR                        = -32700
+	INVALID_REQUEST                    = -32600
+	METHOD_NOT_FOUND                   = -32601
+	INVALID_PARAMS                     = -32602
+	INTERNAL_ERROR                     = -32603
+	HEADER_MISMATCH                    = -32001
+	MISSING_REQUIRED_CLIENT_CAPABILITY = -32003
+	UNSUPPORTED_PROTOCOL_VERSION       = -32004
 
 	// Custom auth error codes
-	UNAUTHORIZED = -32001
-	FORBIDDEN    = -32003
+	UNAUTHORIZED = -401
+	FORBIDDEN    = -403
 )
 
 // ProgressToken is used to associate progress notifications with the original request.
@@ -40,20 +49,16 @@ type RequestId interface{}
 // Request represents a bidirectional message with method and parameters expecting a response.
 type Request struct {
 	Method string `json:"method"`
-	Params struct {
-		Meta struct {
-			// If specified, the caller is requesting out-of-band progress
-			// notifications for this request (as represented by
-			// notifications/progress). The value of this parameter is an
-			// opaque token that will be attached to any subsequent
-			// notifications. The receiver is not obligated to provide these
-			// notifications.
-			ProgressToken ProgressToken `json:"progressToken,omitempty"`
-			// W3C Trace Context fields for distributed tracing
-			Traceparent string `json:"traceparent,omitempty"`
-			Tracestate  string `json:"tracestate,omitempty"`
-		} `json:"_meta,omitempty"`
-	} `json:"params,omitempty"`
+}
+
+type RequestParams struct {
+	Meta *RequestMetaObject `json:"_meta"`
+}
+
+type RequestMetaObject struct {
+	// W3C Trace Context fields for distributed tracing
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
 }
 
 // JSONRPCRequest represents a request that expects a response.
@@ -135,9 +140,10 @@ type JSONRPCError struct {
 
 // Generic baseMessage could either be a JSONRPCNotification or JSONRPCRequest
 type BaseMessage struct {
-	Jsonrpc string    `json:"jsonrpc"`
-	Method  string    `json:"method"`
-	Id      RequestId `json:"id,omitempty"`
+	Jsonrpc string         `json:"jsonrpc"`
+	Method  string         `json:"method"`
+	Id      RequestId      `json:"id,omitempty"`
+	Params  *RequestParams `json:"params,omitempty"`
 }
 
 // NewError is the standard JSONRPC response sent back when an error has been encountered.
@@ -149,6 +155,36 @@ func NewError(id RequestId, code int, message string, data any) JSONRPCError {
 			Code:    code,
 			Message: message,
 			Data:    data,
+		},
+	}
+}
+
+func NewUnsupportedProtocolVersionError(id RequestId, v string) (JSONRPCError, error) {
+	err := fmt.Errorf("unsupported protocol version")
+	return JSONRPCError{
+		Jsonrpc: JSONRPC_VERSION,
+		Id:      id,
+		Error: Error{
+			Code:    UNSUPPORTED_PROTOCOL_VERSION,
+			Message: err.Error(),
+			Data: struct {
+				Supported []string `json:"supported"`
+				Requested string   `json:"requested"`
+			}{
+				Supported: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
+				Requested: v,
+			},
+		},
+	}, err
+}
+
+func NewHeaderMismatchedError(id RequestId, err error) JSONRPCError {
+	return JSONRPCError{
+		Jsonrpc: JSONRPC_VERSION,
+		Id:      id,
+		Error: Error{
+			Code:    HEADER_MISMATCH,
+			Message: err.Error(),
 		},
 	}
 }

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -28,6 +28,7 @@ import (
 	v20250326 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20250326"
 	v20250618 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20250618"
 	v20251125 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20251125"
+	vdraft "github.com/googleapis/mcp-toolbox/internal/server/mcp/vdraft"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 )
@@ -46,14 +47,18 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 // This is the Operation phase of the lifecycle for MCP client-server connections.
 func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch mcpVersion {
-	case v20251125.PROTOCOL_VERSION:
+	case mcputil.VERSION_DRAFT:
+		return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+	case mcputil.VERSION_20251125:
 		return v20251125.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	case v20250618.PROTOCOL_VERSION:
+	case mcputil.VERSION_20250618:
 		return v20250618.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	case v20250326.PROTOCOL_VERSION:
+	case mcputil.VERSION_20250326:
 		return v20250326.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
-	default:
+	case "", mcputil.VERSION_20241105:
 		return v20241105.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+	default:
+		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion)
 	}
 }
 

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"slices"
 
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
@@ -47,10 +46,13 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 
 // ProcessMethod returns a response for the request.
 // This is the Operation phase of the lifecycle for MCP client-server connections.
-func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, enableDraftSpecs bool, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch mcpVersion {
 	case mcputil.VERSION_DRAFT:
-		return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+		if enableDraftSpecs {
+			return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+		}
+		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion)
 	case mcputil.VERSION_20251125:
 		return v20251125.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
 	case mcputil.VERSION_20250618:
@@ -62,9 +64,4 @@ func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId,
 	default:
 		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion)
 	}
-}
-
-// VerifyProtocolVersion verifies if the version string is valid.
-func VerifyProtocolVersion(version string) bool {
-	return slices.Contains(mcputil.SUPPORTED_PROTOCOL_VERSIONS, version)
 }

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -40,6 +40,8 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 	if err := json.Unmarshal(body, &notification); err != nil {
 		return fmt.Errorf("invalid notification request: %w", err)
 	}
+	// Since we do not enforce notifications, we do not need to check the
+	// `Mcp-Method` header here
 	return nil
 }
 

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -30,6 +30,7 @@ import (
 	vdraft "github.com/googleapis/mcp-toolbox/internal/server/mcp/vdraft"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
 )
 
 // NotificationHandler process notifications request. It MUST NOT send a response.
@@ -46,13 +47,18 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 
 // ProcessMethod returns a response for the request.
 // This is the Operation phase of the lifecycle for MCP client-server connections.
-func ProcessMethod(ctx context.Context, enableDraftSpecs bool, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+	enableDraft, ok := util.EnableDraftSpecsFromContext(ctx)
+	if !ok {
+		err := fmt.Errorf("unable to retrieve enableDraftSpecs from context")
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
 	switch mcpVersion {
 	case mcputil.VERSION_DRAFT:
-		if enableDraftSpecs {
+		if enableDraft {
 			return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
 		}
-		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion)
+		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion, enableDraft)
 	case mcputil.VERSION_20251125:
 		return v20251125.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
 	case mcputil.VERSION_20250618:
@@ -62,6 +68,6 @@ func ProcessMethod(ctx context.Context, enableDraftSpecs bool, mcpVersion string
 	case "", mcputil.VERSION_20241105:
 		return v20241105.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
 	default:
-		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion)
+		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion, enableDraft)
 	}
 }

--- a/internal/server/mcp/util/util.go
+++ b/internal/server/mcp/util/util.go
@@ -19,11 +19,12 @@ const (
 	VERSION_20250326 = "2025-03-26"
 	VERSION_20250618 = "2025-06-18"
 	VERSION_20251125 = "2025-11-25"
+	VERSION_DRAFT    = "DRAFT-2026-v1"
 )
 
 // LATEST_PROTOCOL_VERSION is the latest version of the MCP protocol supported.
 // Update the version used in InitializeResponse when this value is updated.
-const LATEST_PROTOCOL_VERSION = VERSION_20251125
+const LATEST_PROTOCOL_VERSION = VERSION_DRAFT
 
 // SUPPORTED_PROTOCOL_VERSIONS is the MCP protocol versions that are supported.
 var SUPPORTED_PROTOCOL_VERSIONS = []string{
@@ -31,4 +32,5 @@ var SUPPORTED_PROTOCOL_VERSIONS = []string{
 	VERSION_20250326,
 	VERSION_20250618,
 	VERSION_20251125,
+	VERSION_DRAFT,
 }

--- a/internal/server/mcp/util/util.go
+++ b/internal/server/mcp/util/util.go
@@ -24,7 +24,11 @@ const (
 
 // LATEST_PROTOCOL_VERSION is the latest version of the MCP protocol supported.
 // Update the version used in InitializeResponse when this value is updated.
-const LATEST_PROTOCOL_VERSION = VERSION_DRAFT
+const LATEST_PROTOCOL_VERSION = VERSION_20251125
+
+// LATEST_PROTOCOL_VERSION_NONSTABLE is the latest version of the MCP protocol
+// supported that includes non-stable version
+const LATEST_PROTOCOL_VERSION_NONSTABLE = VERSION_DRAFT
 
 // SUPPORTED_PROTOCOL_VERSIONS is the MCP protocol versions that are supported.
 var SUPPORTED_PROTOCOL_VERSIONS = []string{
@@ -32,5 +36,22 @@ var SUPPORTED_PROTOCOL_VERSIONS = []string{
 	VERSION_20250326,
 	VERSION_20250618,
 	VERSION_20251125,
+}
+
+var SUPPORTED_PROTOCOL_VERSIONS_NONSTABLE = []string{
 	VERSION_DRAFT,
+}
+
+func GetSupportedVersions(enableDraft bool) []string {
+	if enableDraft {
+		return append(SUPPORTED_PROTOCOL_VERSIONS, SUPPORTED_PROTOCOL_VERSIONS_NONSTABLE...)
+	}
+	return SUPPORTED_PROTOCOL_VERSIONS
+}
+
+func GetLatestSupportedVersion(enableDraft bool) string {
+	if enableDraft {
+		return LATEST_PROTOCOL_VERSION_NONSTABLE
+	}
+	return LATEST_PROTOCOL_VERSION
 }

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -190,7 +190,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -210,16 +213,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -190,7 +190,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -210,16 +213,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -189,7 +189,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -209,16 +212,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -189,7 +189,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -209,16 +212,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/vdraft/manifests.go
+++ b/internal/server/mcp/vdraft/manifests.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdraft
+
+import (
+	"fmt"
+
+	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+// generateToolManifest generates Tool for list tools result
+func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations) Tool {
+	inputSchema, authParams := generateParamManifest(params)
+	var toolAnnotations *ToolAnnotations
+	if annotations != nil {
+		toolAnnotations = &ToolAnnotations{
+			DestructiveHint: annotations.DestructiveHint,
+			IdempotentHint:  annotations.IdempotentHint,
+			OpenWorldHint:   annotations.OpenWorldHint,
+			ReadOnlyHint:    annotations.ReadOnlyHint,
+		}
+	}
+	mcpManifest := Tool{
+		BaseMetadata: BaseMetadata{
+			Name: name,
+		},
+		Description:     desc,
+		ToolInputSchema: inputSchema,
+		Annotations:     toolAnnotations,
+	}
+	metadata := make(map[string]any)
+	if len(authInvoke) > 0 {
+		metadata["toolbox/authInvoke"] = authInvoke
+	}
+	if len(authParams) > 0 {
+		metadata["toolbox/authParam"] = authParams
+	}
+	if len(metadata) > 0 {
+		mcpManifest.Metadata = metadata
+	}
+	return mcpManifest
+}
+
+// generateParamManifest generates the input schema and get authParam
+func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]string) {
+	properties := make(map[string]parameters.ParameterMcpManifest)
+	required := make([]string, 0)
+	authParam := make(map[string][]string)
+
+	for _, p := range ps {
+		// If the parameter is sourced from another param, skip it in the MCP manifest
+		if p.GetValueFromParam() != "" {
+			continue
+		}
+
+		name := p.GetName()
+		paramManifest, authParamList := p.McpManifest()
+		defaultV := p.GetDefault()
+		if defaultV != nil {
+			paramManifest.Default = defaultV
+		}
+		properties[name] = paramManifest
+		// parameters that doesn't have a default value are added to the required field
+		if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+			required = append(required, name)
+		}
+		if len(authParamList) > 0 {
+			authParam[name] = authParamList
+		}
+	}
+	return InputSchema{
+		Type:       "object",
+		Properties: properties,
+		Required:   required,
+	}, authParam
+}
+
+// GenerateListToolsResult generates tools/list method result according to mcp schema
+func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool) (ListToolsResult, error) {
+	mcpManifest := make([]Tool, 0, len(t.ToolNames))
+	for _, toolName := range t.ToolNames {
+		tool, ok := toolsMap[toolName]
+		if !ok {
+			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
+		}
+		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations())
+		mcpManifest = append(mcpManifest, toolManifest)
+	}
+	return ListToolsResult{Tools: mcpManifest}, nil
+}
+
+// generatePromptManifest generates a version-specific Prompt manifest for list/prompts
+func generatePromptManifest(name, desc string, args prompts.Arguments) Prompt {
+	mcpArgs := make([]PromptArgument, 0, len(args))
+	for _, arg := range args {
+		promptArg := PromptArgument{
+			BaseMetadata: BaseMetadata{Name: arg.GetName()},
+			Description:  arg.GetDesc(),
+			Required:     parameters.CheckParamRequired(arg.GetRequired(), arg.GetDefault()),
+		}
+		mcpArgs = append(mcpArgs, promptArg)
+	}
+	return Prompt{
+		BaseMetadata: BaseMetadata{Name: name},
+		Description:  desc,
+		Arguments:    mcpArgs,
+	}
+}
+
+// GenerateListPromptsResult generates the list/prompts result
+func GenerateListPromptsResult(p prompts.Promptset, promptsMap map[string]prompts.Prompt) (ListPromptsResult, error) {
+	mcpManifest := make([]Prompt, 0, len(p.PromptNames))
+	for _, promptName := range p.PromptNames {
+		prompt, ok := promptsMap[promptName]
+		if !ok {
+			return ListPromptsResult{}, fmt.Errorf("prompt does not exist: %s", promptName)
+		}
+		promptManifest := generatePromptManifest(promptName, prompt.GetDesc(), prompt.GetArguments())
+		mcpManifest = append(mcpManifest, promptManifest)
+	}
+	return ListPromptsResult{Prompts: mcpManifest}, nil
+}

--- a/internal/server/mcp/vdraft/manifests.go
+++ b/internal/server/mcp/vdraft/manifests.go
@@ -18,13 +18,14 @@ import (
 	"fmt"
 
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
 // generateToolManifest generates Tool for list tools result
-func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations) Tool {
-	inputSchema, authParams := generateParamManifest(params)
+func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations, urlParams map[string]string) Tool {
+	inputSchema, authParams := generateParamManifest(params, urlParams)
 	var toolAnnotations *ToolAnnotations
 	if annotations != nil {
 		toolAnnotations = &ToolAnnotations{
@@ -56,7 +57,7 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 }
 
 // generateParamManifest generates the input schema and get authParam
-func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]string) {
+func generateParamManifest(ps parameters.Parameters, urlParams map[string]string) (InputSchema, map[string][]string) {
 	properties := make(map[string]parameters.ParameterMcpManifest)
 	required := make([]string, 0)
 	authParam := make(map[string][]string)
@@ -68,6 +69,13 @@ func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]
 		}
 
 		name := p.GetName()
+		if urlParams != nil {
+			// If the parameter is sourced from URL params, skip it in the MCP manifest
+			if _, exists := urlParams[name]; exists {
+				continue
+			}
+		}
+
 		paramManifest, authParamList := p.McpManifest()
 		defaultV := p.GetDefault()
 		if defaultV != nil {
@@ -90,14 +98,18 @@ func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool) (ListToolsResult, error) {
+func GenerateListToolsResult(srcs map[string]sources.Source, t tools.Toolset, toolsMap map[string]tools.Tool, urlParams map[string]string) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
 		tool, ok := toolsMap[toolName]
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations())
+		params, err := tool.GetParameters(srcs)
+		if err != nil {
+			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
+		}
+		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(), urlParams)
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/vdraft/manifests_test.go
+++ b/internal/server/mcp/vdraft/manifests_test.go
@@ -1,0 +1,371 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdraft
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+func TestGenerateToolManifest(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	authServices := []parameters.ParamAuthService{
+		{
+			Name:  "my-google-auth-service",
+			Field: "auth_field",
+		},
+		{
+			Name:  "other-auth-service",
+			Field: "other_auth_field",
+		}}
+	tcs := []struct {
+		desc            string
+		name            string
+		description     string
+		authInvoke      []string
+		params          parameters.Parameters
+		annotations     *tools.ToolAnnotations
+		wantMetadata    map[string]any
+		wantAnnotations []byte
+	}{
+		{
+			desc:         "basic manifest without metadata",
+			name:         "basic",
+			description:  "foo bar",
+			authInvoke:   []string{},
+			params:       parameters.Parameters{parameters.NewStringParameter("string-param", "string parameter")},
+			annotations:  nil,
+			wantMetadata: nil,
+		},
+		{
+			desc:            "basic manifest without metadata with annotations",
+			name:            "basic",
+			description:     "foo bar",
+			authInvoke:      []string{},
+			params:          parameters.Parameters{parameters.NewStringParameter("string-param", "string parameter")},
+			annotations:     &tools.ToolAnnotations{ReadOnlyHint: &trueVal, DestructiveHint: &falseVal},
+			wantMetadata:    nil,
+			wantAnnotations: []byte(`{"readOnlyHint":true,"destructiveHint":false}`),
+		},
+		{
+			desc:         "with auth invoke metadata",
+			name:         "basic",
+			description:  "foo bar",
+			authInvoke:   []string{"auth1", "auth2"},
+			params:       parameters.Parameters{parameters.NewStringParameter("string-param", "string parameter")},
+			annotations:  nil,
+			wantMetadata: map[string]any{"toolbox/authInvoke": []string{"auth1", "auth2"}},
+		},
+		{
+			desc:        "with auth param metadata",
+			name:        "basic",
+			description: "foo bar",
+			authInvoke:  []string{},
+			params:      parameters.Parameters{parameters.NewStringParameterWithAuth("string-param", "string parameter", authServices)},
+			annotations: nil,
+			wantMetadata: map[string]any{
+				"toolbox/authParam": map[string][]string{
+					"string-param": {"my-google-auth-service", "other-auth-service"},
+				},
+			},
+		},
+		{
+			desc:        "with auth invoke and auth param metadata",
+			name:        "basic",
+			description: "foo bar",
+			authInvoke:  []string{"auth1", "auth2"},
+			params:      parameters.Parameters{parameters.NewStringParameterWithAuth("string-param", "string parameter", authServices)},
+			annotations: nil,
+			wantMetadata: map[string]any{
+				"toolbox/authInvoke": []string{"auth1", "auth2"},
+				"toolbox/authParam": map[string][]string{
+					"string-param": {"my-google-auth-service", "other-auth-service"},
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations)
+			gotM := got.Metadata
+			if diff := cmp.Diff(tc.wantMetadata, gotM); diff != "" {
+				t.Fatalf("unexpected metadata (-want +got):\n%s", diff)
+			}
+
+			if got.Annotations != nil {
+				annotations, _ := json.Marshal(got.Annotations)
+				if diff := cmp.Diff(tc.wantAnnotations, annotations); diff != "" {
+					t.Fatalf("unexpected annotations (-want +got):\n%s", diff)
+				}
+			}
+
+		})
+	}
+}
+
+func TestParamManifest(t *testing.T) {
+	authServices := []parameters.ParamAuthService{
+		{
+			Name:  "my-google-auth-service",
+			Field: "auth_field",
+		},
+		{
+			Name:  "other-auth-service",
+			Field: "other_auth_field",
+		}}
+	tcs := []struct {
+		name          string
+		in            parameters.Parameters
+		wantSchema    InputSchema
+		wantAuthParam map[string][]string
+	}{
+		{
+			name: "all types",
+			in: parameters.Parameters{
+				parameters.NewStringParameterWithDefault("foo-string", "foo", "bar"),
+				parameters.NewStringParameter("foo-string2", "bar"),
+				parameters.NewStringParameterWithAuth("foo-string3-auth", "bar", authServices),
+				parameters.NewIntParameter("foo-int2", "bar"),
+				parameters.NewFloatParameter("foo-float", "bar"),
+				parameters.NewArrayParameter("foo-array2", "bar", parameters.NewStringParameter("foo-string", "bar")),
+				parameters.NewMapParameter("foo-map-int", "a map of ints", "integer"),
+				parameters.NewMapParameter("foo-map-any", "a map of any", ""),
+			},
+			wantSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]parameters.ParameterMcpManifest{
+					"foo-string":       {Type: "string", Description: "bar", Default: "foo"},
+					"foo-string2":      {Type: "string", Description: "bar"},
+					"foo-string3-auth": {Type: "string", Description: "bar"},
+					"foo-int2":         {Type: "integer", Description: "bar"},
+					"foo-float":        {Type: "number", Description: "bar"},
+					"foo-array2": {
+						Type:        "array",
+						Description: "bar",
+						Items:       &parameters.ParameterMcpManifest{Type: "string", Description: "bar"},
+					},
+					"foo-map-int": {
+						Type:                 "object",
+						Description:          "a map of ints",
+						AdditionalProperties: map[string]any{"type": "integer"},
+					},
+					"foo-map-any": {
+						Type:                 "object",
+						Description:          "a map of any",
+						AdditionalProperties: true,
+					},
+				},
+				Required: []string{"foo-string2", "foo-string3-auth", "foo-int2", "foo-float", "foo-array2", "foo-map-int", "foo-map-any"},
+			},
+			wantAuthParam: map[string][]string{
+				"foo-string3-auth": []string{"my-google-auth-service", "other-auth-service"},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSchema, gotAuthParam := generateParamManifest(tc.in)
+			if diff := cmp.Diff(tc.wantSchema, gotSchema); diff != "" {
+				t.Fatalf("unexpected manifest (-want +got):\n%s", diff)
+			}
+			if len(gotAuthParam) != len(tc.wantAuthParam) {
+				t.Fatalf("got %d items in auth param map, want %d", len(gotAuthParam), len(tc.wantAuthParam))
+			}
+			for k, want := range tc.wantAuthParam {
+				got, ok := gotAuthParam[k]
+				if !ok {
+					t.Fatalf("missing auth param: %s", k)
+				}
+				slices.Sort(got)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("unexpected auth param, got %s, want %s", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateListToolsResult(t *testing.T) {
+	tool1 := testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+	tool2 := testutils.NewMockTool(
+		"some_params",
+		"",
+		parameters.Parameters{
+			parameters.NewIntParameter("param1", "This is the first parameter."),
+			parameters.NewIntParameter("param2", "This is the second parameter."),
+		}, false, false)
+	toolsMap := make(map[string]tools.Tool)
+	toolsMap[tool1.Name] = tool1
+	toolsMap[tool2.Name] = tool2
+	tc := tools.ToolsetConfig{
+		Name:      "test-toolset",
+		ToolNames: []string{"no_params", "some_params"},
+	}
+	toolset, err := tc.Initialize("test-version", toolsMap)
+	if err != nil {
+		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
+	}
+
+	got, err := GenerateListToolsResult(toolset, toolsMap)
+	if err != nil {
+		t.Fatalf("unable to generate list tools result: %s", err)
+	}
+	want := ListToolsResult{
+		Tools: []Tool{
+			Tool{
+				BaseMetadata: BaseMetadata{Name: "no_params"},
+				Description:  "",
+				ToolInputSchema: InputSchema{
+					Type:       "object",
+					Properties: map[string]parameters.ParameterMcpManifest{},
+					Required:   []string{},
+				},
+			},
+			Tool{
+				BaseMetadata: BaseMetadata{Name: "some_params"},
+				Description:  "",
+				ToolInputSchema: InputSchema{
+					Type: "object",
+					Properties: map[string]parameters.ParameterMcpManifest{
+						"param1": parameters.ParameterMcpManifest{
+							Type:                 "integer",
+							Description:          "This is the first parameter.",
+							Items:                nil,
+							Default:              nil,
+							AdditionalProperties: nil,
+						},
+						"param2": parameters.ParameterMcpManifest{
+							Type:                 "integer",
+							Description:          "This is the second parameter.",
+							Items:                nil,
+							Default:              nil,
+							AdditionalProperties: nil,
+						},
+					},
+					Required: []string{"param1", "param2"},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("unexpected list tools result (-want +got):\n%s", diff)
+	}
+}
+
+func TestGeneratePromptManifest(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name        string
+		promptName  string
+		description string
+		args        prompts.Arguments
+		want        Prompt
+	}{
+		{
+			name:        "No arguments",
+			promptName:  "test-prompt",
+			description: "A test prompt.",
+			args:        prompts.Arguments{},
+			want: Prompt{
+				BaseMetadata: BaseMetadata{Name: "test-prompt"},
+				Description:  "A test prompt.",
+				Arguments:    []PromptArgument{},
+			},
+		},
+		{
+			name:        "With arguments",
+			promptName:  "arg-prompt",
+			description: "Prompt with args.",
+			args: prompts.Arguments{
+				{Parameter: parameters.NewStringParameter("param1", "First param")},
+				{Parameter: parameters.NewIntParameterWithRequired("param2", "Second param", false)},
+			},
+			want: Prompt{
+				BaseMetadata: BaseMetadata{Name: "arg-prompt"},
+				Description:  "Prompt with args.",
+				Arguments: []PromptArgument{
+					{BaseMetadata: BaseMetadata{Name: "param1"}, Description: "First param", Required: true},
+					{BaseMetadata: BaseMetadata{Name: "param2"}, Description: "Second param", Required: false},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := generatePromptManifest(tc.promptName, tc.description, tc.args)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("generatePromptManifest() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateListPromptsResult(t *testing.T) {
+	args := prompts.Arguments{
+		{Parameter: parameters.NewStringParameter("arg1", "Test argument")},
+	}
+	prompt1 := testutils.NewMockPrompt("prompt1", "First test prompt", prompts.Arguments{})
+	prompt2 := testutils.NewMockPrompt("prompt2", "Second test prompt", args)
+
+	promptsMap := make(map[string]prompts.Prompt)
+	promptsMap[prompt1.Name] = prompt1
+	promptsMap[prompt2.Name] = prompt2
+	pc := prompts.PromptsetConfig{
+		Name:        "test-promptset",
+		PromptNames: []string{"prompt1", "prompt2"},
+	}
+	promptset, err := pc.Initialize("test-version", promptsMap)
+	if err != nil {
+		t.Fatalf("unable to initialize promptset %q: %s", "test-promptset", err)
+	}
+
+	got, err := GenerateListPromptsResult(promptset, promptsMap)
+	if err != nil {
+		t.Fatalf("unable to generate list prompt result: %s", err)
+	}
+	want := ListPromptsResult{
+		Prompts: []Prompt{
+			Prompt{
+				BaseMetadata: BaseMetadata{Name: "prompt1"},
+				Description:  "First test prompt",
+				Arguments:    []PromptArgument{},
+			},
+			Prompt{
+				BaseMetadata: BaseMetadata{Name: "prompt2"},
+				Description:  "Second test prompt",
+				Arguments: []PromptArgument{
+					PromptArgument{
+						BaseMetadata: BaseMetadata{Name: "arg1"},
+						Description:  "Test argument",
+						Required:     true,
+					},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("unexpected list tools result (-want +got):\n%s", diff)
+	}
+}

--- a/internal/server/mcp/vdraft/manifests_test.go
+++ b/internal/server/mcp/vdraft/manifests_test.go
@@ -83,7 +83,7 @@ func TestGenerateToolManifest(t *testing.T) {
 			name:        "basic",
 			description: "foo bar",
 			authInvoke:  []string{},
-			params:      parameters.Parameters{parameters.NewStringParameterWithAuth("string-param", "string parameter", authServices)},
+			params:      parameters.Parameters{parameters.NewStringParameter("string-param", "string parameter", parameters.WithStringAuth(authServices))},
 			annotations: nil,
 			wantMetadata: map[string]any{
 				"toolbox/authParam": map[string][]string{
@@ -96,7 +96,7 @@ func TestGenerateToolManifest(t *testing.T) {
 			name:        "basic",
 			description: "foo bar",
 			authInvoke:  []string{"auth1", "auth2"},
-			params:      parameters.Parameters{parameters.NewStringParameterWithAuth("string-param", "string parameter", authServices)},
+			params:      parameters.Parameters{parameters.NewStringParameter("string-param", "string parameter", parameters.WithStringAuth(authServices))},
 			annotations: nil,
 			wantMetadata: map[string]any{
 				"toolbox/authInvoke": []string{"auth1", "auth2"},
@@ -108,19 +108,21 @@ func TestGenerateToolManifest(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			got := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations)
+			got := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations, nil)
 			gotM := got.Metadata
 			if diff := cmp.Diff(tc.wantMetadata, gotM); diff != "" {
 				t.Fatalf("unexpected metadata (-want +got):\n%s", diff)
 			}
 
-			if got.Annotations != nil {
-				annotations, _ := json.Marshal(got.Annotations)
+			if tc.wantAnnotations != nil {
+				annotations, err := json.Marshal(got.Annotations)
+				if err != nil {
+					t.Fatalf("error marshaling annotations")
+				}
 				if diff := cmp.Diff(tc.wantAnnotations, annotations); diff != "" {
 					t.Fatalf("unexpected annotations (-want +got):\n%s", diff)
 				}
 			}
-
 		})
 	}
 }
@@ -138,15 +140,16 @@ func TestParamManifest(t *testing.T) {
 	tcs := []struct {
 		name          string
 		in            parameters.Parameters
+		urlParams     map[string]string
 		wantSchema    InputSchema
 		wantAuthParam map[string][]string
 	}{
 		{
 			name: "all types",
 			in: parameters.Parameters{
-				parameters.NewStringParameterWithDefault("foo-string", "foo", "bar"),
+				parameters.NewStringParameter("foo-string", "bar", parameters.WithStringDefault("foo")),
 				parameters.NewStringParameter("foo-string2", "bar"),
-				parameters.NewStringParameterWithAuth("foo-string3-auth", "bar", authServices),
+				parameters.NewStringParameter("foo-string3-auth", "bar", parameters.WithStringAuth(authServices)),
 				parameters.NewIntParameter("foo-int2", "bar"),
 				parameters.NewFloatParameter("foo-float", "bar"),
 				parameters.NewArrayParameter("foo-array2", "bar", parameters.NewStringParameter("foo-string", "bar")),
@@ -183,10 +186,28 @@ func TestParamManifest(t *testing.T) {
 				"foo-string3-auth": []string{"my-google-auth-service", "other-auth-service"},
 			},
 		},
+		{
+			name: "urlParams is not nil, skips matched params",
+			in: parameters.Parameters{
+				parameters.NewStringParameter("foo-string", "bar"),
+				parameters.NewIntParameter("foo-int", "bar"),
+			},
+			urlParams: map[string]string{
+				"foo-string": "url-val",
+			},
+			wantSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]parameters.ParameterMcpManifest{
+					"foo-int": {Type: "integer", Description: "bar"},
+				},
+				Required: []string{"foo-int"},
+			},
+			wantAuthParam: map[string][]string{},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotAuthParam := generateParamManifest(tc.in)
+			gotSchema, gotAuthParam := generateParamManifest(tc.in, tc.urlParams)
 			if diff := cmp.Diff(tc.wantSchema, gotSchema); diff != "" {
 				t.Fatalf("unexpected manifest (-want +got):\n%s", diff)
 			}
@@ -228,7 +249,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(toolset, toolsMap)
+	got, err := GenerateListToolsResult(nil, toolset, toolsMap, nil)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}
@@ -300,7 +321,7 @@ func TestGeneratePromptManifest(t *testing.T) {
 			description: "Prompt with args.",
 			args: prompts.Arguments{
 				{Parameter: parameters.NewStringParameter("param1", "First param")},
-				{Parameter: parameters.NewIntParameterWithRequired("param2", "Second param", false)},
+				{Parameter: parameters.NewIntParameter("param2", "Second param", parameters.WithIntRequired(false))},
 			},
 			want: Prompt{
 				BaseMetadata: BaseMetadata{Name: "arg-prompt"},

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -1,0 +1,524 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdraft
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
+	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/resources"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ProcessMethod returns a response for the request.
+func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+	switch method {
+	case INITIALIZE:
+		return initializeHandler(ctx, id, body)
+	case PING:
+		return pingHandler(id)
+	case TOOLS_LIST:
+		return toolsListHandler(id, resourceMgr, toolset, body)
+	case TOOLS_CALL:
+		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
+	case PROMPTS_LIST:
+		return promptsListHandler(ctx, id, resourceMgr, promptset, body)
+	case PROMPTS_GET:
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body)
+	default:
+		err := fmt.Errorf("invalid method %s", method)
+		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
+	}
+}
+
+// InitializeResponse runs capability negotiation and protocol version agreement.
+// This is the Initialization phase of the lifecycle for MCP client-server connections.
+// Always start with the latest protocol version supported.
+func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+	v, err := util.ToolboxVersionFromContext(ctx)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	var req InitializeRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("invalid mcp initialize request: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	toolsListChanged := false
+	promptsListChanged := false
+	result := InitializeResult{
+		ProtocolVersion: PROTOCOL_VERSION,
+		Capabilities: ServerCapabilities{
+			Tools: &ListChanged{
+				ListChanged: &toolsListChanged,
+			},
+			Prompts: &ListChanged{
+				ListChanged: &promptsListChanged,
+			},
+		},
+		ServerInfo: Implementation{
+			BaseMetadata: BaseMetadata{
+				Name: SERVER_NAME,
+			},
+			Version: v,
+		},
+	}
+	res := jsonrpc.JSONRPCResponse{
+		Jsonrpc: jsonrpc.JSONRPC_VERSION,
+		Id:      id,
+		Result:  result,
+	}
+
+	return res, nil
+}
+
+// pingHandler handles the "ping" method by returning an empty response.
+func pingHandler(id jsonrpc.RequestId) (any, error) {
+	return jsonrpc.JSONRPCResponse{
+		Jsonrpc: jsonrpc.JSONRPC_VERSION,
+		Id:      id,
+		Result:  struct{}{},
+	}, nil
+}
+
+func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
+	var req ListToolsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("invalid mcp tools list request: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	toolsMap := resourceMgr.GetToolsMap()
+	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap)
+	if err != nil {
+		err = fmt.Errorf("error generating manifest: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	return jsonrpc.JSONRPCResponse{
+		Jsonrpc: jsonrpc.JSONRPC_VERSION,
+		Id:      id,
+		Result:  listToolsResult,
+	}, nil
+}
+
+// toolsCallHandler generate a response for tools call.
+func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.Toolset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+	authServices := resourceMgr.GetAuthServiceMap()
+
+	// retrieve logger from context
+	logger, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	var req CallToolRequest
+	if err = json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("invalid mcp tools call request: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	toolName := req.Params.Name
+	toolArgument := req.Params.Arguments
+	logger.DebugContext(ctx, fmt.Sprintf("tool name: %s", toolName))
+
+	// Update span name and set gen_ai attributes
+	span := trace.SpanFromContext(ctx)
+	span.SetName(fmt.Sprintf("%s %s", TOOLS_CALL, toolName))
+	span.SetAttributes(
+		attribute.String("gen_ai.tool.name", toolName),
+		attribute.String("gen_ai.operation.name", "execute_tool"),
+	)
+
+	// Verify tool belongs to the current toolset before resolving globally.
+	if !toolset.ContainsTool(toolName) {
+		err = fmt.Errorf("invalid tool name: tool with name %q does not exist", toolName)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
+
+	tool, ok := resourceMgr.GetTool(toolName)
+	if !ok {
+		err = fmt.Errorf("invalid tool name: tool with name %q does not exist", toolName)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
+
+	// Populate gen_ai attributes for operation duration metric
+	if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
+		genAIAttrs.OperationName = "execute_tool"
+		genAIAttrs.ToolName = toolName
+	}
+
+	// Get access token
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(resourceMgr)
+	if err != nil {
+		errMsg := fmt.Errorf("error during invocation: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
+	}
+	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+
+	// Check if this specific tool requires the standard authorization header
+	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
+	if err != nil {
+		errMsg := fmt.Errorf("error during invocation: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
+	}
+	if clientAuth {
+		if accessToken == "" {
+			err := util.NewClientServerError(
+				"missing access token in the 'Authorization' header",
+				http.StatusUnauthorized,
+				nil,
+			)
+			return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+		}
+	}
+
+	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
+	aMarshal, err := json.Marshal(toolArgument)
+	if err != nil {
+		err = fmt.Errorf("unable to marshal tools argument: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	var data map[string]any
+	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+		err = fmt.Errorf("unable to decode tools argument: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	// Tool authentication
+	// claimsFromAuth maps the name of the authservice to the claims retrieved from it.
+	claimsFromAuth := make(map[string]map[string]any)
+
+	// if using stdio, header will be nil and auth will not be supported
+	if header != nil {
+		for _, aS := range authServices {
+			claims, err := aS.GetClaimsFromHeader(ctx, header)
+			if err != nil {
+				logger.DebugContext(ctx, err.Error())
+				continue
+			}
+			if claims == nil {
+				// authService not present in header
+				continue
+			}
+			claimsFromAuth[aS.GetName()] = claims
+		}
+	}
+
+	// Tool authorization check
+	verifiedAuthServices := make([]string, len(claimsFromAuth))
+	i := 0
+	for k := range claimsFromAuth {
+		verifiedAuthServices[i] = k
+		i++
+	}
+
+	// Check if any of the specified auth services is verified
+	isAuthorized := tool.Authorized(verifiedAuthServices)
+	if !isAuthorized {
+		err = util.NewClientServerError(
+			"unauthorized Tool call: Please make sure you specify correct auth headers",
+			http.StatusUnauthorized,
+			nil,
+		)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	logger.DebugContext(ctx, "tool invocation authorized")
+
+	// Find MCP enabled auth service
+	var mcpSvcName string
+	for _, aS := range authServices {
+		cfg := aS.ToConfig()
+		if genCfg, ok := cfg.(generic.Config); ok && genCfg.McpEnabled {
+			mcpSvcName = aS.GetName()
+			break
+		}
+	}
+
+	toolScopes := tool.GetScopesRequired()
+	if mcpSvcName != "" && len(toolScopes) > 0 {
+		claims := util.AuthTokenClaimsFromContext(ctx)
+		if claims == nil {
+			err = &generic.MCPAuthError{
+				Code:           http.StatusForbidden,
+				Message:        "missing claims for MCP authorization",
+				ScopesRequired: toolScopes,
+			}
+			return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+		}
+
+		scopeClaim, _ := claims["scope"].(string)
+		tokenScopes := strings.Split(scopeClaim, " ")
+
+		// Check if all required scopes are present in the token
+		missing := false
+		for _, ts := range toolScopes {
+			if !slices.Contains(tokenScopes, ts) {
+				missing = true
+				break
+			}
+		}
+
+		if missing {
+			err = &generic.MCPAuthError{
+				Code:           http.StatusForbidden,
+				Message:        "insufficient scopes for this tool",
+				ScopesRequired: toolScopes,
+			}
+			return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+		}
+	}
+
+	params, err := parameters.ParseParams(tool.GetParameters(), data, claimsFromAuth)
+	if err != nil {
+		err = fmt.Errorf("provided parameters were invalid: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
+	logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
+
+	embeddingModels := resourceMgr.GetEmbeddingModelMap()
+	params, err = tool.EmbedParams(ctx, params, embeddingModels)
+	if err != nil {
+		err = fmt.Errorf("error embedding parameters: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
+
+	// Get instrumentation for recording tool execution duration
+	instrumentation, instrumentationErr := util.InstrumentationFromContext(ctx)
+
+	// run tool invocation and generate response.
+	executionStart := time.Now()
+	results, err := tool.Invoke(ctx, resourceMgr, params, accessToken)
+	executionDuration := time.Since(executionStart).Seconds()
+
+	// Record tool execution duration metric
+	if instrumentationErr == nil {
+		execAttrs := []attribute.KeyValue{
+			attribute.String("gen_ai.tool.name", toolName),
+		}
+		// Add network protocol attributes from context
+		if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
+			if genAIAttrs.NetworkProtocolName != "" {
+				execAttrs = append(execAttrs, attribute.String("network.protocol.name", genAIAttrs.NetworkProtocolName))
+			}
+			if genAIAttrs.NetworkProtocolVersion != "" {
+				execAttrs = append(execAttrs, attribute.String("network.protocol.version", genAIAttrs.NetworkProtocolVersion))
+			}
+		}
+		if err != nil {
+			execAttrs = append(execAttrs, attribute.String("error.type", err.Error()))
+		}
+		instrumentation.ToolExecutionDuration.Record(ctx, executionDuration, metric.WithAttributes(execAttrs...))
+	}
+
+	if err != nil {
+		var tbErr util.ToolboxError
+
+		if errors.As(err, &tbErr) {
+			switch tbErr.Category() {
+			case util.CategoryAgent:
+				// MCP - Tool execution error
+				// Return SUCCESS but with IsError: true
+				text := TextContent{
+					Type: "text",
+					Text: err.Error(),
+				}
+				return jsonrpc.JSONRPCResponse{
+					Jsonrpc: jsonrpc.JSONRPC_VERSION,
+					Id:      id,
+					Result:  CallToolResult{Content: []TextContent{text}, IsError: true},
+				}, nil
+
+			case util.CategoryServer:
+				// MCP Spec - Protocol error
+				// Return JSON-RPC ERROR
+				var clientServerErr *util.ClientServerError
+				rpcCode := jsonrpc.INTERNAL_ERROR // Default to Internal Error (-32603)
+
+				if errors.As(err, &clientServerErr) {
+					if clientServerErr.Code == http.StatusUnauthorized || clientServerErr.Code == http.StatusForbidden {
+						if clientAuth {
+							rpcCode = jsonrpc.INVALID_REQUEST
+						} else {
+							rpcCode = jsonrpc.INTERNAL_ERROR
+						}
+					}
+				}
+				return jsonrpc.NewError(id, rpcCode, err.Error(), nil), err
+			}
+		} else {
+			// Unknown error -> 500
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+
+	content := make([]TextContent, 0)
+
+	sliceRes, ok := results.([]any)
+	if !ok {
+		sliceRes = []any{results}
+	}
+
+	for _, d := range sliceRes {
+		text := TextContent{Type: "text"}
+		dM, err := json.Marshal(d)
+		if err != nil {
+			text.Text = fmt.Sprintf("fail to marshal: %s, result: %s", err, d)
+		} else {
+			text.Text = string(dM)
+		}
+		content = append(content, text)
+	}
+
+	return jsonrpc.JSONRPCResponse{
+		Jsonrpc: jsonrpc.JSONRPC_VERSION,
+		Id:      id,
+		Result:  CallToolResult{Content: content},
+	}, nil
+}
+
+// promptsListHandler handles the "prompts/list" method.
+func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte) (any, error) {
+	// retrieve logger from context
+	logger, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	logger.DebugContext(ctx, "handling prompts/list request")
+
+	var req ListPromptsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("invalid mcp prompts list request: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	promptsMap := resourceMgr.GetPromptsMap()
+	listPromptsResult, err := GenerateListPromptsResult(promptset, promptsMap)
+	if err != nil {
+		err = fmt.Errorf("error generating manifest: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	logger.DebugContext(ctx, fmt.Sprintf("returning %d prompts", len(listPromptsResult.Prompts)))
+	return jsonrpc.JSONRPCResponse{
+		Jsonrpc: jsonrpc.JSONRPC_VERSION,
+		Id:      id,
+		Result:  listPromptsResult,
+	}, nil
+}
+
+// promptsGetHandler handles the "prompts/get" method.
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
+	// retrieve logger from context
+	logger, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	logger.DebugContext(ctx, "handling prompts/get request")
+
+	var req GetPromptRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		err = fmt.Errorf("invalid mcp prompts/get request: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	promptName := req.Params.Name
+	logger.DebugContext(ctx, fmt.Sprintf("prompt name: %s", promptName))
+
+	// Update span name and set gen_ai attributes
+	span := trace.SpanFromContext(ctx)
+	span.SetName(fmt.Sprintf("%s %s", PROMPTS_GET, promptName))
+	span.SetAttributes(attribute.String("gen_ai.prompt.name", promptName))
+
+	// Verify prompt belongs to the current promptset before resolving globally.
+	if !promptset.ContainsPrompt(promptName) {
+		err := fmt.Errorf("prompt with name %q does not exist", promptName)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
+
+	prompt, ok := resourceMgr.GetPrompt(promptName)
+	if !ok {
+		err := fmt.Errorf("prompt with name %q does not exist", promptName)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
+
+	// Populate gen_ai attributes for operation duration metric
+	if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
+		genAIAttrs.OperationName = "get_prompt"
+		genAIAttrs.PromptName = promptName
+	}
+
+	// Parse the arguments provided in the request.
+	argValues, err := prompt.ParseArgs(req.Params.Arguments, nil)
+	if err != nil {
+		err = fmt.Errorf("invalid arguments for prompt %q: %w", promptName, err)
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
+	}
+	logger.DebugContext(ctx, fmt.Sprintf("parsed args: %v", argValues))
+
+	// Substitute the argument values into the prompt's messages.
+	substituted, err := prompt.SubstituteParams(argValues)
+	if err != nil {
+		err = fmt.Errorf("error substituting params for prompt %q: %w", promptName, err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	// Cast the result to the expected []prompts.Message type.
+	substitutedMessages, ok := substituted.([]prompts.Message)
+	if !ok {
+		err = fmt.Errorf("internal error: SubstituteParams returned unexpected type")
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	logger.DebugContext(ctx, "substituted params successfully")
+
+	// Format the response messages into the required structure.
+	promptMessages := make([]PromptMessage, len(substitutedMessages))
+	for i, msg := range substitutedMessages {
+		promptMessages[i] = PromptMessage{
+			Role: msg.Role,
+			Content: TextContent{
+				Type: "text",
+				Text: msg.Content,
+			},
+		}
+	}
+
+	result := GetPromptResult{
+		Description: prompt.Manifest().Description,
+		Messages:    promptMessages,
+	}
+
+	return jsonrpc.JSONRPCResponse{
+		Jsonrpc: jsonrpc.JSONRPC_VERSION,
+		Id:      id,
+		Result:  result,
+	}, nil
+}

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -258,7 +258,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -278,16 +281,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -21,11 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"slices"
-	"strings"
 	"time"
 
-	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
+	"github.com/googleapis/mcp-toolbox/internal/auth"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
@@ -44,7 +42,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case SERVER_DISCOVER:
 		return serverDiscoverHandler(ctx, id, body, header)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body, header)
+		return toolsListHandler(ctx, id, resourceMgr, toolset, body, header)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
@@ -124,6 +122,11 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
+	enableDraft, ok := util.EnableDraftSpecsFromContext(ctx)
+	if !ok {
+		err = fmt.Errorf("unable to retrieve enableDraftSpecs from context")
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
 
 	var req DiscoverRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -142,7 +145,7 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 	toolsListChanged := false
 	promptsListChanged := false
 	result := DiscoverResult{
-		SupportedVersions: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
+		SupportedVersions: mcputil.GetSupportedVersions(enableDraft),
 		Capabilities: ServerCapabilities{
 			Tools: &ListChanged{
 				ListChanged: &toolsListChanged,
@@ -166,7 +169,7 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 	return res, nil
 }
 
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, header http.Header) (any, error) {
+func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, header http.Header) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
@@ -181,8 +184,9 @@ func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManag
 		return validateErr, err
 	}
 
+	urlParams, _ := util.UrlParamsFromContext(ctx)
 	toolsMap := resourceMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap)
+	listToolsResult, err := GenerateListToolsResult(resourceMgr.GetSourcesMap(), toolset, toolsMap, urlParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -293,11 +297,19 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	// if using stdio, header will be nil and auth will not be supported
 	if header != nil {
 		for _, aS := range authServices {
-			claims, err := aS.GetClaimsFromHeader(ctx, header)
-			if err != nil {
-				logger.DebugContext(ctx, err.Error())
-				continue
+			var claims map[string]any
+			var err error
+
+			if mSvc, ok := aS.(auth.MCPAuthService); ok && mSvc.IsMCPEnabled() {
+				claims = util.AuthTokenClaimsFromContext(ctx)
+			} else {
+				claims, err = aS.GetClaimsFromHeader(ctx, header)
+				if err != nil {
+					logger.DebugContext(ctx, err.Error())
+					continue
+				}
 			}
+
 			if claims == nil {
 				// authService not present in header
 				continue
@@ -326,51 +338,20 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 	logger.DebugContext(ctx, "tool invocation authorized")
 
-	// Find MCP enabled auth service
-	var mcpSvcName string
-	for _, aS := range authServices {
-		cfg := aS.ToConfig()
-		if genCfg, ok := cfg.(generic.Config); ok && genCfg.McpEnabled {
-			mcpSvcName = aS.GetName()
-			break
-		}
+	if err := mcputil.ValidateScopes(ctx, tool.GetScopesRequired(), authServices); err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	toolScopes := tool.GetScopesRequired()
-	if mcpSvcName != "" && len(toolScopes) > 0 {
-		claims := util.AuthTokenClaimsFromContext(ctx)
-		if claims == nil {
-			err = &generic.MCPAuthError{
-				Code:           http.StatusForbidden,
-				Message:        "missing claims for MCP authorization",
-				ScopesRequired: toolScopes,
-			}
-			return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
-		}
-
-		scopeClaim, _ := claims["scope"].(string)
-		tokenScopes := strings.Split(scopeClaim, " ")
-
-		// Check if all required scopes are present in the token
-		missing := false
-		for _, ts := range toolScopes {
-			if !slices.Contains(tokenScopes, ts) {
-				missing = true
-				break
-			}
-		}
-
-		if missing {
-			err = &generic.MCPAuthError{
-				Code:           http.StatusForbidden,
-				Message:        "insufficient scopes for this tool",
-				ScopesRequired: toolScopes,
-			}
-			return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
-		}
+	toolParams, err := tool.GetParameters(resourceMgr.GetSourcesMap())
+	if err != nil {
+		err = fmt.Errorf("error getting parameters for tool: %w", err)
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
 
-	params, err := parameters.ParseParams(tool.GetParameters(), data, claimsFromAuth)
+	// Auto-populate arguments from URL parameters
+	data = mcputil.PopulateUrlParams(ctx, data, toolParams)
+
+	params, err := parameters.ParseParams(toolParams, data, claimsFromAuth)
 	if err != nil {
 		err = fmt.Errorf("provided parameters were invalid: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -40,18 +40,17 @@ import (
 
 // ProcessMethod returns a response for the request.
 func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
-	stdio := header == nil
 	switch method {
 	case SERVER_DISCOVER:
-		return serverDiscoverHandler(ctx, id, body, stdio)
+		return serverDiscoverHandler(ctx, id, body, header)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body, stdio)
+		return toolsListHandler(id, resourceMgr, toolset, body, header)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
-		return promptsListHandler(ctx, id, resourceMgr, promptset, body, stdio)
+		return promptsListHandler(ctx, id, resourceMgr, promptset, body, header)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, promptset, resourceMgr, body, stdio)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body, header)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
@@ -97,7 +96,30 @@ func validateMetadata(id jsonrpc.RequestId, params RequestParams, stdio bool) (a
 	return nil, nil
 }
 
-func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, stdio bool) (any, error) {
+// validateHeader checks the header of every requests
+// Toolbox do not check for `Mcp-Param-{Name}` header since we are not
+// implementing custom headers from parameters
+// Do not need to check for Base64-encoding or invalid characters since we are
+// only checking `mcp-method` and `mcp-name`
+func validateHeader(id jsonrpc.RequestId, header http.Header, method, name string) (any, error) {
+	// stdio transport will not have header
+	if header == nil {
+		return nil, nil
+	}
+	headerMethod := header.Get("mcp-method")
+	if headerMethod != method {
+		err := fmt.Errorf("Mcp-Method header value '%s' does not match body value '%s'", headerMethod, method)
+		return jsonrpc.NewHeaderMismatchedError(id, err), err
+	}
+	headerName := header.Get("mcp-name")
+	if headerName != name {
+		err := fmt.Errorf("Mcp-Name header value '%s' does not match body value '%s'", headerName, name)
+		return jsonrpc.NewHeaderMismatchedError(id, err), err
+	}
+	return nil, nil
+}
+
+func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, header http.Header) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -108,7 +130,11 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 		err = fmt.Errorf("invalid server discover request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params, stdio)
+	validateHeaderErr, err := validateHeader(id, header, SERVER_DISCOVER, "")
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params, header == nil)
 	if err != nil {
 		return validateErr, err
 	}
@@ -140,13 +166,17 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 	return res, nil
 }
 
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, stdio bool) (any, error) {
+func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, header http.Header) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	validateHeaderErr, err := validateHeader(id, header, TOOLS_LIST, "")
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
 		return validateErr, err
 	}
@@ -178,6 +208,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	if err = json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools call request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateHeaderErr, err := validateHeader(id, header, TOOLS_CALL, req.Params.Name)
+	if err != nil {
+		return validateHeaderErr, err
 	}
 	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
@@ -445,7 +479,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 }
 
 // promptsListHandler handles the "prompts/list" method.
-func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte, stdio bool) (any, error) {
+func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte, header http.Header) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -458,7 +492,11 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 		err = fmt.Errorf("invalid mcp prompts list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	validateHeaderErr, err := validateHeader(id, header, PROMPTS_LIST, "")
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
 		return validateErr, err
 	}
@@ -478,7 +516,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, stdio bool) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -491,7 +529,11 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prom
 		err = fmt.Errorf("invalid mcp prompts/get request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
-	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	validateHeaderErr, err := validateHeader(id, header, PROMPTS_GET, req.Params.Name)
+	if err != nil {
+		return validateHeaderErr, err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
 	if err != nil {
 		return validateErr, err
 	}

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -39,44 +40,83 @@ import (
 
 // ProcessMethod returns a response for the request.
 func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+	stdio := header == nil
 	switch method {
-	case INITIALIZE:
-		return initializeHandler(ctx, id, body)
-	case PING:
-		return pingHandler(id)
+	case SERVER_DISCOVER:
+		return serverDiscoverHandler(ctx, id, body, stdio)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body)
+		return toolsListHandler(id, resourceMgr, toolset, body, stdio)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
-		return promptsListHandler(ctx, id, resourceMgr, promptset, body)
+		return promptsListHandler(ctx, id, resourceMgr, promptset, body, stdio)
 	case PROMPTS_GET:
-		return promptsGetHandler(ctx, id, promptset, resourceMgr, body)
+		return promptsGetHandler(ctx, id, promptset, resourceMgr, body, stdio)
 	default:
 		err := fmt.Errorf("invalid method %s", method)
 		return jsonrpc.NewError(id, jsonrpc.METHOD_NOT_FOUND, err.Error(), nil), err
 	}
 }
 
-// InitializeResponse runs capability negotiation and protocol version agreement.
-// This is the Initialization phase of the lifecycle for MCP client-server connections.
-// Always start with the latest protocol version supported.
-func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+// validateMetadata checks the metadata of every requests
+func validateMetadata(id jsonrpc.RequestId, params RequestParams, stdio bool) (any, error) {
+	// Check _meta field for protocol version
+	if params.Meta != nil {
+		// check for protocol version metadata
+		v := params.Meta.ProtocolVersion
+		if v == "" {
+			metaErr := fmt.Errorf("missing io.modelcontextprotocol/protocolVersion")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// do not have to verify header for stdio; already verified during stdio
+		// message processing
+		if !stdio {
+			if PROTOCOL_VERSION != v {
+				metaErr := fmt.Errorf("header mismatch: MCP-Protocol-Version header value '%s' does not match body value '%s'", PROTOCOL_VERSION, v)
+				return jsonrpc.NewHeaderMismatchedError(id, metaErr), metaErr
+			}
+		}
+
+		// check for clientInfo
+		clientInfo := params.Meta.ClientInfo
+		if clientInfo.Version == "" || clientInfo.Name == "" {
+			metaErr := fmt.Errorf("missing field from io.modelcontextprotocol/clientInfo")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// check for clientCapabilities
+		clientCapabilities := params.Meta.MetaClientCapabilities
+		if clientCapabilities == nil {
+			metaErr := fmt.Errorf("missing field from io.modelcontextprotocol/clientCapabilities")
+			return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+		}
+		// skip checking clientCapabilities since Toolbox do not utilize any of those
+	} else {
+		metaErr := fmt.Errorf("missing required fields in request metadata")
+		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, metaErr.Error(), nil), metaErr
+	}
+	return nil, nil
+}
+
+func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, stdio bool) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
 
-	var req InitializeRequest
+	var req DiscoverRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		err = fmt.Errorf("invalid mcp initialize request: %w", err)
+		err = fmt.Errorf("invalid server discover request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	toolsListChanged := false
 	promptsListChanged := false
-	result := InitializeResult{
-		ProtocolVersion: PROTOCOL_VERSION,
+	result := DiscoverResult{
+		SupportedVersions: mcputil.SUPPORTED_PROTOCOL_VERSIONS,
 		Capabilities: ServerCapabilities{
 			Tools: &ListChanged{
 				ListChanged: &toolsListChanged,
@@ -97,24 +137,18 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 		Id:      id,
 		Result:  result,
 	}
-
 	return res, nil
 }
 
-// pingHandler handles the "ping" method by returning an empty response.
-func pingHandler(id jsonrpc.RequestId) (any, error) {
-	return jsonrpc.JSONRPCResponse{
-		Jsonrpc: jsonrpc.JSONRPC_VERSION,
-		Id:      id,
-		Result:  struct{}{},
-	}, nil
-}
-
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
+func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte, stdio bool) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	toolsMap := resourceMgr.GetToolsMap()
@@ -144,6 +178,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	if err = json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools call request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, header == nil)
+	if err != nil {
+		return validateErr, err
 	}
 
 	toolName := req.Params.Name
@@ -407,7 +445,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 }
 
 // promptsListHandler handles the "prompts/list" method.
-func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte) (any, error) {
+func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, promptset prompts.Promptset, body []byte, stdio bool) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -419,6 +457,10 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp prompts list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	promptsMap := resourceMgr.GetPromptsMap()
@@ -436,7 +478,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *
 }
 
 // promptsGetHandler handles the "prompts/get" method.
-func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte) (any, error) {
+func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, stdio bool) (any, error) {
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
@@ -448,6 +490,10 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prom
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp prompts/get request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+	validateErr, err := validateMetadata(id, req.Params.RequestParams, stdio)
+	if err != nil {
+		return validateErr, err
 	}
 
 	promptName := req.Params.Name

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdraft
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+)
+
+func TestValidateMetadata(t *testing.T) {
+	var dummyId jsonrpc.RequestId
+	clientCapabilities := &ClientCapabilities{}
+
+	tests := []struct {
+		name        string
+		params      RequestParams
+		stdio       bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "Missing Meta entirely",
+			params: RequestParams{
+				Meta: nil,
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing required fields in request metadata",
+		},
+		{
+			name: "Missing Protocol Version",
+			params: RequestParams{
+				Meta: &RequestMetaObject{}, // ProtocolVersion defaults to ""
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing io.modelcontextprotocol/protocolVersion",
+		},
+		{
+			name: "Protocol Version Mismatch (non-stdio)",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: "invalid-version-999",
+				},
+			},
+			stdio:       false,
+			wantErr:     true,
+			errContains: "header mismatch",
+		},
+		{
+			name: "Missing ClientInfo Name",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION,
+					ClientInfo: Implementation{
+						Version:      "1.0",
+						BaseMetadata: BaseMetadata{Name: ""}, // Missing name
+					},
+				},
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing field from io.modelcontextprotocol/clientInfo",
+		},
+		{
+			name: "Missing ClientInfo Version",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION,
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "", // Missing version
+					},
+				},
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing field from io.modelcontextprotocol/clientInfo",
+		},
+		{
+			name: "Missing Client Capabilities",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION,
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "1.0",
+					},
+					MetaClientCapabilities: nil, // Missing capabilities
+				},
+			},
+			stdio:       true,
+			wantErr:     true,
+			errContains: "missing field from io.modelcontextprotocol/clientCapabilities",
+		},
+		{
+			name: "stdio transport",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					// ProtocolVersion can be anything if stdio is true
+					// Technically it will be valid and would already be
+					// verified during message processing
+					ProtocolVersion: "any-version",
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "1.0",
+					},
+					MetaClientCapabilities: clientCapabilities,
+				},
+			},
+			stdio:   true,
+			wantErr: false,
+		},
+		{
+			name: "Success request metadata",
+			params: RequestParams{
+				Meta: &RequestMetaObject{
+					ProtocolVersion: PROTOCOL_VERSION, // Must match exactly when stdio=false
+					ClientInfo: Implementation{
+						BaseMetadata: BaseMetadata{Name: "TestClient"},
+						Version:      "1.0",
+					},
+					MetaClientCapabilities: clientCapabilities,
+				},
+			},
+			stdio:   false,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := validateMetadata(dummyId, tt.params, tt.stdio)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateMetadata() expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("validateMetadata() error = %v, want error containing %q", err, tt.errContains)
+				}
+				if res == nil {
+					t.Errorf("validateMetadata() expected jsonrpc error response, got nil res")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateMetadata() expected no error, got %v", err)
+				}
+				if res != nil {
+					t.Errorf("validateMetadata() expected nil res on success, got %v", res)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -509,7 +509,7 @@ func TestToolsListHandler(t *testing.T) {
 					t.Fatalf("unexpected error during marshaling")
 				}
 			}
-			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body, tt.header)
+			got, err := toolsListHandler(context.Background(), dummyID, resourceMgr, tt.toolset, body, tt.header)
 
 			if tt.wantErr {
 				if err == nil {

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -15,10 +15,25 @@
 package vdraft
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/googleapis/mcp-toolbox/internal/log"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/resources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// Dummy JSONRPC ID for testing
+var (
+	dummyID           jsonrpc.RequestId = 1
+	fakeVersionString                   = "0.0.0"
 )
 
 func TestValidateMetadata(t *testing.T) {
@@ -162,6 +177,736 @@ func TestValidateMetadata(t *testing.T) {
 				}
 				if res != nil {
 					t.Errorf("validateMetadata() expected nil res on success, got %v", res)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  http.Header
+		method  string
+		reqName string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil header (stdio transport)",
+			header:  nil,
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: false,
+		},
+		{
+			name: "valid header matches body",
+			header: http.Header{
+				"Mcp-Method": []string{"test-method"},
+				"Mcp-Name":   []string{"test-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: false,
+		},
+		{
+			name: "mismatched method",
+			header: http.Header{
+				"Mcp-Method": []string{"wrong-method"},
+				"Mcp-Name":   []string{"test-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Method header value 'wrong-method' does not match body value 'test-method'",
+		},
+		{
+			name: "mismatched name",
+			header: http.Header{
+				"Mcp-Method": []string{"test-method"},
+				"Mcp-Name":   []string{"wrong-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Name header value 'wrong-name' does not match body value 'test-name'",
+		},
+		{
+			name: "missing method in header",
+			header: http.Header{
+				"Mcp-Name": []string{"test-name"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Method header value '' does not match body value 'test-method'",
+		},
+		{
+			name: "missing name in header",
+			header: http.Header{
+				"Mcp-Method": []string{"test-method"},
+			},
+			method:  "test-method",
+			reqName: "test-name",
+			wantErr: true,
+			errMsg:  "Mcp-Name header value '' does not match body value 'test-name'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotObj, err := validateHeader(dummyID, tt.header, tt.method, tt.reqName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateHeader() expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("validateHeader() error = %v, wantMsg %v", err, tt.errMsg)
+				}
+				if gotObj == nil {
+					t.Errorf("validateHeader() expected an error object return value, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("validateHeader() unexpected error: %v", err)
+				}
+				if gotObj != nil {
+					t.Errorf("validateHeader() expected nil object, got %v", gotObj)
+				}
+			}
+		})
+	}
+}
+
+func TestServerDiscoverHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxVersion := util.WithToolboxVersionKey(ctx, fakeVersionString)
+	tests := []struct {
+		name        string
+		body        DiscoverRequest
+		rawBody     []byte
+		header      http.Header
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing version in context",
+			body: DiscoverRequest{
+				Request: jsonrpc.Request{
+					Method: "server/discover",
+				},
+				Params: RequestParams{
+					Meta: &RequestMetaObject{
+						ProtocolVersion: PROTOCOL_VERSION,
+						ClientInfo: Implementation{
+							BaseMetadata: BaseMetadata{Name: "TestClient"},
+							Version:      "1.0",
+						},
+						MetaClientCapabilities: &ClientCapabilities{},
+					},
+				},
+			},
+			header:      nil,
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve toolbox version",
+		},
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "invalid server discover request",
+		},
+		{
+			name: "header validation failure",
+			body: DiscoverRequest{
+				Request: jsonrpc.Request{
+					Method: "server/discover",
+				},
+				Params: RequestParams{
+					Meta: &RequestMetaObject{
+						ProtocolVersion: PROTOCOL_VERSION,
+						ClientInfo: Implementation{
+							BaseMetadata: BaseMetadata{Name: "TestClient"},
+							Version:      "1.0",
+						},
+						MetaClientCapabilities: &ClientCapabilities{},
+					},
+				},
+			},
+			header:      http.Header{"Mcp-Method": []string{"WRONG_METHOD"}},
+			context:     ctxVersion,
+			wantErr:     true,
+			errContains: "does not match body value",
+		},
+		{
+			name: "success",
+			body: DiscoverRequest{
+				Request: jsonrpc.Request{
+					Method: "server/discover",
+				},
+				Params: RequestParams{
+					Meta: &RequestMetaObject{
+						ProtocolVersion: PROTOCOL_VERSION,
+						ClientInfo: Implementation{
+							BaseMetadata: BaseMetadata{Name: "TestClient"},
+							Version:      "1.0",
+						},
+						MetaClientCapabilities: &ClientCapabilities{},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{SERVER_DISCOVER}},
+			context: ctxVersion,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := serverDiscoverHandler(tt.context, dummyID, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %v, want error containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsListHandler(t *testing.T) {
+	// Initialize tools using provided testutils mock instances
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        ListToolsRequest
+		rawBody     []byte
+		header      http.Header
+		toolset     tools.Toolset
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "invalid mcp tools list request",
+		},
+		{
+			name: "header mismatch",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:      http.Header{"Mcp-Method": []string{"WRONG_METHOD"}},
+			toolset:     toolsets[""],
+			wantErr:     true,
+			errContains: "does not match body value",
+		},
+		{
+			name: "success - stdio (nil header)",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:  nil,
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+		{
+			name: "success - http",
+			body: ListToolsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "tools/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{TOOLS_LIST}},
+			toolset: toolsets[""],
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestToolsCallHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctxLogger := util.WithLogger(ctx, testLogger)
+	// Setup tools including the auth/unauth ones
+	mockTools := []testutils.MockTool{
+		testutils.MockTool1,
+		testutils.MockTool4,
+		testutils.MockTool5,
+	}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+
+	tests := []struct {
+		name        string
+		body        CallToolRequest
+		rawBody     []byte
+		header      http.Header
+		context     context.Context
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json body",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "invalid mcp tools call request",
+		},
+		{
+			name: "missing logger in context",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "no_params",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      nil,
+			context:     ctx,
+			wantErr:     true,
+			errContains: "unable to retrieve logger",
+		},
+		{
+			name: "tool not in toolset",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "unknown_tool",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      nil,
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "tool with name \"unknown_tool\" does not exist",
+		},
+		{
+			name: "missing client auth token",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "require_client_auth_tool",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      http.Header{"Mcp-Method": []string{TOOLS_CALL}, "Mcp-Name": []string{"require_client_auth_tool"}},
+			context:     ctxLogger,
+			wantErr:     true,
+			errContains: "missing access token in the 'Authorization' header",
+		},
+		{
+			name: "successful invocation - no params",
+			body: CallToolRequest{
+				Request: jsonrpc.Request{
+					Method: "tools/call",
+				},
+				Params: CallToolRequestParams{
+					Name: "no_params",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{TOOLS_CALL}, "Mcp-Name": []string{"no_params"}},
+			context: ctxLogger,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := toolsCallHandler(tt.context, dummyID, toolsets[""], resourceMgr, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsListHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        ListPromptsRequest
+		rawBody     []byte
+		header      http.Header
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			wantErr:     true,
+			errContains: "invalid mcp prompts list request",
+		},
+		{
+			name: "success",
+			body: ListPromptsRequest{
+				PaginatedRequest: PaginatedRequest{
+					Request: jsonrpc.Request{
+						Method: "prompts/list",
+					},
+					Params: PaginatedRequestParams{
+						RequestParams: RequestParams{
+							Meta: &RequestMetaObject{
+								ProtocolVersion: PROTOCOL_VERSION,
+								ClientInfo: Implementation{
+									BaseMetadata: BaseMetadata{Name: "TestClient"},
+									Version:      "1.0",
+								},
+								MetaClientCapabilities: &ClientCapabilities{},
+							},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{PROMPTS_LIST}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsListHandler(ctx, dummyID, resourceMgr, promptsets[""], body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestPromptsGetHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unable to initialize logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+	// Initialize prompts
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, nil, mockPrompts)
+	resourceMgr := resources.NewResourceManager(nil, nil, nil, toolsMap, toolsets, promptsMap, promptsets)
+	tests := []struct {
+		name        string
+		body        GetPromptRequest
+		rawBody     []byte
+		header      http.Header
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "invalid json request",
+			rawBody:     []byte(`{invalid json}`),
+			header:      nil,
+			wantErr:     true,
+			errContains: "invalid mcp prompts/get request",
+		},
+		{
+			name: "prompt does not exist",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: GetPromptRequestParams{
+					Name: "missing_prompt",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:      nil,
+			wantErr:     true,
+			errContains: "does not exist",
+		},
+		{
+			name: "success with args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: GetPromptRequestParams{
+					Name: "prompt2",
+					Arguments: map[string]any{
+						"arg1": "value1",
+					},
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{PROMPTS_GET}, "Mcp-Name": []string{"prompt2"}},
+			wantErr: false,
+		},
+		{
+			name: "success without args",
+			body: GetPromptRequest{
+				Request: jsonrpc.Request{
+					Method: "prompts/get",
+				},
+				Params: GetPromptRequestParams{
+					Name: "prompt1",
+					RequestParams: RequestParams{
+						Meta: &RequestMetaObject{
+							ProtocolVersion: PROTOCOL_VERSION,
+							ClientInfo: Implementation{
+								BaseMetadata: BaseMetadata{Name: "TestClient"},
+								Version:      "1.0",
+							},
+							MetaClientCapabilities: &ClientCapabilities{},
+						},
+					},
+				},
+			},
+			header:  http.Header{"Mcp-Method": []string{PROMPTS_GET}, "Mcp-Name": []string{"prompt1"}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.rawBody
+			var err error
+			if body == nil {
+				body, err = json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("unexpected error during marshaling")
+				}
+			}
+			got, err := promptsGetHandler(ctx, dummyID, promptsets[""], resourceMgr, body, tt.header)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want string containing %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil {
+					t.Errorf("expected valid response, got nil")
 				}
 			}
 		})

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -281,6 +281,7 @@ func TestValidateHeader(t *testing.T) {
 
 func TestServerDiscoverHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	ctx = util.WithEnableDraftSpecs(ctx, true)
 	defer cancel()
 	ctxVersion := util.WithToolboxVersionKey(ctx, fakeVersionString)
 	tests := []struct {

--- a/internal/server/mcp/vdraft/types.go
+++ b/internal/server/mcp/vdraft/types.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vdraft
+
+import (
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	"github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+// SERVER_NAME is the server name used in Implementation.
+const SERVER_NAME = "Toolbox"
+
+// PROTOCOL_VERSION is the version of the MCP protocol in this package.
+const PROTOCOL_VERSION = util.VERSION_DRAFT
+
+// methods that are supported.
+const (
+	INITIALIZE   = "initialize"
+	PING         = "ping"
+	TOOLS_LIST   = "tools/list"
+	TOOLS_CALL   = "tools/call"
+	PROMPTS_LIST = "prompts/list"
+	PROMPTS_GET  = "prompts/get"
+)
+
+/* Initialization */
+
+// Params to define MCP Client during initialize request.
+type InitializeParams struct {
+	// The latest version of the Model Context Protocol that the client supports.
+	// The client MAY decide to support older versions as well.
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ClientCapabilities `json:"capabilities"`
+	ClientInfo      Implementation     `json:"clientInfo"`
+}
+
+// InitializeRequest is sent from the client to the server when it first
+// connects, asking it to begin initialization.
+type InitializeRequest struct {
+	jsonrpc.Request
+	Params InitializeParams `json:"params"`
+}
+
+// InitializeResult is sent after receiving an initialize request from the
+// client.
+type InitializeResult struct {
+	jsonrpc.Result
+	// The version of the Model Context Protocol that the server wants to use.
+	// This may not match the version that the client requested. If the client cannot
+	// support this version, it MUST disconnect.
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ServerCapabilities `json:"capabilities"`
+	ServerInfo      Implementation     `json:"serverInfo"`
+	// Instructions describing how to use the server and its features.
+	//
+	// This can be used by clients to improve the LLM's understanding of
+	// available tools, resources, etc. It can be thought of like a "hint" to the model.
+	// For example, this information MAY be added to the system prompt.
+	Instructions string `json:"instructions,omitempty"`
+}
+
+// InitializedNotification is sent from the client to the server after
+// initialization has finished.
+type InitializedNotification struct {
+	jsonrpc.Notification
+}
+
+// ListChange represents whether the server supports notification for changes to the capabilities.
+type ListChanged struct {
+	ListChanged *bool `json:"listChanged,omitempty"`
+}
+
+// ClientCapabilities represents capabilities a client may support. Known
+// capabilities are defined here, in this schema, but this is not a closed set: any
+// client can define its own, additional capabilities.
+type ClientCapabilities struct {
+	// Experimental, non-standard capabilities that the client supports.
+	Experimental map[string]interface{} `json:"experimental,omitempty"`
+	// Present if the client supports listing roots.
+	Roots *ListChanged `json:"roots,omitempty"`
+	// Present if the client supports sampling from an LLM.
+	Sampling struct{} `json:"sampling,omitempty"`
+}
+
+// ServerCapabilities represents capabilities that a server may support. Known
+// capabilities are defined here, in this schema, but this is not a closed set: any
+// server can define its own, additional capabilities.
+type ServerCapabilities struct {
+	Tools   *ListChanged `json:"tools,omitempty"`
+	Prompts *ListChanged `json:"prompts,omitempty"`
+}
+
+// Base interface for metadata with name (identifier) and title (display name) properties.
+type BaseMetadata struct {
+	// Intended for programmatic or logical use, but used as a display name in past specs
+	// or fallback (if title isn't present).
+	Name string `json:"name"`
+	// Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+	//even by those unfamiliar with domain-specific terminology.
+	//
+	// If not provided, the name should be used for display (except for Tool,
+	// where `annotations.title` should be given precedence over using `name`,
+	// if present).
+	Title string `json:"title,omitempty"`
+}
+
+// Implementation describes the name and version of an MCP implementation.
+type Implementation struct {
+	BaseMetadata
+	Version string `json:"version"`
+}
+
+/* Empty result */
+
+// EmptyResult represents a response that indicates success but carries no data.
+type EmptyResult jsonrpc.Result
+
+/* Pagination */
+
+// Cursor is an opaque token used to represent a cursor for pagination.
+type Cursor string
+
+type PaginatedRequest struct {
+	jsonrpc.Request
+	Params struct {
+		// An opaque token representing the current pagination position.
+		// If provided, the server should return results starting after this cursor.
+		Cursor Cursor `json:"cursor,omitempty"`
+	} `json:"params,omitempty"`
+}
+
+type PaginatedResult struct {
+	jsonrpc.Result
+	// An opaque token representing the pagination position after the last returned result.
+	// If present, there may be more results available.
+	NextCursor Cursor `json:"nextCursor,omitempty"`
+}
+
+/* Tools */
+
+// Sent from the client to request a list of tools the server has.
+type ListToolsRequest struct {
+	PaginatedRequest
+}
+
+// The server's response to a tools/list request from the client.
+type ListToolsResult struct {
+	PaginatedResult
+	Tools []Tool `json:"tools"`
+}
+
+type Tool struct {
+	BaseMetadata
+	/**
+	 * A human-readable description of the tool.
+	 *
+	 * This can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a "hint" to the model.
+	 */
+	Description string `json:"description,omitempty"`
+	// A JSON Schema object defining the expected parameters for the tool.
+	ToolInputSchema InputSchema `json:"inputSchema,omitempty"`
+	// Optional additional tool information.
+	Annotations *ToolAnnotations `json:"annotations,omitempty"`
+	// See [General fields: `_meta`](/specification/2025-11-25/basic/index#_meta) for notes on `_meta` usage.
+	Metadata map[string]any `json:"_meta,omitempty"`
+}
+
+type InputSchema struct {
+	Type       string                                     `json:"type"`
+	Properties map[string]parameters.ParameterMcpManifest `json:"properties"`
+	Required   []string                                   `json:"required"`
+}
+
+// Used by the client to invoke a tool provided by the server.
+type CallToolRequest struct {
+	jsonrpc.Request
+	Params struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments,omitempty"`
+	} `json:"params,omitempty"`
+}
+
+// The sender or recipient of messages and data in a conversation.
+type Role string
+
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+)
+
+// Base for objects that include optional annotations for the client.
+// The client can use annotations to inform how objects are used or displayed
+type Annotated struct {
+	Annotations *struct {
+		// Describes who the intended customer of this object or data is.
+		// It can include multiple entries to indicate content useful for multiple
+		// audiences (e.g., `["user", "assistant"]`).
+		Audience []Role `json:"audience,omitempty"`
+		// Describes how important this data is for operating the server.
+		//
+		// A value of 1 means "most important," and indicates that the data is
+		// effectively required, while 0 means "least important," and indicates that
+		// the data is entirely optional.
+		//
+		// @TJS-type number
+		// @minimum 0
+		// @maximum 1
+		Priority float64 `json:"priority,omitempty"`
+	} `json:"annotations,omitempty"`
+}
+
+// TextContent represents text provided to or from an LLM.
+type TextContent struct {
+	Annotated
+	Type string `json:"type"`
+	// The text content of the message.
+	Text string `json:"text"`
+}
+
+// The server's response to a tool call.
+//
+// Any errors that originate from the tool SHOULD be reported inside the result
+// object, with `isError` set to true, _not_ as an MCP protocol-level error
+// response. Otherwise, the LLM would not be able to see that an error occurred
+// and self-correct.
+//
+// However, any errors in _finding_ the tool, an error indicating that the
+// server does not support tool calls, or any other exceptional conditions,
+// should be reported as an MCP error response.
+type CallToolResult struct {
+	jsonrpc.Result
+	// Could be either a TextContent, ImageContent, or EmbeddedResources
+	// For Toolbox, we will only be sending TextContent
+	Content []TextContent `json:"content"`
+	// Whether the tool call ended in an error.
+	// If not set, this is assumed to be false (the call was successful).
+	//
+	// Any errors that originate from the tool SHOULD be reported inside the result
+	// object, with `isError` set to true, _not_ as an MCP protocol-level error
+	// response. Otherwise, the LLM would not be able to see that an error occurred
+	// and self-correct.
+	//
+	// However, any errors in _finding_ the tool, an error indicating that the
+	// server does not support tool calls, or any other exceptional conditions,
+	// should be reported as an MCP error response.
+	IsError bool `json:"isError,omitempty"`
+	// An optional JSON object that represents the structured result of the tool call.
+	StructuredContent map[string]any `json:"structuredContent,omitempty"`
+}
+
+// Additional properties describing a Tool to clients.
+//
+// NOTE: all properties in ToolAnnotations are **hints**.
+// They are not guaranteed to provide a faithful description of
+// tool behavior (including descriptive properties like `title`).
+//
+// Clients should never make tool use decisions based on ToolAnnotations
+// received from untrusted servers.
+type ToolAnnotations struct {
+	// A human-readable title for the tool.
+	Title string `json:"title,omitempty"`
+	// If true, the tool does not modify its environment.
+	// Default: false
+	ReadOnlyHint *bool `json:"readOnlyHint,omitempty"`
+	// If true, the tool may perform destructive updates to its environment.
+	// If false, the tool performs only additive updates.
+	// (This property is meaningful only when `readOnlyHint == false`)
+	// Default: true
+	DestructiveHint *bool `json:"destructiveHint,omitempty"`
+	// If true, calling the tool repeatedly with the same arguments
+	// will have no additional effect on the its environment.
+	// (This property is meaningful only when `readOnlyHint == false`)
+	// Default: false
+	IdempotentHint *bool `json:"idempotentHint,omitempty"`
+	// If true, this tool may interact with an "open world" of external
+	// entities. If false, the tool's domain of interaction is closed.
+	// For example, the world of a web search tool is open, whereas that
+	// of a memory tool is not.
+	// Default: true
+	OpenWorldHint *bool `json:"openWorldHint,omitempty"`
+}
+
+/* Prompts */
+
+// Sent from the client to request a list of prompts the server has.
+type ListPromptsRequest struct {
+	PaginatedRequest
+}
+
+// The server's response to a prompts/list request from the client.
+type ListPromptsResult struct {
+	PaginatedResult
+	Prompts []Prompt `json:"prompts"`
+}
+
+// Used by the client to get a prompt provided by the server.
+type GetPromptRequest struct {
+	jsonrpc.Request
+	Params struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments,omitempty"`
+	} `json:"params"`
+}
+
+// The server's response to a prompts/get request from the client.
+type GetPromptResult struct {
+	jsonrpc.Result
+	Description string          `json:"description,omitempty"`
+	Messages    []PromptMessage `json:"messages"`
+}
+
+// A prompt or prompt template that the server offers.
+type Prompt struct {
+	BaseMetadata
+	// An optional description of what this prompt provides
+	Description string `json:"description,omitempty"`
+	// A list of arguments to use for templating the prompt.
+	Arguments []PromptArgument `json:"arguments,omitempty"`
+	// See [General fields: `_meta`](/specification/2025-11-25/basic/index#_meta) for notes on `_meta` usage.
+	Metadata map[string]any `json:"_meta,omitempty"`
+}
+
+// Describes an argument that a prompt can accept.
+type PromptArgument struct {
+	BaseMetadata
+	// A human-readable description of the argument.
+	Description string `json:"description,omitempty"`
+	// Whether this argument must be provided.
+	Required bool `json:"required,omitempty"`
+}
+
+// Describes a message returned as part of a prompt.
+type PromptMessage struct {
+	Role    string      `json:"role"`
+	Content TextContent `json:"content"`
+}

--- a/internal/server/mcp/vdraft/types.go
+++ b/internal/server/mcp/vdraft/types.go
@@ -28,59 +28,67 @@ const PROTOCOL_VERSION = util.VERSION_DRAFT
 
 // methods that are supported.
 const (
-	INITIALIZE   = "initialize"
-	PING         = "ping"
-	TOOLS_LIST   = "tools/list"
-	TOOLS_CALL   = "tools/call"
-	PROMPTS_LIST = "prompts/list"
-	PROMPTS_GET  = "prompts/get"
+	SERVER_DISCOVER = "server/discover"
+	TOOLS_LIST      = "tools/list"
+	TOOLS_CALL      = "tools/call"
+	PROMPTS_LIST    = "prompts/list"
+	PROMPTS_GET     = "prompts/get"
 )
 
-/* Initialization */
-
-// Params to define MCP Client during initialize request.
-type InitializeParams struct {
-	// The latest version of the Model Context Protocol that the client supports.
-	// The client MAY decide to support older versions as well.
-	ProtocolVersion string             `json:"protocolVersion"`
-	Capabilities    ClientCapabilities `json:"capabilities"`
-	ClientInfo      Implementation     `json:"clientInfo"`
+/* Request Params */
+type RequestParams struct {
+	Meta *RequestMetaObject `json:"_meta"`
 }
 
-// InitializeRequest is sent from the client to the server when it first
-// connects, asking it to begin initialization.
-type InitializeRequest struct {
-	jsonrpc.Request
-	Params InitializeParams `json:"params"`
-}
-
-// InitializeResult is sent after receiving an initialize request from the
-// client.
-type InitializeResult struct {
-	jsonrpc.Result
-	// The version of the Model Context Protocol that the server wants to use.
-	// This may not match the version that the client requested. If the client cannot
-	// support this version, it MUST disconnect.
-	ProtocolVersion string             `json:"protocolVersion"`
-	Capabilities    ServerCapabilities `json:"capabilities"`
-	ServerInfo      Implementation     `json:"serverInfo"`
-	// Instructions describing how to use the server and its features.
-	//
-	// This can be used by clients to improve the LLM's understanding of
-	// available tools, resources, etc. It can be thought of like a "hint" to the model.
-	// For example, this information MAY be added to the system prompt.
-	Instructions string `json:"instructions,omitempty"`
-}
-
-// InitializedNotification is sent from the client to the server after
-// initialization has finished.
-type InitializedNotification struct {
-	jsonrpc.Notification
-}
-
-// ListChange represents whether the server supports notification for changes to the capabilities.
-type ListChanged struct {
-	ListChanged *bool `json:"listChanged,omitempty"`
+/**
+ * Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.
+ *
+ * Certain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.
+ *
+ * Valid keys have two segments:
+ *
+ * **Prefix:**
+ * - Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).
+ * - Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).
+ * - Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).
+ * - Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.
+ *
+ * **Name:**
+ * - Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).
+ * - Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).
+ */
+type RequestMetaObject struct {
+	// If specified, the caller is requesting out-of-band progress
+	// notifications for this request (as represented by
+	// notifications/progress). The value of this parameter is an
+	// opaque token that will be attached to any subsequent
+	// notifications. The receiver is not obligated to provide these
+	// notifications.
+	ProgressToken jsonrpc.ProgressToken `json:"progressToken,omitempty"`
+	/**
+	 * The MCP Protocol Version being used for this request. Required.
+	 *
+	 * For the HTTP transport, this value MUST match the `MCP-Protocol-Version`
+	 * header; otherwise the server MUST return a `400 Bad Request`. If the
+	 * server does not support the requested version, it MUST return an
+	 * UnsupportedProtocolVersionError.
+	 */
+	ProtocolVersion string `json:"io.modelcontextprotocol/protocolVersion"`
+	/**
+	 * Identifies the client software making the request. Required.
+	 *
+	 * The Implementation schema requires `name` and `version`; other
+	 * fields are optional.
+	 */
+	ClientInfo Implementation `json:"io.modelcontextprotocol/clientInfo"`
+	/**
+	 * The client's capabilities for this specific request. Required.
+	 *
+	 * Capabilities are declared per-request rather than once at initialization;
+	 * an empty object means the client supports no optional capabilities.
+	 * Servers MUST NOT infer capabilities from prior requests.
+	 */
+	MetaClientCapabilities *ClientCapabilities `json:"io.modelcontextprotocol/clientCapabilities"`
 }
 
 // ClientCapabilities represents capabilities a client may support. Known
@@ -95,12 +103,44 @@ type ClientCapabilities struct {
 	Sampling struct{} `json:"sampling,omitempty"`
 }
 
-// ServerCapabilities represents capabilities that a server may support. Known
-// capabilities are defined here, in this schema, but this is not a closed set: any
-// server can define its own, additional capabilities.
-type ServerCapabilities struct {
-	Tools   *ListChanged `json:"tools,omitempty"`
-	Prompts *ListChanged `json:"prompts,omitempty"`
+/* Discovery */
+
+/**
+ * A request from the client asking the server to advertise its supported
+ * protocol versions, capabilities, and other metadata. Servers **MUST**
+ * implement `server/discover`. Clients **MAY** call it but are not required
+ * to — version negotiation can also happen inline via per-request `_meta`.
+ */
+type DiscoverRequest struct {
+	jsonrpc.Request
+	Params RequestParams `json:"params,omitempty"`
+}
+
+// The result returned by the server for a {@link DiscoverRequest | server/discover} request.
+type DiscoverResult struct {
+	jsonrpc.Result
+	/**
+	 * MCP Protocol Versions this server supports. The client should choose a
+	 * version from this list for use in subsequent requests.
+	 */
+	SupportedVersions []string `json:"supportedVersions"`
+	/**
+	 * The capabilities of the server.
+	 */
+	Capabilities ServerCapabilities `json:"capabilities"`
+	/**
+	 * Information about the server software implementation.
+	 */
+	ServerInfo Implementation `json:"serverInfo"`
+	/**
+	 * Natural-language guidance describing the server and its features.
+	 *
+	 * This can be used by clients to improve an LLM's understanding of
+	 * available tools (e.g., by including it in a system prompt). It should
+	 * focus on information that helps the model use the server effectively
+	 * and should not duplicate information already in tool descriptions.
+	 */
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // Base interface for metadata with name (identifier) and title (display name) properties.
@@ -123,6 +163,19 @@ type Implementation struct {
 	Version string `json:"version"`
 }
 
+// ServerCapabilities represents capabilities that a server may support. Known
+// capabilities are defined here, in this schema, but this is not a closed set: any
+// server can define its own, additional capabilities.
+type ServerCapabilities struct {
+	Tools   *ListChanged `json:"tools,omitempty"`
+	Prompts *ListChanged `json:"prompts,omitempty"`
+}
+
+// ListChange represents whether the server supports notification for changes to the capabilities.
+type ListChanged struct {
+	ListChanged *bool `json:"listChanged,omitempty"`
+}
+
 /* Empty result */
 
 // EmptyResult represents a response that indicates success but carries no data.
@@ -133,13 +186,17 @@ type EmptyResult jsonrpc.Result
 // Cursor is an opaque token used to represent a cursor for pagination.
 type Cursor string
 
+// Common params for paginated requests.
 type PaginatedRequest struct {
 	jsonrpc.Request
-	Params struct {
-		// An opaque token representing the current pagination position.
-		// If provided, the server should return results starting after this cursor.
-		Cursor Cursor `json:"cursor,omitempty"`
-	} `json:"params,omitempty"`
+	Params PaginatedRequestParams `json:"params,omitempty"`
+}
+
+type PaginatedRequestParams struct {
+	RequestParams
+	// An opaque token representing the current pagination position.
+	// If provided, the server should return results starting after this cursor.
+	Cursor Cursor `json:"cursor,omitempty"`
 }
 
 type PaginatedResult struct {
@@ -187,10 +244,20 @@ type InputSchema struct {
 // Used by the client to invoke a tool provided by the server.
 type CallToolRequest struct {
 	jsonrpc.Request
-	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
-	} `json:"params,omitempty"`
+	Params CallToolRequestParams `json:"params,omitempty"`
+}
+
+// Parameters for a `tools/call` request.
+type CallToolRequestParams struct {
+	RequestParams
+	/**
+	 * The name of the tool.
+	 */
+	Name string `json:"name"`
+	/**
+	 * Arguments to use for the tool call.
+	 */
+	Arguments map[string]any `json:"arguments,omitempty"`
 }
 
 // The sender or recipient of messages and data in a conversation.
@@ -309,10 +376,14 @@ type ListPromptsResult struct {
 // Used by the client to get a prompt provided by the server.
 type GetPromptRequest struct {
 	jsonrpc.Request
-	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
-	} `json:"params"`
+	Params GetPromptRequestParams `json:"params"`
+}
+
+// Parameters for a `prompts/get` request.
+type GetPromptRequestParams struct {
+	RequestParams
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
 }
 
 // The server's response to a prompts/get request from the client.

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -1192,7 +1192,7 @@ func TestMcpEndpointWithoutEnablingDraftSpecs(t *testing.T) {
 			"code": float64(-32004),
 			"data": map[string]interface{}{
 				"requested": "DRAFT-2026-v1",
-				"supported": []interface{}{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25", "DRAFT-2026-v1"},
+				"supported": []interface{}{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"},
 			},
 			"message": "unsupported protocol version",
 		},

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -110,6 +110,9 @@ var prompt2Args = []any{
 	},
 }
 
+// TestMcpEndpointWithoutInitialized is expecting Toolbox to response with the
+// v2024-11-05 version. This was a customs transport that we implemented during
+// the initial integration of MCP within Toolbox.
 func TestMcpEndpointWithoutInitialized(t *testing.T) {
 	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3, testutils.MockTool4, testutils.MockTool5}
 	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
@@ -459,7 +462,7 @@ func TestMcpEndpoint(t *testing.T) {
 	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3, testutils.MockTool4, testutils.MockTool5, testutils.MockToolUrlBinding}
 	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
 	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, mockPrompts)
-	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
+	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets, withEnableDraftSpecs())
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
@@ -1147,6 +1150,93 @@ func TestMcpEndpoint(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+// TestMcpEndpointWithoutEnablingDraftSpecs checks a method on draft specs
+// without enabling draft specs in server. The server should response with
+// unsupported protocol version errror.
+func TestMcpEndpointWithoutEnablingDraftSpecs(t *testing.T) {
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3, testutils.MockTool4, testutils.MockTool5}
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1, testutils.MockPrompt2}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, mockPrompts)
+	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	protocol := protocolVersionDraft
+	meta := map[string]any{
+		"io.modelcontextprotocol/protocolVersion": protocolVersionDraft,
+		"io.modelcontextprotocol/clientInfo": map[string]any{
+			"version": "client-temp-version",
+			"name":    "client-name",
+		},
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+	}
+
+	url := "/"
+	body := jsonrpc.JSONRPCRequest{
+		Jsonrpc: jsonrpcVersion,
+		Id:      "server-discover",
+		Request: jsonrpc.Request{
+			Method: "server/discover",
+		},
+	}
+	methodName := "server/discover"
+	wantStatusCode := http.StatusBadRequest
+	want := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "server-discover",
+		"error": map[string]interface{}{
+			"code": float64(-32004),
+			"data": map[string]interface{}{
+				"requested": "DRAFT-2026-v1",
+				"supported": []interface{}{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25", "DRAFT-2026-v1"},
+			},
+			"message": "unsupported protocol version",
+		},
+	}
+	// add required header
+	header := map[string]string{}
+	header["Mcp-Protocol-Version"] = protocol
+	header["Mcp-Method"] = methodName
+	if body.Params != nil {
+		body.Params.(map[string]any)["_meta"] = meta
+	} else {
+		body.Params = map[string]any{
+			"_meta": meta,
+		}
+	}
+	reqMarshal, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("unexpected error during marshaling of body")
+	}
+
+	if protocol != protocolVersion20241105 && len(header) == 0 {
+		t.Fatalf("header is missing")
+	}
+
+	resp, resBody, err := runRequest(ts, http.MethodPost, url, bytes.NewBuffer(reqMarshal), header)
+
+	if err != nil {
+		t.Fatalf("unexpected error during request: %s", err)
+	}
+
+	if resp.StatusCode != wantStatusCode {
+		t.Errorf("StatusCode mismatch: got %d, want %d", resp.StatusCode, wantStatusCode)
+	}
+
+	if contentType := resp.Header.Get("Content-type"); contentType != "application/json" {
+		t.Fatalf("unexpected content-type header: want %s, got %s", "application/json", contentType)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(resBody, &got); err != nil {
+		t.Fatalf("unexpected error unmarshalling body: %s", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected response: got %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -468,6 +468,7 @@ func TestMcpEndpoint(t *testing.T) {
 		name           string
 		protocol       string
 		idHeader       bool
+		reqHeader      []string
 		initWant       map[string]any
 		invalidMethods []string
 		meta           map[string]any
@@ -510,9 +511,10 @@ func TestMcpEndpoint(t *testing.T) {
 			invalidMethods: []string{"server/discover"},
 		},
 		{
-			name:     "version 2025-06-18",
-			protocol: protocolVersion20250618,
-			idHeader: false,
+			name:      "version 2025-06-18",
+			protocol:  protocolVersion20250618,
+			idHeader:  false,
+			reqHeader: []string{"Mcp-Protocol-Version"},
 			initWant: map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "mcp-initialize",
@@ -528,9 +530,10 @@ func TestMcpEndpoint(t *testing.T) {
 			invalidMethods: []string{"server/discover"},
 		},
 		{
-			name:     "version 2025-11-25",
-			protocol: protocolVersion20251125,
-			idHeader: false,
+			name:      "version 2025-11-25",
+			protocol:  protocolVersion20251125,
+			idHeader:  false,
+			reqHeader: []string{"Mcp-Protocol-Version"},
 			initWant: map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "mcp-initialize",
@@ -549,6 +552,7 @@ func TestMcpEndpoint(t *testing.T) {
 			name:           "version DRAFT",
 			protocol:       protocolVersionDraft,
 			idHeader:       false,
+			reqHeader:      []string{"Mcp-Protocol-Version", "Mcp-Method", "Mcp-Name"},
 			invalidMethods: []string{"ping"},
 			meta: map[string]any{
 				"io.modelcontextprotocol/protocolVersion": protocolVersionDraft,
@@ -566,20 +570,12 @@ func TestMcpEndpoint(t *testing.T) {
 			if len(vtc.initWant) != 0 {
 				sessionId = runInitializeLifecycle(t, ts, vtc.protocol, vtc.initWant, vtc.idHeader)
 			}
-
-			header := map[string]string{}
-			if sessionId != "" {
-				header["Mcp-Session-Id"] = sessionId
-			}
-			if vtc.protocol != protocolVersion20241105 && vtc.protocol != protocolVersion20250326 {
-				header["MCP-Protocol-Version"] = vtc.protocol
-			}
-
 			testCases := []*struct {
 				name           string
 				url            string
 				isErr          bool
-				body           any
+				body           jsonrpc.JSONRPCRequest
+				batchBody      []jsonrpc.JSONRPCRequest
 				methodName     string
 				wantStatusCode int
 				want           map[string]any
@@ -863,7 +859,7 @@ func TestMcpEndpoint(t *testing.T) {
 					name:  "batch requests",
 					url:   "/",
 					isErr: true,
-					body: []any{
+					batchBody: []jsonrpc.JSONRPCRequest{
 						jsonrpc.JSONRPCRequest{
 							Jsonrpc: "1.0",
 							Id:      "batch-requests1",
@@ -1079,22 +1075,41 @@ func TestMcpEndpoint(t *testing.T) {
 			for i := range testCases {
 				tc := *testCases[i]
 				t.Run(tc.name, func(t *testing.T) {
+					// add required header
+					header := map[string]string{}
+					if sessionId != "" {
+						header["Mcp-Session-Id"] = sessionId
+					}
+					if slices.Contains(vtc.reqHeader, "Mcp-Protocol-Version") {
+						header["Mcp-Protocol-Version"] = vtc.protocol
+					}
+					if slices.Contains(vtc.reqHeader, "Mcp-Method") {
+						header["Mcp-Method"] = tc.methodName
+					}
+					if slices.Contains(vtc.reqHeader, "Mcp-Name") && (tc.methodName == "tools/call" || tc.methodName == "prompts/get") {
+						params := tc.body.Params.(map[string]any)
+						header["Mcp-Name"] = params["name"].(string)
+					}
 					if vtc.meta != nil {
-						switch v := tc.body.(type) {
-						case jsonrpc.JSONRPCRequest:
-							if v.Params != nil {
-								v.Params.(map[string]any)["_meta"] = vtc.meta
-							} else {
-								v.Params = map[string]any{
-									"_meta": vtc.meta,
-								}
+						body := tc.body
+						if body.Params != nil {
+							body.Params.(map[string]any)["_meta"] = vtc.meta
+						} else {
+							body.Params = map[string]any{
+								"_meta": vtc.meta,
 							}
-							tc.body = v
 						}
+						tc.body = body
 					}
 					reqMarshal, err := json.Marshal(tc.body)
 					if err != nil {
 						t.Fatalf("unexpected error during marshaling of body")
+					}
+					if tc.batchBody != nil {
+						reqMarshal, err = json.Marshal(tc.batchBody)
+						if err != nil {
+							t.Fatalf("unexpected error during marshaling of body")
+						}
 					}
 
 					if vtc.protocol != protocolVersion20241105 && len(header) == 0 {

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -44,6 +45,7 @@ const protocolVersion20241105 = "2024-11-05"
 const protocolVersion20250326 = "2025-03-26"
 const protocolVersion20250618 = "2025-06-18"
 const protocolVersion20251125 = "2025-11-25"
+const protocolVersionDraft = "DRAFT-2026-v1"
 const serverName = "Toolbox"
 
 var basicInputSchema = map[string]any{
@@ -463,10 +465,12 @@ func TestMcpEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	versTestCases := []struct {
-		name     string
-		protocol string
-		idHeader bool
-		initWant map[string]any
+		name           string
+		protocol       string
+		idHeader       bool
+		initWant       map[string]any
+		invalidMethods []string
+		meta           map[string]any
 	}{
 		{
 			name:     "version 2024-11-05",
@@ -484,6 +488,8 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+
+			invalidMethods: []string{"server/discover"},
 		},
 		{
 			name:     "version 2025-03-26",
@@ -501,6 +507,7 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+			invalidMethods: []string{"server/discover"},
 		},
 		{
 			name:     "version 2025-06-18",
@@ -518,6 +525,7 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+			invalidMethods: []string{"server/discover"},
 		},
 		{
 			name:     "version 2025-11-25",
@@ -535,11 +543,29 @@ func TestMcpEndpoint(t *testing.T) {
 					"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 				},
 			},
+			invalidMethods: []string{"server/discover"},
+		},
+		{
+			name:           "version DRAFT",
+			protocol:       protocolVersionDraft,
+			idHeader:       false,
+			invalidMethods: []string{"ping"},
+			meta: map[string]any{
+				"io.modelcontextprotocol/protocolVersion": protocolVersionDraft,
+				"io.modelcontextprotocol/clientInfo": map[string]any{
+					"version": "client-temp-version",
+					"name":    "client-name",
+				},
+				"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+			},
 		},
 	}
 	for _, vtc := range versTestCases {
 		t.Run(vtc.name, func(t *testing.T) {
-			sessionId := runInitializeLifecycle(t, ts, vtc.protocol, vtc.initWant, vtc.idHeader)
+			sessionId := ""
+			if len(vtc.initWant) != 0 {
+				sessionId = runInitializeLifecycle(t, ts, vtc.protocol, vtc.initWant, vtc.idHeader)
+			}
 
 			header := map[string]string{}
 			if sessionId != "" {
@@ -549,11 +575,12 @@ func TestMcpEndpoint(t *testing.T) {
 				header["MCP-Protocol-Version"] = vtc.protocol
 			}
 
-			testCases := []struct {
+			testCases := []*struct {
 				name           string
 				url            string
 				isErr          bool
 				body           any
+				methodName     string
 				wantStatusCode int
 				want           map[string]any
 			}{
@@ -566,6 +593,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "notification",
 						},
 					},
+					methodName:     "notification",
 					wantStatusCode: http.StatusAccepted,
 				},
 				{
@@ -578,11 +606,37 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "ping",
 						},
 					},
+					methodName:     "ping",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "ping-test-123",
 						"result":  map[string]any{},
+					},
+				},
+				{
+					name: "server/discover",
+					url:  "/",
+					body: jsonrpc.JSONRPCRequest{
+						Jsonrpc: jsonrpcVersion,
+						Id:      "server-discover",
+						Request: jsonrpc.Request{
+							Method: "server/discover",
+						},
+					},
+					methodName:     "server/discover",
+					wantStatusCode: http.StatusOK,
+					want: map[string]any{
+						"jsonrpc": "2.0",
+						"id":      "server-discover",
+						"result": map[string]any{
+							"supportedVersions": []any{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25", "DRAFT-2026-v1"},
+							"capabilities": map[string]any{
+								"tools":   map[string]any{"listChanged": false},
+								"prompts": map[string]any{"listChanged": false},
+							},
+							"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+						},
 					},
 				},
 				{
@@ -595,6 +649,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "tools/list",
 						},
 					},
+					methodName:     "tools/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -641,6 +696,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "prompts/list",
 						},
 					},
+					methodName:     "prompts/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -674,6 +730,7 @@ func TestMcpEndpoint(t *testing.T) {
 							},
 						},
 					},
+					methodName:     "prompts/get",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -701,6 +758,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "tools/list",
 						},
 					},
+					methodName:     "tools/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -726,6 +784,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "tools/list",
 						},
 					},
+					methodName:     "tools/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -745,7 +804,8 @@ func TestMcpEndpoint(t *testing.T) {
 						Id:      "missing-method",
 						Request: jsonrpc.Request{},
 					},
-					wantStatusCode: http.StatusOK,
+					methodName:     "",
+					wantStatusCode: http.StatusNotFound,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "missing-method",
@@ -766,7 +826,8 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "foo",
 						},
 					},
-					wantStatusCode: http.StatusOK,
+					methodName:     "foo",
+					wantStatusCode: http.StatusNotFound,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "invalid-method",
@@ -787,6 +848,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "foo",
 						},
 					},
+					methodName:     "foo",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -840,6 +902,7 @@ func TestMcpEndpoint(t *testing.T) {
 							"name": "no_params",
 						},
 					},
+					methodName:     "tools/call",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -867,6 +930,7 @@ func TestMcpEndpoint(t *testing.T) {
 							"name": "unauthorized_tool",
 						},
 					},
+					methodName:     "tools/call",
 					wantStatusCode: http.StatusUnauthorized,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -890,6 +954,7 @@ func TestMcpEndpoint(t *testing.T) {
 							"name": "require_client_auth_tool",
 						},
 					},
+					methodName:     "tools/call",
 					wantStatusCode: http.StatusUnauthorized,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -1011,8 +1076,22 @@ func TestMcpEndpoint(t *testing.T) {
 					},
 				},
 			}
-			for _, tc := range testCases {
+			for i := range testCases {
+				tc := *testCases[i]
 				t.Run(tc.name, func(t *testing.T) {
+					if vtc.meta != nil {
+						switch v := tc.body.(type) {
+						case jsonrpc.JSONRPCRequest:
+							if v.Params != nil {
+								v.Params.(map[string]any)["_meta"] = vtc.meta
+							} else {
+								v.Params = map[string]any{
+									"_meta": vtc.meta,
+								}
+							}
+							tc.body = v
+						}
+					}
 					reqMarshal, err := json.Marshal(tc.body)
 					if err != nil {
 						t.Fatalf("unexpected error during marshaling of body")
@@ -1023,6 +1102,10 @@ func TestMcpEndpoint(t *testing.T) {
 					}
 
 					resp, body, err := runRequest(ts, http.MethodPost, tc.url, bytes.NewBuffer(reqMarshal), header)
+
+					if slices.Contains(vtc.invalidMethods, tc.methodName) {
+						return
+					}
 
 					if err != nil {
 						t.Fatalf("unexpected error during request: %s", err)
@@ -1043,7 +1126,7 @@ func TestMcpEndpoint(t *testing.T) {
 							t.Fatalf("unexpected error unmarshalling body: %s", err)
 						}
 						if !reflect.DeepEqual(got, tc.want) {
-							t.Fatalf("unexpected response: got %+v, want %+v", got, tc.want)
+							t.Fatalf("unexpected response: got %#v, want %#v", got, tc.want)
 						}
 					}
 				})
@@ -1053,24 +1136,46 @@ func TestMcpEndpoint(t *testing.T) {
 }
 
 func TestInvalidProtocolVersionHeader(t *testing.T) {
-	r, shutdown := setUpServer(t, "mcp", nil, nil, nil, nil)
+	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2, testutils.MockTool3, testutils.MockTool4, testutils.MockTool5}
+	mockPrompts := []testutils.MockPrompt{testutils.MockPrompt1}
+	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, mockPrompts)
+	r, shutdown := setUpServer(t, "mcp", toolsMap, toolsets, promptsMap, promptsets)
 	defer shutdown()
 	ts := runServer(r, false)
 	defer ts.Close()
 
+	reqBody := jsonrpc.JSONRPCRequest{
+		Jsonrpc: jsonrpcVersion,
+		Id:      "tools-list",
+		Request: jsonrpc.Request{
+			Method: "tools/list",
+		},
+	}
+	reqMarshal, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("unexpected error during marshaling of body")
+	}
 	header := map[string]string{}
 	header["MCP-Protocol-Version"] = "foo"
 
-	resp, body, err := runRequest(ts, http.MethodPost, "/", nil, header)
+	resp, body, err := runRequest(ts, http.MethodPost, "/", bytes.NewBuffer(reqMarshal), header)
 	if resp.Status != "400 Bad Request" {
-		t.Fatalf("unexpected status: %s", resp.Status)
+		t.Fatalf("unexpected status: %s; %s", resp.Status, body)
 	}
 	var got map[string]any
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("unexpected error unmarshalling body: %s", err)
 	}
-	want := "invalid protocol version: foo"
-	if got["error"] != want {
+	errMap, ok := got["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'error' field to be a map, got %T", got["error"])
+	}
+	msg, ok := errMap["message"].(string)
+	if !ok {
+		t.Fatalf("expected 'message' field to be a string, got %T", errMap["message"])
+	}
+	want := "unsupported protocol version"
+	if msg != want {
 		t.Fatalf("unexpected error message: got %s, want %s", got["error"], want)
 	}
 	if err != nil {
@@ -1404,85 +1509,121 @@ func TestSseManagerGetNilSessionValue(t *testing.T) {
 	}
 }
 
-// withTraceContextPropagator registers the W3C trace-context propagator globally
-// for the duration of the test. extractMeta delegates to otel.GetTextMapPropagator,
-// and the default global propagator is a no-op — so without this helper the
-// "extracted" trace context would always be invalid.
-func withTraceContextPropagator(t *testing.T) {
+func TestExtractMeta(t *testing.T) {
+	// withTraceContextPropagator registers the W3C trace-context propagator globally
+	// for the duration of the test. extractMeta delegates to otel.GetTextMapPropagator,
+	// and the default global propagator is a no-op — so without this helper the
+	// "extracted" trace context would always be invalid.
 	t.Helper()
 	prev := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
-}
 
-func TestExtractMeta_EmptyOrInvalidBody(t *testing.T) {
-	cases := map[string][]byte{
-		"empty":      []byte(""),
-		"not json":   []byte("not json"),
-		"no _meta":   []byte(`{"params":{}}`),
-		"no params":  []byte(`{"method":"tools/call"}`),
-		"empty meta": []byte(`{"params":{"_meta":{}}}`),
+	testCases := []struct {
+		name                 string
+		body                 []byte
+		wantEmptyCtx         bool
+		wantValidSpanContext bool
+		wantTraceId          string
+		wantProtocolVersion  string
+		wantTelemetryAttr    *util.TelemetryAttributes
+		wantClientName       string
+		wantClientVersion    string
+	}{
+		{
+			name:         "empty meta",
+			body:         []byte(""),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "not json meta",
+			body:         []byte("not json"),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "no _meta",
+			body:         []byte(`{"params":{}}`),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "no params",
+			body:         []byte(`{"method":"tools/call"}`),
+			wantEmptyCtx: true,
+		},
+		{
+			name:         "empty meta",
+			body:         []byte(`{"params":{"_meta":{}}}`),
+			wantEmptyCtx: true,
+		},
+		{
+			name:                 "traceparent only",
+			body:                 []byte(`{"params":{"_meta":{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}}}`),
+			wantValidSpanContext: true,
+			wantEmptyCtx:         true,
+		},
+		{
+			name: "telemetry attributes only",
+			body: []byte(`{"params":{"_meta":{"dev.mcp-toolbox/telemetry":{` +
+				`"client.name":"toolbox-langchain-python",` +
+				`"client.version":"v0.1.0",` +
+				`"client.model":"gemini-2.5-flash",` +
+				`"client.user.id":"user-123",` +
+				`"client.agent.id":"agent-456"}}}}`),
+			wantTelemetryAttr: &util.TelemetryAttributes{
+				ClientName: "toolbox-langchain-python", ClientVersion: "v0.1.0",
+				ClientModel: "gemini-2.5-flash", ClientUserID: "user-123", ClientAgentID: "agent-456",
+			},
+		},
+		{
+			name: "traceparent, telemetry and protocol version",
+			body: []byte(`{"params":{"_meta":{` +
+				`"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",` +
+				`"dev.mcp-toolbox/telemetry":{"client.name":"foo","client.version":"v1"},` +
+				`"io.modelcontextprotocol/protocolVersion":"v999"}}}`),
+			wantTelemetryAttr: &util.TelemetryAttributes{
+				ClientName: "foo", ClientVersion: "v1",
+				ClientModel: "", ClientUserID: "", ClientAgentID: "",
+			},
+			wantValidSpanContext: true,
+			wantClientName:       "foo",
+			wantClientVersion:    "v1",
+			wantProtocolVersion:  "v999",
+		},
 	}
-	for name, body := range cases {
-		t.Run(name, func(t *testing.T) {
-			ctx := extractMeta(context.Background(), body)
-			if util.TelemetryAttributesFromContext(ctx) != nil {
-				t.Error("expected no telemetry attributes")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metaProtocolVersion, ctx := extractMeta(context.Background(), tc.body)
+			ta := util.TelemetryAttributesFromContext(ctx)
+			if tc.wantEmptyCtx {
+				if ta != nil {
+					t.Fatalf("expected no telemetry attributes")
+				}
+			}
+
+			if !reflect.DeepEqual(ta, tc.wantTelemetryAttr) {
+				t.Fatalf("got %#v, want %#v", ta, tc.wantTelemetryAttr)
+				if tc.wantClientName != "" && ta.ClientName != tc.wantClientName {
+					t.Fatalf("invalid telemetry attr client name: got %s, want %s", ta.ClientName, tc.wantClientName)
+				}
+				if tc.wantClientVersion != "" && ta.ClientVersion != tc.wantClientVersion {
+					t.Fatalf("invalid telemetry attr client version: got %s, want %s", ta.ClientVersion, tc.wantClientVersion)
+				}
+			}
+
+			if tc.wantValidSpanContext {
+				sc := trace.SpanContextFromContext(ctx)
+				if !sc.IsValid() {
+					t.Fatal("expected valid span context")
+				}
+				if got := sc.TraceID().String(); got != "0af7651916cd43dd8448eb211c80319c" {
+					t.Errorf("trace id mismatch: got %s", got)
+				}
+			}
+
+			if tc.wantProtocolVersion != metaProtocolVersion {
+				t.Fatalf("meta protocol version mismatch: got %s, want %s", metaProtocolVersion, tc.wantProtocolVersion)
 			}
 		})
-	}
-}
-
-func TestExtractMeta_TraceparentOnly(t *testing.T) {
-	withTraceContextPropagator(t)
-	body := []byte(`{"params":{"_meta":{"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}}}`)
-	ctx := extractMeta(context.Background(), body)
-
-	sc := trace.SpanContextFromContext(ctx)
-	if !sc.IsValid() {
-		t.Fatal("expected valid span context from extracted traceparent")
-	}
-	if got := sc.TraceID().String(); got != "0af7651916cd43dd8448eb211c80319c" {
-		t.Errorf("trace id mismatch: got %s", got)
-	}
-	if util.TelemetryAttributesFromContext(ctx) != nil {
-		t.Error("expected no telemetry attributes when only traceparent is sent")
-	}
-}
-
-func TestExtractMeta_TelemetryAttrsOnly(t *testing.T) {
-	body := []byte(`{"params":{"_meta":{"dev.mcp-toolbox/telemetry":{` +
-		`"client.name":"toolbox-langchain-python",` +
-		`"client.version":"v0.1.0",` +
-		`"client.model":"gemini-2.5-flash",` +
-		`"client.user.id":"user-123",` +
-		`"client.agent.id":"agent-456"}}}}`)
-
-	ta := util.TelemetryAttributesFromContext(extractMeta(context.Background(), body))
-	if ta == nil {
-		t.Fatal("expected TelemetryAttributes in context")
-	}
-	want := util.TelemetryAttributes{
-		ClientName: "toolbox-langchain-python", ClientVersion: "v0.1.0",
-		ClientModel: "gemini-2.5-flash", ClientUserID: "user-123", ClientAgentID: "agent-456",
-	}
-	if *ta != want {
-		t.Errorf("got %+v, want %+v", *ta, want)
-	}
-}
-
-func TestExtractMeta_TraceparentAndTelemetryBoth(t *testing.T) {
-	withTraceContextPropagator(t)
-	body := []byte(`{"params":{"_meta":{` +
-		`"traceparent":"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",` +
-		`"dev.mcp-toolbox/telemetry":{"client.name":"foo","client.version":"v1"}}}}`)
-	ctx := extractMeta(context.Background(), body)
-
-	if !trace.SpanContextFromContext(ctx).IsValid() {
-		t.Error("expected valid span context")
-	}
-	ta := util.TelemetryAttributesFromContext(ctx)
-	if ta == nil || ta.ClientName != "foo" || ta.ClientVersion != "v1" {
-		t.Errorf("expected telemetry attrs alongside traceparent, got %+v", ta)
 	}
 }

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -974,6 +974,7 @@ func TestMcpEndpoint(t *testing.T) {
 							Method: "tools/list",
 						},
 					},
+					methodName:     "tools/list",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
@@ -1032,6 +1033,7 @@ func TestMcpEndpoint(t *testing.T) {
 							},
 						},
 					},
+					methodName:     "tools/call",
 					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -62,6 +62,7 @@ type Server struct {
 	ResourceMgr         *resources.ResourceManager
 	mcpPrmFile          string
 	httpMaxRequestBytes int64
+	enableDraftSpecs    bool
 }
 
 func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
@@ -468,6 +469,11 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*Server, error) {
 		toolboxUrl:          cfg.ToolboxUrl,
 		mcpPrmFile:          cfg.McpPrmFile,
 		httpMaxRequestBytes: limit,
+		enableDraftSpecs:    cfg.EnableDraftSpecs,
+	}
+
+	if s.enableDraftSpecs {
+		s.logger.WarnContext(ctx, "Flag --enable-draft-specs is active. Please note that draft specs are subject to breaking changes and will be completely removed (not redirected) once stable MCP specifications are released. Do not use this configuration in production.")
 	}
 
 	// cors

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -363,3 +363,19 @@ func UrlParamsFromContext(ctx context.Context) (map[string]string, bool) {
 	}
 	return nil, false
 }
+
+// enableDraftSpecs is the key to check if the server enabled mcp draft specs
+const enableDraftSpecs contextKey = "enableDraftSpecs"
+
+// WithEnableDraftSpecs adds enable draft specs bool into the context as a value
+func WithEnableDraftSpecs(ctx context.Context, enableDraft bool) context.Context {
+	return context.WithValue(ctx, enableDraftSpecs, enableDraft)
+}
+
+// EnableDraftSpecsFromContext retrieves enable draft specs bool from context
+func EnableDraftSpecsFromContext(ctx context.Context) (bool, bool) {
+	if enableDraft, ok := ctx.Value(enableDraftSpecs).(bool); ok {
+		return enableDraft, true
+	}
+	return false, false
+}


### PR DESCRIPTION
Support draft specs for MCP. This is tentatively set to release on 07-28. 

User will have to start the server with `--enable-draft-specs` flag.