### PR TITLE
feat(server): set MCP server instructions from group description

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -837,7 +837,13 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			version = mcputil.GetLatestSupportedVersion(s.enableDraftSpecs)
 		}
 
-		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, nil, body, nil)
+		// Surface the connected group's description as the server instructions.
+		var instructions string
+		if g, ok := s.ResourceMgr.GetGroup(toolsetName); ok {
+			instructions = g.Description
+		}
+
+		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, tools.Toolset{}, prompts.Promptset{}, instructions, nil, body, nil)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			if rpcErr, ok := result.(jsonrpc.JSONRPCError); ok {
@@ -860,7 +866,7 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 			span.SetAttributes(attribute.String("error.type", metricErrorType))
 			return "", rpcErr, err
 		}
-		result, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, g.ToToolset(), g.ToPromptset(), s.ResourceMgr, body, header)
+		result, err := mcp.ProcessMethod(ctx, protocolVersion, baseMessage.Id, baseMessage.Method, g.ToToolset(), g.ToPromptset(), g.Description, s.ResourceMgr, body, header)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			// Set error.type based on JSON-RPC error code

--- a/internal/server/mcp/mcp.go
+++ b/internal/server/mcp/mcp.go
@@ -47,7 +47,7 @@ func NotificationHandler(ctx context.Context, body []byte) error {
 
 // ProcessMethod returns a response for the request.
 // This is the Operation phase of the lifecycle for MCP client-server connections.
-func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, instructions string, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	enableDraft, ok := util.EnableDraftSpecsFromContext(ctx)
 	if !ok {
 		err := fmt.Errorf("unable to retrieve enableDraftSpecs from context")
@@ -56,17 +56,17 @@ func ProcessMethod(ctx context.Context, mcpVersion string, id jsonrpc.RequestId,
 	switch mcpVersion {
 	case mcputil.VERSION_DRAFT:
 		if enableDraft {
-			return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+			return vdraft.ProcessMethod(ctx, id, method, toolset, promptset, instructions, resourceMgr, body, header)
 		}
 		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion, enableDraft)
 	case mcputil.VERSION_20251125:
-		return v20251125.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+		return v20251125.ProcessMethod(ctx, id, method, toolset, promptset, instructions, resourceMgr, body, header)
 	case mcputil.VERSION_20250618:
-		return v20250618.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+		return v20250618.ProcessMethod(ctx, id, method, toolset, promptset, instructions, resourceMgr, body, header)
 	case mcputil.VERSION_20250326:
-		return v20250326.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+		return v20250326.ProcessMethod(ctx, id, method, toolset, promptset, instructions, resourceMgr, body, header)
 	case "", mcputil.VERSION_20241105:
-		return v20241105.ProcessMethod(ctx, id, method, toolset, promptset, resourceMgr, body, header)
+		return v20241105.ProcessMethod(ctx, id, method, toolset, promptset, instructions, resourceMgr, body, header)
 	default:
 		return jsonrpc.NewUnsupportedProtocolVersionError(id, mcpVersion, enableDraft)
 	}

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -38,10 +38,10 @@ import (
 )
 
 // ProcessMethod returns a response for the request.
-func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, instructions string, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch method {
 	case INITIALIZE:
-		return initializeHandler(ctx, id, body)
+		return initializeHandler(ctx, id, instructions, body)
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
@@ -61,7 +61,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 // InitializeResponse runs capability negotiation and protocol version agreement.
 // This is the Initialization phase of the lifecycle for MCP client-server connections.
 // Always start with the latest protocol version supported.
-func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+func initializeHandler(ctx context.Context, id jsonrpc.RequestId, instructions string, body []byte) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -91,6 +91,7 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 			},
 			Version: v,
 		},
+		Instructions: instructions,
 	}
 	res := jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,

--- a/internal/server/mcp/v20241105/method_test.go
+++ b/internal/server/mcp/v20241105/method_test.go
@@ -95,7 +95,7 @@ func TestInitializeHandler(t *testing.T) {
 				}
 			}
 
-			got, err := initializeHandler(tt.context, dummyID, body)
+			got, err := initializeHandler(tt.context, dummyID, "test instructions", body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -129,6 +129,9 @@ func TestInitializeHandler(t *testing.T) {
 				}
 				if initResult.ServerInfo.Version != fakeVersionString {
 					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+				if initResult.Instructions != "test instructions" {
+					t.Errorf("expected instructions %q, got %q", "test instructions", initResult.Instructions)
 				}
 			}
 		})

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -38,10 +38,10 @@ import (
 )
 
 // ProcessMethod returns a response for the request.
-func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, instructions string, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch method {
 	case INITIALIZE:
-		return initializeHandler(ctx, id, body)
+		return initializeHandler(ctx, id, instructions, body)
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
@@ -61,7 +61,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 // InitializeResponse runs capability negotiation and protocol version agreement.
 // This is the Initialization phase of the lifecycle for MCP client-server connections.
 // Always start with the latest protocol version supported.
-func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+func initializeHandler(ctx context.Context, id jsonrpc.RequestId, instructions string, body []byte) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -91,6 +91,7 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 			},
 			Version: v,
 		},
+		Instructions: instructions,
 	}
 	res := jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,

--- a/internal/server/mcp/v20250326/method_test.go
+++ b/internal/server/mcp/v20250326/method_test.go
@@ -95,7 +95,7 @@ func TestInitializeHandler(t *testing.T) {
 				}
 			}
 
-			got, err := initializeHandler(tt.context, dummyID, body)
+			got, err := initializeHandler(tt.context, dummyID, "test instructions", body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -129,6 +129,9 @@ func TestInitializeHandler(t *testing.T) {
 				}
 				if initResult.ServerInfo.Version != fakeVersionString {
 					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+				if initResult.Instructions != "test instructions" {
+					t.Errorf("expected instructions %q, got %q", "test instructions", initResult.Instructions)
 				}
 			}
 		})

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -38,10 +38,10 @@ import (
 )
 
 // ProcessMethod returns a response for the request.
-func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, instructions string, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch method {
 	case INITIALIZE:
-		return initializeHandler(ctx, id, body)
+		return initializeHandler(ctx, id, instructions, body)
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
@@ -61,7 +61,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 // InitializeResponse runs capability negotiation and protocol version agreement.
 // This is the Initialization phase of the lifecycle for MCP client-server connections.
 // Always start with the latest protocol version supported.
-func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+func initializeHandler(ctx context.Context, id jsonrpc.RequestId, instructions string, body []byte) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -91,6 +91,7 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 			},
 			Version: v,
 		},
+		Instructions: instructions,
 	}
 	res := jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,

--- a/internal/server/mcp/v20250618/method_test.go
+++ b/internal/server/mcp/v20250618/method_test.go
@@ -95,7 +95,7 @@ func TestInitializeHandler(t *testing.T) {
 				}
 			}
 
-			got, err := initializeHandler(tt.context, dummyID, body)
+			got, err := initializeHandler(tt.context, dummyID, "test instructions", body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -129,6 +129,9 @@ func TestInitializeHandler(t *testing.T) {
 				}
 				if initResult.ServerInfo.Version != fakeVersionString {
 					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+				if initResult.Instructions != "test instructions" {
+					t.Errorf("expected instructions %q, got %q", "test instructions", initResult.Instructions)
 				}
 			}
 		})

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -38,10 +38,10 @@ import (
 )
 
 // ProcessMethod returns a response for the request.
-func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, instructions string, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch method {
 	case INITIALIZE:
-		return initializeHandler(ctx, id, body)
+		return initializeHandler(ctx, id, instructions, body)
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
@@ -61,7 +61,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 // InitializeResponse runs capability negotiation and protocol version agreement.
 // This is the Initialization phase of the lifecycle for MCP client-server connections.
 // Always start with the latest protocol version supported.
-func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (any, error) {
+func initializeHandler(ctx context.Context, id jsonrpc.RequestId, instructions string, body []byte) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -91,6 +91,7 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 			},
 			Version: v,
 		},
+		Instructions: instructions,
 	}
 	res := jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,

--- a/internal/server/mcp/v20251125/method_test.go
+++ b/internal/server/mcp/v20251125/method_test.go
@@ -95,7 +95,7 @@ func TestInitializeHandler(t *testing.T) {
 				}
 			}
 
-			got, err := initializeHandler(tt.context, dummyID, body)
+			got, err := initializeHandler(tt.context, dummyID, "test instructions", body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -129,6 +129,9 @@ func TestInitializeHandler(t *testing.T) {
 				}
 				if initResult.ServerInfo.Version != fakeVersionString {
 					t.Errorf("expected version %q, got %q", fakeVersionString, initResult.ServerInfo.Version)
+				}
+				if initResult.Instructions != "test instructions" {
+					t.Errorf("expected instructions %q, got %q", "test instructions", initResult.Instructions)
 				}
 			}
 		})

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -37,10 +37,10 @@ import (
 )
 
 // ProcessMethod returns a response for the request.
-func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
+func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, toolset tools.Toolset, promptset prompts.Promptset, instructions string, resourceMgr *resources.ResourceManager, body []byte, header http.Header) (any, error) {
 	switch method {
 	case SERVER_DISCOVER:
-		return serverDiscoverHandler(ctx, id, body, header)
+		return serverDiscoverHandler(ctx, id, instructions, body, header)
 	case TOOLS_LIST:
 		return toolsListHandler(ctx, id, resourceMgr, toolset, body, header)
 	case TOOLS_CALL:
@@ -117,7 +117,7 @@ func validateHeader(id jsonrpc.RequestId, header http.Header, method, name strin
 	return nil, nil
 }
 
-func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, header http.Header) (any, error) {
+func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, instructions string, body []byte, header http.Header) (any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -160,6 +160,7 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 			},
 			Version: v,
 		},
+		Instructions: instructions,
 	}
 	res := jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -378,7 +378,7 @@ func TestServerDiscoverHandler(t *testing.T) {
 					t.Fatalf("unexpected error during marshaling")
 				}
 			}
-			got, err := serverDiscoverHandler(tt.context, dummyID, body, tt.header)
+			got, err := serverDiscoverHandler(tt.context, dummyID, "test instructions", body, tt.header)
 
 			if tt.wantErr {
 				if err == nil {
@@ -392,7 +392,18 @@ func TestServerDiscoverHandler(t *testing.T) {
 					t.Fatalf("unexpected error: %v", err)
 				}
 				if got == nil {
-					t.Errorf("expected valid response, got nil")
+					t.Fatalf("expected valid response, got nil")
+				}
+				res, ok := got.(jsonrpc.JSONRPCResponse)
+				if !ok {
+					t.Fatalf("expected response of type jsonrpc.JSONRPCResponse, got %T", got)
+				}
+				discoverResult, ok := res.Result.(DiscoverResult)
+				if !ok {
+					t.Fatalf("expected result of type DiscoverResult, got %T", res.Result)
+				}
+				if discoverResult.Instructions != "test instructions" {
+					t.Errorf("expected instructions %q, got %q", "test instructions", discoverResult.Instructions)
 				}
 			}
 		})

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -1799,3 +1799,126 @@ func TestMcpPromptScopingByGroup(t *testing.T) {
 		})
 	}
 }
+
+func TestMcpInstructionsFromGroupDescription(t *testing.T) {
+	const groupDescription = "Use these tools to manage widgets."
+	toolsMap := map[string]tools.Tool{}
+	promptsMap := map[string]prompts.Prompt{}
+	describedGroup, err := group.GroupConfig{Name: "described", Description: groupDescription}.Initialize(testutils.MockVersionString, toolsMap, promptsMap)
+	if err != nil {
+		t.Fatalf("unable to initialize described group: %s", err)
+	}
+	plainGroup, err := group.GroupConfig{Name: "plain"}.Initialize(testutils.MockVersionString, toolsMap, promptsMap)
+	if err != nil {
+		t.Fatalf("unable to initialize plain group: %s", err)
+	}
+	groups := map[string]group.Group{"described": describedGroup, "plain": plainGroup}
+	r, shutdown := setUpServer(t, "mcp", toolsMap, promptsMap, groups, withEnableDraftSpecs())
+	defer shutdown()
+	ts := runServer(r, false)
+	defer ts.Close()
+
+	baseResult := func(protocolVersion string) map[string]any {
+		return map[string]any{
+			"protocolVersion": protocolVersion,
+			"capabilities": map[string]any{
+				"tools":   map[string]any{"listChanged": false},
+				"prompts": map[string]any{"listChanged": false},
+			},
+			"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+		}
+	}
+
+	// initialize path: the 4 pre-draft versions.
+	initVersions := []string{protocolVersion20241105, protocolVersion20250326, protocolVersion20250618, protocolVersion20251125}
+	for _, pv := range initVersions {
+		t.Run("initialize "+pv, func(t *testing.T) {
+			// described group surfaces its description as instructions.
+			describedWant := baseResult(pv)
+			describedWant["instructions"] = groupDescription
+			assertInitializeInstructions(t, ts, "/described", pv, map[string]any{"jsonrpc": "2.0", "id": "mcp-initialize", "result": describedWant})
+
+			// group with no description omits the instructions field.
+			assertInitializeInstructions(t, ts, "/plain", pv, map[string]any{"jsonrpc": "2.0", "id": "mcp-initialize", "result": baseResult(pv)})
+		})
+	}
+
+	// serverDiscover path: draft version.
+	t.Run("serverDiscover DRAFT", func(t *testing.T) {
+		discoverBody := map[string]any{
+			"jsonrpc": jsonrpcVersion,
+			"id":      "server-discover",
+			"method":  "server/discover",
+			"params": map[string]any{
+				"_meta": map[string]any{
+					"io.modelcontextprotocol/protocolVersion": protocolVersionDraft,
+					"io.modelcontextprotocol/clientInfo": map[string]any{
+						"version": "client-temp-version",
+						"name":    "client-name",
+					},
+					"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+				},
+			},
+		}
+		reqMarshal, err := json.Marshal(discoverBody)
+		if err != nil {
+			t.Fatalf("unexpected error marshaling body: %s", err)
+		}
+		header := map[string]string{"Mcp-Protocol-Version": protocolVersionDraft, "Mcp-Method": "server/discover"}
+		resp, body, err := runRequest(ts, http.MethodPost, "/described", bytes.NewBuffer(reqMarshal), header)
+		if err != nil {
+			t.Fatalf("unexpected error during request: %s", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("StatusCode mismatch: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("unexpected error unmarshalling body: %s", err)
+		}
+		want := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "server-discover",
+			"result": map[string]any{
+				"supportedVersions": []any{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25", "DRAFT-2026-v1"},
+				"capabilities": map[string]any{
+					"tools":   map[string]any{"listChanged": false},
+					"prompts": map[string]any{"listChanged": false},
+				},
+				"serverInfo":   map[string]any{"name": serverName, "version": testutils.MockVersionString},
+				"instructions": groupDescription,
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("unexpected response: got %#v, want %#v", got, want)
+		}
+	})
+}
+
+func assertInitializeInstructions(t *testing.T, ts *httptest.Server, url, protocolVersion string, want map[string]any) {
+	t.Helper()
+	reqBody := map[string]any{
+		"jsonrpc": jsonrpcVersion,
+		"id":      "mcp-initialize",
+		"method":  "initialize",
+		"params":  map[string]any{"protocolVersion": protocolVersion},
+	}
+	reqMarshal, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling body: %s", err)
+	}
+	resp, body, err := runRequest(ts, http.MethodPost, url, bytes.NewBuffer(reqMarshal), nil)
+	if err != nil {
+		t.Fatalf("unexpected error during request: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode mismatch: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unexpected error unmarshalling body: %s", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected response: got %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Description

Makes MCP server `instructions` reflect the connected group's `description`. Previously the `instructions` field existed in every protocol version's result type but was never set.

Stacked on #3576 (base `feat/groups-pr2-prompt-scoping`).