### PR TITLE
fix(cockroachdb): detect existing LIMIT across whitespace variants

### DIFF
--- a/internal/sources/cockroachdb/cockroachdb.go
+++ b/internal/sources/cockroachdb/cockroachdb.go
@@ -117,6 +117,9 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 var _ sources.Source = &Source{}
 
+// limitClausePattern detects an existing LIMIT clause regardless of surrounding whitespace.
+var limitClausePattern = regexp.MustCompile(`(?i)\bLIMIT\b`)
+
 type Source struct {
 	Config
 	Pool *pgxpool.Pool
@@ -307,9 +310,8 @@ func (s *Source) ApplyQueryLimits(sql string) (string, error) {
 
 	// Apply row limit only to SELECT queries
 	if sqlType == SQLTypeSelect && s.MaxRowLimit > 0 {
-		// Check if query already has LIMIT clause
-		normalized := strings.ToUpper(sql)
-		if !strings.Contains(normalized, " LIMIT ") {
+		// Check if query already has LIMIT clause (any whitespace boundary)
+		if !limitClausePattern.MatchString(sql) {
 			// Add LIMIT clause - trim trailing whitespace and semicolon
 			sql = strings.TrimSpace(sql)
 			sql = strings.TrimSuffix(sql, ";")

--- a/internal/sources/cockroachdb/security_test.go
+++ b/internal/sources/cockroachdb/security_test.go
@@ -240,6 +240,27 @@ func TestApplyQueryLimits(t *testing.T) {
 			shouldAddLimit: true,
 		},
 		{
+			name:           "SELECT with multiline existing LIMIT",
+			sql:            "SELECT *\nFROM users\nLIMIT 50",
+			maxRowLimit:    100,
+			expectedSQL:    "SELECT *\nFROM users\nLIMIT 50",
+			shouldAddLimit: false,
+		},
+		{
+			name:           "SELECT with tab-separated LIMIT",
+			sql:            "SELECT * FROM users\tLIMIT 25",
+			maxRowLimit:    100,
+			expectedSQL:    "SELECT * FROM users\tLIMIT 25",
+			shouldAddLimit: false,
+		},
+		{
+			name:           "SELECT with lowercase multiline limit",
+			sql:            "select *\nfrom users\nlimit 10",
+			maxRowLimit:    100,
+			expectedSQL:    "select *\nfrom users\nlimit 10",
+			shouldAddLimit: false,
+		},
+		{
 			name:           "INSERT should not have LIMIT added",
 			sql:            "INSERT INTO users (name) VALUES ('alice')",
 			maxRowLimit:    100,


### PR DESCRIPTION
## Summary
- Use `(?i)\bLIMIT\b` instead of ` LIMIT ` substring matching in `ApplyQueryLimits`
- Add multiline/tab/lowercase LIMIT regression tests

Fixes #3553

## Test plan
- [x] `TestApplyQueryLimits` covers multiline and tab-separated LIMIT cases

Made with [Cursor](https://cursor.com)