### PR TITLE
fix(cmd): recursively scan nested YAML files in --config-folder

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -428,32 +428,67 @@ func (p *ConfigParser) LoadAndMergeConfigs(ctx context.Context, filePaths []stri
 	return configs[0], nil
 }
 
-// GetPathsFromConfigFolder loads all YAML files from a directory and merges them
+// GetPathsFromConfigFolder returns all YAML config files under folderPath,
+// including nested subdirectories, in deterministic sorted order.
 func GetPathsFromConfigFolder(ctx context.Context, folderPath string) ([]string, error) {
-	// Check if directory exists
-	info, err := os.Stat(folderPath)
-	if err != nil {
-		return nil, fmt.Errorf("unable to access config folder at %q: %w", folderPath, err)
-	}
-	if !info.IsDir() {
-		return nil, fmt.Errorf("path %q is not a directory", folderPath)
+	if err := validateConfigFolder(folderPath); err != nil {
+		return nil, err
 	}
 
-	// Find all YAML files in the directory
-	pattern := filepath.Join(folderPath, "*.yaml")
-	yamlFiles, err := filepath.Glob(pattern)
+	var allFiles []string
+	err := filepath.WalkDir(folderPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			allFiles = append(allFiles, path)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error finding YAML files in %q: %w", folderPath, err)
 	}
 
-	// Also find .yml files
-	ymlPattern := filepath.Join(folderPath, "*.yml")
-	ymlFiles, err := filepath.Glob(ymlPattern)
-	if err != nil {
-		return nil, fmt.Errorf("error finding YML files in %q: %w", folderPath, err)
+	slices.Sort(allFiles)
+	return allFiles, nil
+}
+
+// GetConfigFolderWatchDirs returns folderPath and every subdirectory under it so
+// config hot-reload can observe nested YAML files.
+func GetConfigFolderWatchDirs(folderPath string) ([]string, error) {
+	if err := validateConfigFolder(folderPath); err != nil {
+		return nil, err
 	}
 
-	// Combine both file lists
-	allFiles := append(yamlFiles, ymlFiles...)
-	return allFiles, nil
+	var dirs []string
+	err := filepath.WalkDir(folderPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error walking config folder %q: %w", folderPath, err)
+	}
+
+	slices.Sort(dirs)
+	return dirs, nil
+}
+
+func validateConfigFolder(folderPath string) error {
+	info, err := os.Stat(folderPath)
+	if err != nil {
+		return fmt.Errorf("unable to access config folder at %q: %w", folderPath, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path %q is not a directory", folderPath)
+	}
+	return nil
 }

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -15,7 +15,10 @@
 package internal
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -2415,5 +2418,70 @@ tools:
 				}
 			}
 		})
+	}
+}
+
+func TestGetPathsFromConfigFolder(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "sources.yaml"), []byte("kind: source\nname: root\n"), 0o644); err != nil {
+		t.Fatalf("write root yaml: %v", err)
+	}
+
+	nestedDir := filepath.Join(root, "tools-a")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "tool-a.yaml"), []byte("kind: tool\nname: tool-a\n"), 0o644); err != nil {
+		t.Fatalf("write nested yaml: %v", err)
+	}
+
+	deepDir := filepath.Join(root, "tools-b", "nested")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatalf("mkdir deep nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(deepDir, "tool-c.yml"), []byte("kind: tool\nname: tool-c\n"), 0o644); err != nil {
+		t.Fatalf("write deep nested yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.txt"), []byte("ignore me"), 0o644); err != nil {
+		t.Fatalf("write non-yaml file: %v", err)
+	}
+
+	got, err := GetPathsFromConfigFolder(ctx, root)
+	if err != nil {
+		t.Fatalf("GetPathsFromConfigFolder() error = %v", err)
+	}
+
+	want := []string{
+		filepath.Join(root, "sources.yaml"),
+		filepath.Join(nestedDir, "tool-a.yaml"),
+		filepath.Join(deepDir, "tool-c.yml"),
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("GetPathsFromConfigFolder() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetConfigFolderWatchDirs(t *testing.T) {
+	root := t.TempDir()
+
+	nestedDir := filepath.Join(root, "tools-a", "nested")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	got, err := GetConfigFolderWatchDirs(root)
+	if err != nil {
+		t.Fatalf("GetConfigFolderWatchDirs() error = %v", err)
+	}
+
+	want := []string{
+		root,
+		filepath.Join(root, "tools-a"),
+		nestedDir,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("GetConfigFolderWatchDirs() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -205,18 +205,15 @@ func scanWatchedFiles(watchingFolder bool, folderToWatch string, watchedFiles ma
 	changed := false
 	currentDiskFiles := make(map[string]bool)
 	if watchingFolder {
-		files, err := os.ReadDir(folderToWatch)
+		files, err := internal.GetPathsFromConfigFolder(context.Background(), folderToWatch)
 		if err != nil {
 			return nil, changed, fmt.Errorf("error reading config folder %w", err)
 		}
-		for _, f := range files {
-			if !f.IsDir() && (strings.HasSuffix(f.Name(), ".yaml") || strings.HasSuffix(f.Name(), ".yml")) {
-				fullPath := filepath.Join(folderToWatch, f.Name())
-				currentDiskFiles[fullPath] = true
-				if info, err := f.Info(); err == nil {
-					if checkModTime(fullPath, info.ModTime(), lastSeen) {
-						changed = true
-					}
+		for _, fullPath := range files {
+			currentDiskFiles[fullPath] = true
+			if info, err := os.Stat(fullPath); err == nil {
+				if checkModTime(fullPath, info.ModTime(), lastSeen) {
+					changed = true
 				}
 			}
 		}
@@ -234,7 +231,7 @@ func scanWatchedFiles(watchingFolder bool, folderToWatch string, watchedFiles ma
 }
 
 // watchChanges checks for changes in the provided yaml config(s) or folder.
-func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles map[string]bool, s *server.Server, pollTickerSecond int) {
+func watchChanges(ctx context.Context, configFolderRoot string, watchDirs map[string]bool, watchedFiles map[string]bool, s *server.Server, pollTickerSecond int) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		panic(err)
@@ -254,16 +251,13 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 	// if watchedFiles is empty, indicates that user passed entire folder instead
 	if len(watchedFiles) == 0 {
 		watchingFolder = true
-
-		// validate that watchDirs only has single element
-		if len(watchDirs) > 1 {
-			logger.WarnContext(ctx, "error setting watcher, expected single config folder if no file(s) are defined.")
-			return
-		}
-
-		for onlyKey := range watchDirs {
-			folderToWatch = onlyKey
-			break
+		if configFolderRoot != "" {
+			folderToWatch = filepath.Clean(configFolderRoot)
+		} else if len(watchDirs) == 1 {
+			for onlyKey := range watchDirs {
+				folderToWatch = onlyKey
+				break
+			}
 		}
 	}
 
@@ -402,7 +396,14 @@ func resolveWatcherInputs(toolsFile string, toolsFiles []string, toolsFolder str
 	if len(toolsFiles) > 0 {
 		relevantFiles = toolsFiles
 	} else if toolsFolder != "" {
-		watchDirs[filepath.Clean(toolsFolder)] = true
+		cleanFolder := filepath.Clean(toolsFolder)
+		if dirs, err := internal.GetConfigFolderWatchDirs(cleanFolder); err == nil {
+			for _, dir := range dirs {
+				watchDirs[dir] = true
+			}
+		} else {
+			watchDirs[cleanFolder] = true
+		}
 	} else {
 		relevantFiles = []string{toolsFile}
 	}
@@ -527,7 +528,7 @@ func run(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 	if isCustomConfigured && !opts.Cfg.DisableReload {
 		watchDirs, watchedFiles := resolveWatcherInputs(opts.Config, opts.Configs, opts.ConfigFolder)
 		// start watching the file(s) or folder for changes to trigger dynamic reloading
-		go watchChanges(ctx, watchDirs, watchedFiles, s, opts.Cfg.PollInterval)
+		go watchChanges(ctx, opts.ConfigFolder, watchDirs, watchedFiles, s, opts.Cfg.PollInterval)
 	}
 
 	// wait for either the server to error out or the command's context to be canceled

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -576,6 +576,28 @@ func TestResolveWatcherInputs(t *testing.T) {
 	}
 }
 
+func TestResolveWatcherInputsNestedConfigFolder(t *testing.T) {
+	root := t.TempDir()
+	nestedDir := filepath.Join(root, "tools-a")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	gotWatchDirs, gotWatchedFiles := resolveWatcherInputs("", nil, root)
+
+	if len(gotWatchedFiles) != 0 {
+		t.Fatalf("expected empty watchedFiles for folder mode, got %v", gotWatchedFiles)
+	}
+
+	wantWatchDirs := map[string]bool{
+		root:      true,
+		nestedDir: true,
+	}
+	if diff := cmp.Diff(wantWatchDirs, gotWatchDirs); diff != "" {
+		t.Fatalf("incorrect watchDirs: diff %v", diff)
+	}
+}
+
 // helper function for testing file detection in dynamic reloading
 func tmpFileWithCleanup(content []byte) (string, func(), error) {
 	f, err := os.CreateTemp("", "*")
@@ -629,7 +651,7 @@ func TestSingleEdit(t *testing.T) {
 	watchedFiles := map[string]bool{cleanFileToWatch: true}
 	watchDirs := map[string]bool{watchDir: true}
 
-	go watchChanges(ctx, watchDirs, watchedFiles, mockServer, 0)
+	go watchChanges(ctx, "", watchDirs, watchedFiles, mockServer, 0)
 
 	// escape backslash so regex doesn't fail on windows filepaths
 	regexEscapedPathFile := strings.ReplaceAll(cleanFileToWatch, `\`, `\\\\*\\`)


### PR DESCRIPTION
## Summary

Make `--config-folder` recursively discover `.yaml` / `.yml` config files in nested subdirectories and return them in deterministic sorted order.

## Motivation

Today `GetPathsFromConfigFolder` only loads files directly under the root folder via flat `filepath.Glob`, so nested layouts are silently ignored. This breaks organized config trees and also misaligns with `toolbox skills-generate`, which copies nested folders into skill assets but runtime loading could not see tools in subdirectories (#3540).

## Changes

- Replace flat globbing with `filepath.WalkDir` and `slices.Sort` in `GetPathsFromConfigFolder`.
- Add `GetConfigFolderWatchDirs` to register all subdirectories for fsnotify hot-reload.
- Update NFS polling scan to use the same recursive discovery.
- Pass the original `--config-folder` root into `watchChanges` so reload scans the full tree even when multiple watch directories are registered.
- Add unit/integration tests for recursive discovery and nested watcher inputs.

## Tests

- `go test ./cmd/... -run 'TestGetPathsFromConfigFolder|TestGetConfigFolderWatchDirs|TestResolveWatcherInputsNestedConfigFolder|TestResolveWatcherInputs|TestSingleEdit' -count=1`
- `go vet ./cmd/... ./cmd/internal/...`

## Notes

- Merge semantics are unchanged; only file discovery and reload watching behavior are updated.
- Composer-2.5 review: APPROVE after `watchChanges` root-path fix.

Fixes #3540