### PR TITLE
fix: fix potential panic in tools call handler

### DIFF
--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -190,7 +190,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -210,16 +213,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -190,7 +190,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -210,16 +213,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -189,7 +189,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -209,16 +212,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -189,7 +189,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -209,16 +212,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -258,7 +258,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
 	}
-	accessToken := tools.AccessToken(header.Get(authTokenHeadername))
+	var accessToken tools.AccessToken
+	if header != nil {
+		accessToken = tools.AccessToken(header.Get(authTokenHeadername))
+	}
 
 	// Check if this specific tool requires the standard authorization header
 	clientAuth, err := tool.RequiresClientAuthorization(resourceMgr)
@@ -278,16 +281,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// marshal arguments and decode it using decodeJSON instead to prevent loss between floats/int.
-	aMarshal, err := json.Marshal(toolArgument)
-	if err != nil {
-		err = fmt.Errorf("unable to marshal tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
-	}
-
 	var data map[string]any
-	if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
-		err = fmt.Errorf("unable to decode tools argument: %w", err)
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	if toolArgument != nil {
+		aMarshal, err := json.Marshal(toolArgument)
+		if err != nil {
+			err = fmt.Errorf("unable to marshal tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+
+		if err = util.DecodeJSON(bytes.NewBuffer(aMarshal), &data); err != nil {
+			err = fmt.Errorf("unable to decode tools argument: %w", err)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+	if data == nil {
+		data = make(map[string]any)
 	}
 
 	// Tool authentication


### PR DESCRIPTION
The `header` parameter can be nil when using the STDIO transport. Directly calling `header.Get(...)` without a nil check will cause a nil pointer/map dereference panic.

If `toolArgument` is `nil` (e.g., when no arguments are provided or they are omitted), `util.DecodeJSON` will decode it into `data` as `nil`. Later, `mcputil.PopulateUrlParams` or other functions might attempt to write to or access `data`, causing a panic on a `nil` map. Please initialize `data` to an empty map if it is decoded as `nil`.