### PR TITLE
fix(looker, tool/run-dashboard): add support for SQL Runner query tiles

### DIFF
--- a/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
+++ b/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
@@ -180,6 +180,34 @@ func tileQueryWorker(ctx context.Context, sdk *v4.LookerSDK, options *rtl.ApiSet
 			data["body_text"] = *element.BodyText
 		}
 
+		// Check for SQL query
+		var sqlQueryId string
+		if element.ResultMaker != nil && element.ResultMaker.SqlQueryId != nil && *element.ResultMaker.SqlQueryId != "" {
+			sqlQueryId = *element.ResultMaker.SqlQueryId
+		}
+
+		if sqlQueryId != "" {
+			data["element_type"] = "sql_query"
+			queryResult, err := sdk.RunSqlQuery(sqlQueryId, "json", "", options)
+			if err != nil {
+				data["query_status"] = fmt.Sprintf("error running SQL query %s: %s", sqlQueryId, err)
+				out <- data
+				return
+			}
+
+			var resp []any
+			if err := json.Unmarshal([]byte(queryResult), &resp); err != nil {
+				data["query_status"] = fmt.Sprintf("error unmarshaling SQL query %s result: %s", sqlQueryId, err)
+				out <- data
+				return
+			}
+
+			data["query_status"] = "success"
+			data["query_result"] = resp
+			out <- data
+			return
+		}
+
 		var q v4.Query
 		if element.Query != nil {
 			data["element_type"] = "query"

--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -153,6 +153,11 @@ func TestLooker(t *testing.T) {
 				"source":      "my-instance",
 				"description": "Simple tool to test end to end functionality.",
 			},
+			"run_dashboard": map[string]any{
+				"type":        "looker-run-dashboard",
+				"source":      "my-instance",
+				"description": "Simple tool to test end to end functionality.",
+			},
 			"make_dashboard": map[string]any{
 				"type":        "looker-make-dashboard",
 				"source":      "my-instance",
@@ -1171,6 +1176,23 @@ func TestLooker(t *testing.T) {
 			},
 		},
 	)
+	tests.RunToolGetTestByName(t, "run_dashboard",
+		map[string]any{
+			"run_dashboard": map[string]any{
+				"description":  "Simple tool to test end to end functionality.",
+				"authRequired": []any{},
+				"parameters": []any{
+					map[string]any{
+						"authServices": []any{},
+						"description":  "The id of the dashboard to run.",
+						"name":         "dashboard_id",
+						"required":     true,
+						"type":         "string",
+					},
+				},
+			},
+		},
+	)
 	tests.RunToolGetTestByName(t, "make_dashboard",
 		map[string]any{
 			"make_dashboard": map[string]any{
@@ -2146,6 +2168,8 @@ func TestLooker(t *testing.T) {
 	defer deleteDashboard()
 	testAddDashboardFilter(t, dashboardId)
 	testAddDashboardElement(t, dashboardId)
+	testAddDashboardSqlElement(t, dashboardId)
+	testRunDashboard(t, dashboardId)
 
 	wantResult = "\"Connection\":\"thelook\""
 	tests.RunToolInvokeParametersTest(t, "health_pulse", []byte(`{"action": "check_db_connections"}`), wantResult)
@@ -2326,6 +2350,77 @@ func testAddDashboardElement(t *testing.T, dashboardId string) {
 	})
 }
 
+func testAddDashboardSqlElement(t *testing.T, dashboardId string) {
+	t.Run("TestAddDashboardSqlElement", func(t *testing.T) {
+		sdk := newLookerTestSDK(t)
+
+		connections, err := sdk.AllConnections("name", nil)
+		if err != nil || len(connections) == 0 {
+			t.Fatalf("Failed to retrieve connections: %v", err)
+		}
+		connName := *connections[0].Name
+
+		// Create a SQL query
+		sqlQuery, err := sdk.CreateSqlQuery(v4.SqlQueryCreate{
+			ConnectionName: stringPtr(connName),
+			Sql:            stringPtr("SELECT 100 AS test_number"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("Failed to create SQL query: %v", err)
+		}
+
+		// Create dashboard element with SQL query
+		reqBody := v4.WriteDashboardElement{
+			DashboardId:   stringPtr(dashboardId),
+			Type:          stringPtr("vis"),
+			ResultMakerId: sqlQuery.ResultMakerId,
+			Title:         stringPtr("SQL Runner - Nil Query"),
+		}
+
+		_, err = sdk.CreateDashboardElement(v4.RequestCreateDashboardElement{
+			Body: reqBody,
+		}, nil)
+		if err != nil {
+			t.Fatalf("Failed to create SQL dashboard element: %v", err)
+		}
+		t.Log("Successfully added SQL query element to dashboard")
+	})
+}
+
+func testRunDashboard(t *testing.T, dashboardId string) {
+	t.Run("TestRunDashboardSqlRunnerVerification", func(t *testing.T) {
+		reqBody := []byte(fmt.Sprintf(`{"dashboard_id": "%s"}`, dashboardId))
+		url := "http://127.0.0.1:5000/api/tool/run_dashboard/invoke"
+		resp, bodyBytes := tests.RunRequest(t, http.MethodPost, url, bytes.NewBuffer(reqBody), nil)
+		if resp.StatusCode != 200 {
+			t.Fatalf("unexpected status code: got %d, want %d. Body: %s", resp.StatusCode, 200, string(bodyBytes))
+		}
+
+		var respBody map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &respBody); err != nil {
+			t.Fatalf("error parsing response body: %v", err)
+		}
+
+		gotResult, ok := respBody["result"].(string)
+		if !ok {
+			t.Fatalf("unable to find result in response body")
+		}
+
+		expectedSubstrings := []string{
+			"TestDashboardElement",
+			"SQL Runner - Nil Query",
+			`"element_type":"sql_query"`,
+			`"query_status":"success"`,
+			"test_number",
+		}
+		for _, substr := range expectedSubstrings {
+			if !strings.Contains(gotResult, substr) {
+				t.Errorf("expected result to contain %q, but got:\n%s", substr, gotResult)
+			}
+		}
+	})
+}
+
 func testMakeDashboard(t *testing.T, randstr string) (string, func()) {
 	var id string
 	t.Run("TestMakeDashboard", func(t *testing.T) {
@@ -2362,4 +2457,8 @@ func testMakeDashboard(t *testing.T, randstr string) (string, func()) {
 		}
 		t.Logf("deleted Dashboard %s", id)
 	}
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
## Description
Resolves an issue where SQL Runner query tiles (which reference SqlQueryId in ResultMaker instead of defining a LookML Query at the root of the dashboard element) were falsely classified as text tiles and skipped during execution. This fix checks if SqlQueryId is present in ResultMaker and executes the query using RunSqlQuery.

🛠️ Fixes #3592
