### PR TITLE
chore(ci): Add manual fixes to harden workflows

### DIFF
--- a/.github/workflows/cloud_build_failure_reporter.yml
+++ b/.github/workflows/cloud_build_failure_reporter.yml
@@ -38,10 +38,12 @@ jobs:
 
     steps:
       - uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # v9
+        env:
+          TRIGGER_NAMES: ${{ inputs.trigger_names }}
         with:
           script: |-
                   // parse test names
-                  const testNameSubstring = '${{ inputs.trigger_names }}';
+                  const testNameSubstring = process.env.TRIGGER_NAMES;
                   const testNameFound = new Map(); //keeps track of whether each test is found
                   testNameSubstring.split(',').forEach(testName => {
                     testNameFound.set(testName, false); 
@@ -171,8 +173,8 @@ jobs:
                   const noTestFound = Array.from(testNameFound.values()).every(value => value === false);
                   if (noTestFound){
                     createOrCommentIssue(
-                      'Missing periodic tests: ${{ inputs.trigger_names }}',
-                      `No periodic test is found for triggers: ${{ inputs.trigger_names }}. Last checked from ${
+                      `Missing periodic tests: ${process.env.TRIGGER_NAMES}`,
+                      `No periodic test is found for triggers: ${process.env.TRIGGER_NAMES}. Last checked from ${
                         commits[0].html_url
                       } to ${commits[commits.length - 1].html_url}.`
                     );

--- a/.github/workflows/cloudflare_sync.yaml
+++ b/.github/workflows/cloudflare_sync.yaml
@@ -21,6 +21,7 @@ concurrency:
   group: cloudflare-sync
   cancel-in-progress: true
 
+# zizmor flags workflow_run, but this is safe because it only deploys internal branches and is strictly gated to the base repository.
 on: # zizmor: ignore[dangerous-triggers]
   workflow_dispatch:
   workflow_run:
@@ -30,6 +31,7 @@ on: # zizmor: ignore[dangerous-triggers]
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Hardened workflow_run: strictly verifies the triggering run originated from the base repository to prevent execution from forks.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository)

--- a/.github/workflows/cloudflare_sync.yaml
+++ b/.github/workflows/cloudflare_sync.yaml
@@ -21,7 +21,7 @@ concurrency:
   group: cloudflare-sync
   cancel-in-progress: true
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   workflow_dispatch:
   workflow_run:
     workflows: ["CF: Deploy Dev Docs", "CF: Deploy Versioned Docs", "CF: Deploy Previous Version Docs"]
@@ -30,7 +30,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 name: conformance
-on:
+# zizmor flags pull_request_target, but it is safely gated by the 'tests: run' label manually applied by maintainers.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request:
   pull_request_target:
     types: [labeled]

--- a/.github/workflows/deploy_versioned_docs_to_cf.yaml
+++ b/.github/workflows/deploy_versioned_docs_to_cf.yaml
@@ -48,6 +48,8 @@ jobs:
           extended: true
 
       - name: Setup Node
+        # zizmor flags setup-node for cache-poisoning on releases, but since we don't pass `cache: npm`, no caching occurs. Safe to ignore.
+        # zizmor: ignore[cache-poisoning]
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"

--- a/.github/workflows/docs_preview_build_cf.yaml
+++ b/.github/workflows/docs_preview_build_cf.yaml
@@ -23,7 +23,8 @@ on:
       - '.github/workflows/docs*_cf.yaml'
       - '.hugo/**'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build-preview:

--- a/.github/workflows/docs_preview_deploy_cf.yaml
+++ b/.github/workflows/docs_preview_deploy_cf.yaml
@@ -14,7 +14,8 @@
 
 name: "CF: Deploy Docs Preview"
 
-on:
+# zizmor flags workflow_run input, but this workflow safely sanitizes the untrusted PR number artifact before use.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["CF: Build Docs Preview"]
     types:
@@ -83,10 +84,13 @@ jobs:
 
       - name: Post Preview URL Comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_NUMBER: ${{ steps.get_pr.outputs.pr_number }}
+          DEPLOY_URL: ${{ steps.cf_deploy.outputs.pages-deployment-alias-url }}
         with:
           script: |
-            const prNumber = parseInt('${{ steps.get_pr.outputs.pr_number }}', 10);
-            const deployUrl = '${{ steps.cf_deploy.outputs.pages-deployment-alias-url }}';
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const deployUrl = process.env.DEPLOY_URL;
             const marker = '<!-- cf-preview-comment-marker -->';
 
             // Fetch all comments on the PR

--- a/.github/workflows/lint_fallback.yaml
+++ b/.github/workflows/lint_fallback.yaml
@@ -14,7 +14,8 @@
 
 name: lint
 
-on:
+# zizmor flags pull_request_target, but this fallback workflow never checks out code.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request:
     paths:
       - "docs/**"

--- a/.github/workflows/tests_fallback.yaml
+++ b/.github/workflows/tests_fallback.yaml
@@ -14,7 +14,8 @@
 
 name: tests
 
-on:
+# zizmor flags pull_request_target, but this fallback workflow never checks out code.
+on: # zizmor: ignore[dangerous-triggers]
   push:
     branches:
       - "main"


### PR DESCRIPTION
## Description

This PR resolves security vulnerabilities  flagged by `zizmor` in our GitHub Actions workflows to harden our CI pipelines. 
* Fixes template injection in `cloud_build_failure_reporter.yml` and `docs_preview_deploy_cf.yaml` by passing variables safely through `env`.
* Limits overly broad `read-all` permissions in `docs_preview_build_cf.yaml` to `contents: read`.
* Hardens the `workflow_run` trigger in `cloudflare_sync.yaml` by verifying the `head_repository` is the base repo.
* Documents and suppresses `zizmor` false-positives for `pull_request_target` and `cache-poisoning` in workflows that are strictly gated, sanitize their artifacts, or never check out untrusted code.
