### PR TITLE
fix(server/mcp): return method-not-found errors with HTTP 200, not 404

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -650,8 +650,10 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 					render.Status(r, http.StatusUnauthorized)
 				}
 			}
-		case jsonrpc.METHOD_NOT_FOUND:
-			render.Status(r, http.StatusNotFound)
+		// METHOD_NOT_FOUND (-32601) is intentionally not mapped to an HTTP
+		// error: under MCP streamable HTTP, 404 means the session expired and
+		// requires clients to discard it and re-initialize, so protocol-level
+		// errors must ride on HTTP 200.
 		case jsonrpc.HEADER_MISMATCH, jsonrpc.UNSUPPORTED_PROTOCOL_VERSION:
 			render.Status(r, http.StatusBadRequest)
 		case jsonrpc.INVALID_PARAMS:

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -921,7 +921,7 @@ func TestMcpEndpoint(t *testing.T) {
 						Request: jsonrpc.Request{},
 					},
 					methodName:     "",
-					wantStatusCode: http.StatusNotFound,
+					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "missing-method",
@@ -943,7 +943,7 @@ func TestMcpEndpoint(t *testing.T) {
 						},
 					},
 					methodName:     "foo",
-					wantStatusCode: http.StatusNotFound,
+					wantStatusCode: http.StatusOK,
 					want: map[string]any{
 						"jsonrpc": "2.0",
 						"id":      "invalid-method",


### PR DESCRIPTION
Fixes #3588

## Problem

Toolbox maps JSON-RPC `-32601` (method not found) to HTTP 404. Under the MCP streamable HTTP transport, 404 has a reserved meaning unrelated to method errors ([Transports § Session Management](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management)):

> 3. The server **MAY** terminate the session at any time, after which it **MUST** respond to requests containing that session ID with HTTP 404 Not Found.
> 4. When a client receives HTTP 404 in response to a request containing an `Mcp-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest` without a session ID attached.

So any spec-compliant client that probes an optional method (e.g. `resources/list`, which Toolbox doesn't implement) has its session killed and re-initializes — a permanent connect/reconnect loop. Details, real-world impact (Toolbox behind an MCP multiplexing gateway with claude.ai as the client), and repro in #3588.

## Change

- `internal/server/mcp.go`: drop the `METHOD_NOT_FOUND → http.StatusNotFound` mapping so the `-32601` error is returned in the JSON-RPC `error` member on HTTP 200 — consistent with how other request-level errors (e.g. invalid toolset, `-32600`) are already returned. A comment marks the omission as intentional so the mapping doesn't get reintroduced.
- `internal/server/mcp_test.go`: the two existing cases covering this path (`missing method`, `invalid method`) now expect `http.StatusOK`; their JSON-RPC error body assertions are unchanged.

`go test ./internal/server/...`, `go vet`, and `gofmt` are clean.

> [!NOTE]
> This fix was investigated and drafted by an AI assistant (Claude Code) working from a real production incident, and reviewed by a human before submission.