### PR TITLE
feat: implement read-only mode for MVP databases and tool suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,16 @@ name: search-hotels-by-name
 type: postgres-sql
 source: my-pg-source
 description: Search for hotels based on name.
+annotations:
+  readOnlyHint: true
 parameters:
   - name: name
     type: string
     description: The name of the hotel.
 statement: SELECT * FROM hotels WHERE name ILIKE '%' || $1 || '%';
 ```
+
+> **Note on Read-Only Mode:** You can add an `annotations: { readOnlyHint: <bool> }` block to your custom tools. If your source is configured in read-only mode, tools explicitly marked as `readOnlyHint: false` will be automatically suppressed to save the agent's context window. If omitted, the tool remains available but emits a startup warning.
 
 For more details on configuring different types of tools, see the
 [Tools](https://mcp-toolbox.dev/documentation/configuration/tools/).

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ parameters:
 statement: SELECT * FROM hotels WHERE name ILIKE '%' || $1 || '%';
 ```
 
-> **Note on Read-Only Mode:** You can add an `annotations: { readOnlyHint: <bool> }` block to your custom tools. If your source is configured in read-only mode, tools explicitly marked as `readOnlyHint: false` will be automatically suppressed to save the agent's context window. If omitted, the tool remains available but emits a startup warning.
+> [!NOTE]
+> You can add an `annotations: { readOnlyHint: <bool> }` block to your custom tools. If your source is configured in read-only mode, tools explicitly marked as `readOnlyHint: false` will be automatically suppressed to save the agent's context window. If omitted, the tool remains available but emits a startup warning.
 
 For more details on configuring different types of tools, see the
 [Tools](https://mcp-toolbox.dev/documentation/configuration/tools/).

--- a/docs/ALLOYDBPG_README.md
+++ b/docs/ALLOYDBPG_README.md
@@ -81,6 +81,7 @@ export ALLOYDB_POSTGRES_DATABASE="<your-database-name>"
 export ALLOYDB_POSTGRES_USER="<your-database-user>"  # Optional
 export ALLOYDB_POSTGRES_PASSWORD="<your-database-password>"  # Optional
 export ALLOYDB_POSTGRES_IP_TYPE="PUBLIC"  # Optional: `PUBLIC`, `PRIVATE`, `PSC`. Defaults to `PUBLIC`.
+export ALLOYDB_READONLY="true" # Optional: Restricts tools and executes queries on read-only endpoints.
 ```
 
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):

--- a/docs/CLOUDSQLMYSQL_README.md
+++ b/docs/CLOUDSQLMYSQL_README.md
@@ -77,6 +77,7 @@ export CLOUD_SQL_MYSQL_DATABASE="<your-database-name>"
 export CLOUD_SQL_MYSQL_USER="<your-database-user>"  # Optional
 export CLOUD_SQL_MYSQL_PASSWORD="<your-database-password>"  # Optional
 export CLOUD_SQL_MYSQL_IP_TYPE="PUBLIC"  # Optional: `PUBLIC`, `PRIVATE`, `PSC`. Defaults to `PUBLIC`.
+export CLOUDSQL_MYSQL_READONLY="true" # Optional: Restricts tools and executes queries on read-only endpoints.
 ```
 
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):

--- a/docs/CLOUDSQLPG_README.md
+++ b/docs/CLOUDSQLPG_README.md
@@ -94,6 +94,7 @@ export CLOUD_SQL_POSTGRES_DATABASE="<your-database-name>"
 export CLOUD_SQL_POSTGRES_USER="<your-database-user>"  # Optional
 export CLOUD_SQL_POSTGRES_PASSWORD="<your-database-password>"  # Optional
 export CLOUD_SQL_POSTGRES_IP_TYPE="PUBLIC"  # Optional: `PUBLIC`, `PRIVATE`, `PSC`. Defaults to `PUBLIC`.
+export CLOUDSQL_PG_READONLY="true" # Optional: Restricts tools and executes queries on read-only endpoints.
 ```
 
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):

--- a/docs/SPANNER_README.md
+++ b/docs/SPANNER_README.md
@@ -67,6 +67,7 @@ export SPANNER_PROJECT="<your-gcp-project-id>"
 export SPANNER_INSTANCE="<your-spanner-instance-id>"
 export SPANNER_DATABASE="<your-spanner-database-id>"
 export SPANNER_DIALECT="googlesql" # Optional: "googlesql" or "postgresql". Defaults to "googlesql".
+export SPANNER_READONLY="true" # Optional: Restricts tools and executes queries on read-only endpoints.
 ```
 
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.52.0
 )
 
@@ -283,7 +284,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
@@ -23,6 +23,7 @@ database: ${ALLOYDB_POSTGRES_DATABASE}
 user: ${ALLOYDB_POSTGRES_USER:}
 password: ${ALLOYDB_POSTGRES_PASSWORD:}
 ipType: ${ALLOYDB_POSTGRES_IP_TYPE:public}
+readonly: ${ALLOYDB_READONLY:false}
 ---
 kind: source
 name: cloud-monitoring-source
@@ -38,6 +39,16 @@ name: execute_sql
 type: postgres-execute-sql
 source: alloydb-pg-source
 description: Use this tool to execute a single SQL statement.
+annotations:
+  readOnlyHint: false
+---
+kind: tool
+name: execute_sql_readonly
+type: postgres-execute-sql
+source: alloydb-pg-source
+description: Use this tool to execute a single read-only SQL statement.
+annotations:
+  readOnlyHint: true
 ---
 kind: tool
 name: list_tables

--- a/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
@@ -22,6 +22,7 @@ database: ${CLOUD_SQL_MYSQL_DATABASE}
 user: ${CLOUD_SQL_MYSQL_USER:}
 password: ${CLOUD_SQL_MYSQL_PASSWORD:}
 ipType: ${CLOUD_SQL_MYSQL_IP_TYPE:PUBLIC}
+readonly: ${CLOUDSQL_MYSQL_READONLY:false}
 ---
 kind: source
 name: cloud-sql-admin-source
@@ -37,6 +38,16 @@ name: execute_sql
 type: mysql-execute-sql
 source: cloud-sql-mysql-source
 description: Use this tool to execute SQL.
+annotations:
+  readOnlyHint: false
+---
+kind: tool
+name: execute_sql_readonly
+type: mysql-execute-sql
+source: cloud-sql-mysql-source
+description: Use this tool to execute a single read-only SQL statement.
+annotations:
+  readOnlyHint: true
 ---
 kind: tool
 name: list_active_queries

--- a/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
@@ -22,6 +22,7 @@ database: ${CLOUD_SQL_POSTGRES_DATABASE}
 user: ${CLOUD_SQL_POSTGRES_USER:}
 password: ${CLOUD_SQL_POSTGRES_PASSWORD:}
 ipType: ${CLOUD_SQL_POSTGRES_IP_TYPE:public}
+readonly: ${CLOUDSQL_PG_READONLY:false}
 ---
 kind: source
 name: cloud-sql-admin-source
@@ -37,6 +38,16 @@ name: execute_sql
 type: postgres-execute-sql
 source: cloudsql-pg-source
 description: Use this tool to execute a single SQL statement.
+annotations:
+  readOnlyHint: false
+---
+kind: tool
+name: execute_sql_readonly
+type: postgres-execute-sql
+source: cloudsql-pg-source
+description: Use this tool to execute a single read-only SQL statement.
+annotations:
+  readOnlyHint: true
 ---
 kind: tool
 name: list_tables

--- a/internal/prebuiltconfigs/tools/spanner.yaml
+++ b/internal/prebuiltconfigs/tools/spanner.yaml
@@ -19,12 +19,15 @@ project: ${SPANNER_PROJECT}
 instance: ${SPANNER_INSTANCE}
 database: ${SPANNER_DATABASE}
 dialect: ${SPANNER_DIALECT:googlesql}
+readonly: ${SPANNER_READONLY:false}
 ---
 kind: tool
 name: execute_sql
 type: spanner-execute-sql
 source: spanner-source
 description: Use this tool to execute DML SQL. Please use the ${SPANNER_DIALECT:googlesql} interface for Spanner.
+annotations:
+  readOnlyHint: false
 ---
 kind: tool
 name: execute_sql_dql
@@ -32,6 +35,8 @@ type: spanner-execute-sql
 source: spanner-source
 description: Use this tool to execute DQL SQL. Please use the ${SPANNER_DIALECT:googlesql} interface for Spanner.
 readOnly: true
+annotations:
+  readOnlyHint: true
 ---
 kind: tool
 name: list_tables

--- a/internal/server/readonly_tools_test.go
+++ b/internal/server/readonly_tools_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/googleapis/mcp-toolbox/internal/log"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -46,9 +47,11 @@ func (m *mockSource) ToConfig() sources.SourceConfig {
 	return nil
 }
 
+var _ sources.ReadOnlySource = (*mockSource)(nil)
+
 type mockToolConfig struct {
 	tools.ConfigBase
-	source string
+	Source string
 }
 
 func (m *mockToolConfig) ToolConfigType() string {
@@ -63,13 +66,13 @@ func (m *mockToolConfig) Initialize(ctx context.Context) (tools.Tool, error) {
 	}
 	return &mockTool{
 		BaseTool: tools.NewBaseTool(m.ConfigBase, annotations, tools.Manifest{}, nil),
-		source:   m.source,
+		Source:   m.Source,
 	}, nil
 }
 
 type mockTool struct {
 	tools.BaseTool[tools.ConfigBase]
-	source string
+	Source string
 }
 
 func (m *mockTool) Invoke(ctx context.Context, sp tools.SourceProvider, pv parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
@@ -91,15 +94,15 @@ func TestInitializeTools_ReadOnlySuppression(t *testing.T) {
 		ToolConfigs: map[string]tools.ToolConfig{
 			"write-tool": &mockToolConfig{
 				ConfigBase: tools.ConfigBase{Name: "write-tool"},
-				source:     "mock-db",
+				Source:     "mock-db",
 			},
 			"readonly-tool": &mockToolConfig{
 				ConfigBase: tools.ConfigBase{Name: "readonly-tool"},
-				source:     "mock-db",
+				Source:     "mock-db",
 			},
 			"unannotated-tool": &mockToolConfig{
 				ConfigBase: tools.ConfigBase{Name: "unannotated-tool"},
-				source:     "mock-db",
+				Source:     "mock-db",
 			},
 		},
 	}
@@ -139,14 +142,15 @@ func TestInitializeTools_WriteModeNoSuppression(t *testing.T) {
 		ToolConfigs: map[string]tools.ToolConfig{
 			"write-tool": &mockToolConfig{
 				ConfigBase: tools.ConfigBase{Name: "write-tool"},
-				source:     "mock-db",
+				Source:     "mock-db",
 			},
 		},
 	}
 
 	testLogger, _ := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	instr, _ := telemetry.CreateTelemetryInstrumentation("test")
 
-	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, telemetry.NewNoopInstrumentation(), testLogger)
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, instr, testLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/server/readonly_tools_test.go
+++ b/internal/server/readonly_tools_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 
 	"github.com/googleapis/mcp-toolbox/internal/log"
-	"github.com/googleapis/mcp-toolbox/internal/parameters"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
 type mockSource struct {
@@ -56,10 +56,7 @@ func (m *mockToolConfig) ToolConfigType() string {
 }
 
 func (m *mockToolConfig) Initialize(ctx context.Context) (tools.Tool, error) {
-	readOnlyHint := false
-	if m.Name == "readonly-tool" {
-		readOnlyHint = true
-	}
+	readOnlyHint := m.Name == "readonly-tool"
 	var annotations *tools.ToolAnnotations
 	if m.Name != "unannotated-tool" {
 		annotations = &tools.ToolAnnotations{ReadOnlyHint: &readOnlyHint}

--- a/internal/server/readonly_tools_test.go
+++ b/internal/server/readonly_tools_test.go
@@ -16,34 +16,39 @@ package server
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/parameters"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
-	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
 )
 
 type mockSource struct {
 	readOnly bool
 }
 
-func (m *mockSource) SourceType() string {
-	return "mock-source"
+func (m *mockSource) Initialize(ctx context.Context) error {
+	return nil
 }
-
+func (m *mockSource) Cleanup() error {
+	return nil
+}
+func (m *mockSource) IsReadOnlyMode() bool {
+	return m.readOnly
+}
+func (m *mockSource) SourceType() string {
+	return "mock-db"
+}
 func (m *mockSource) ToConfig() sources.SourceConfig {
 	return nil
 }
 
-func (m *mockSource) IsReadOnlyMode() bool {
-	return m.readOnly
-}
-
 type mockToolConfig struct {
+	tools.ConfigBase
 	source string
-	Source string
-	name   string
 }
 
 func (m *mockToolConfig) ToolConfigType() string {
@@ -51,53 +56,35 @@ func (m *mockToolConfig) ToolConfigType() string {
 }
 
 func (m *mockToolConfig) Initialize(ctx context.Context) (tools.Tool, error) {
+	readOnlyHint := false
+	if m.Name == "readonly-tool" {
+		readOnlyHint = true
+	}
+	var annotations *tools.ToolAnnotations
+	if m.Name != "unannotated-tool" {
+		annotations = &tools.ToolAnnotations{ReadOnlyHint: &readOnlyHint}
+	}
 	return &mockTool{
-		source: m.source,
-		name:   m.name,
+		BaseTool: tools.NewBaseTool(m.ConfigBase, annotations, tools.Manifest{}, nil),
+		source:   m.source,
 	}, nil
 }
 
 type mockTool struct {
+	tools.BaseTool[tools.ConfigBase]
 	source string
-	name   string
 }
 
-func (m *mockTool) Name() string {
-	return m.name
-}
-
-func (m *mockTool) Description() string {
-	return "mock tool"
-}
-
-func (m *mockTool) Execute(ctx context.Context, params map[string]any) (*tools.ToolResponse, error) {
+func (m *mockTool) Invoke(ctx context.Context, sp tools.SourceProvider, pv parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
 	return nil, nil
 }
 
-func (m *mockTool) InputSchema() map[string]any {
+func (m *mockTool) ToConfig() tools.ToolConfig {
 	return nil
-}
-
-func (m *mockTool) GetLinkedSource() sources.Source {
-	return nil
-}
-
-func (m *mockTool) GetAnnotations() *tools.Annotations {
-	if m.name == "unannotated-tool" {
-		return nil
-	}
-	readOnlyHint := false
-	if m.name == "readonly-tool" {
-		readOnlyHint = true
-	}
-	return &tools.Annotations{
-		ReadOnlyHint: &readOnlyHint,
-	}
 }
 
 func TestInitializeTools_ReadOnlySuppression(t *testing.T) {
 	ctx := context.Background()
-	tracer := telemetry.NewNoopInstrumentation()
 
 	sourcesMap := map[string]sources.Source{
 		"mock-db": &mockSource{readOnly: true},
@@ -106,37 +93,68 @@ func TestInitializeTools_ReadOnlySuppression(t *testing.T) {
 	cfg := ServerConfig{
 		ToolConfigs: map[string]tools.ToolConfig{
 			"write-tool": &mockToolConfig{
-				source: "mock-db",
-				Source: "mock-db",
-				name:   "write-tool",
+				ConfigBase: tools.ConfigBase{Name: "write-tool"},
+				source:     "mock-db",
 			},
 			"readonly-tool": &mockToolConfig{
-				source: "mock-db",
-				Source: "mock-db",
-				name:   "readonly-tool",
+				ConfigBase: tools.ConfigBase{Name: "readonly-tool"},
+				source:     "mock-db",
 			},
 			"unannotated-tool": &mockToolConfig{
-				source: "mock-db",
-				Source: "mock-db",
-				name:   "unannotated-tool",
+				ConfigBase: tools.ConfigBase{Name: "unannotated-tool"},
+				source:     "mock-db",
 			},
 		},
 	}
 
-	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, tracer, log.NewLogger(true))
+	testLogger, _ := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, nil, testLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, ok := toolsMap["write-tool"]; ok {
-		t.Errorf("expected write-tool to be suppressed")
-	}
-
+	// 1. readonly-tool should be present
 	if _, ok := toolsMap["readonly-tool"]; !ok {
-		t.Errorf("expected readonly-tool to be present")
+		t.Errorf("readonly-tool should NOT be suppressed")
 	}
 
+	// 2. write-tool should be suppressed
+	if _, ok := toolsMap["write-tool"]; ok {
+		t.Errorf("write-tool should be suppressed")
+	}
+
+	// 3. unannotated-tool should NOT be suppressed (graceful fallback)
 	if _, ok := toolsMap["unannotated-tool"]; !ok {
-		t.Errorf("expected unannotated-tool to be present (but emit a warning)")
+		t.Errorf("unannotated-tool should NOT be suppressed")
+	}
+}
+
+func TestInitializeTools_WriteModeNoSuppression(t *testing.T) {
+	ctx := context.Background()
+
+	sourcesMap := map[string]sources.Source{
+		"mock-db": &mockSource{readOnly: false}, // Write mode!
+	}
+
+	cfg := ServerConfig{
+		ToolConfigs: map[string]tools.ToolConfig{
+			"write-tool": &mockToolConfig{
+				ConfigBase: tools.ConfigBase{Name: "write-tool"},
+				source:     "mock-db",
+			},
+		},
+	}
+
+	testLogger, _ := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, nil, testLogger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// write-tool should be present because the source is NOT read-only
+	if _, ok := toolsMap["write-tool"]; !ok {
+		t.Errorf("write-tool should NOT be suppressed in write mode")
 	}
 }

--- a/internal/server/readonly_tools_test.go
+++ b/internal/server/readonly_tools_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/telemetry"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+)
+
+type mockSource struct {
+	readOnly bool
+}
+
+func (m *mockSource) SourceType() string {
+	return "mock-source"
+}
+
+func (m *mockSource) ToConfig() sources.SourceConfig {
+	return nil
+}
+
+func (m *mockSource) IsReadOnlyMode() bool {
+	return m.readOnly
+}
+
+type mockToolConfig struct {
+	source string
+	Source string
+	name   string
+}
+
+func (m *mockToolConfig) ToolConfigType() string {
+	return "mock-tool"
+}
+
+func (m *mockToolConfig) Initialize(ctx context.Context) (tools.Tool, error) {
+	return &mockTool{
+		source: m.source,
+		name:   m.name,
+	}, nil
+}
+
+type mockTool struct {
+	source string
+	name   string
+}
+
+func (m *mockTool) Name() string {
+	return m.name
+}
+
+func (m *mockTool) Description() string {
+	return "mock tool"
+}
+
+func (m *mockTool) Execute(ctx context.Context, params map[string]any) (*tools.ToolResponse, error) {
+	return nil, nil
+}
+
+func (m *mockTool) InputSchema() map[string]any {
+	return nil
+}
+
+func (m *mockTool) GetLinkedSource() sources.Source {
+	return nil
+}
+
+func (m *mockTool) GetAnnotations() *tools.Annotations {
+	if m.name == "unannotated-tool" {
+		return nil
+	}
+	readOnlyHint := false
+	if m.name == "readonly-tool" {
+		readOnlyHint = true
+	}
+	return &tools.Annotations{
+		ReadOnlyHint: &readOnlyHint,
+	}
+}
+
+func TestInitializeTools_ReadOnlySuppression(t *testing.T) {
+	ctx := context.Background()
+	tracer := telemetry.NewNoopInstrumentation()
+
+	sourcesMap := map[string]sources.Source{
+		"mock-db": &mockSource{readOnly: true},
+	}
+
+	cfg := ServerConfig{
+		ToolConfigs: map[string]tools.ToolConfig{
+			"write-tool": &mockToolConfig{
+				source: "mock-db",
+				Source: "mock-db",
+				name:   "write-tool",
+			},
+			"readonly-tool": &mockToolConfig{
+				source: "mock-db",
+				Source: "mock-db",
+				name:   "readonly-tool",
+			},
+			"unannotated-tool": &mockToolConfig{
+				source: "mock-db",
+				Source: "mock-db",
+				name:   "unannotated-tool",
+			},
+		},
+	}
+
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, tracer, log.NewLogger(true))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := toolsMap["write-tool"]; ok {
+		t.Errorf("expected write-tool to be suppressed")
+	}
+
+	if _, ok := toolsMap["readonly-tool"]; !ok {
+		t.Errorf("expected readonly-tool to be present")
+	}
+
+	if _, ok := toolsMap["unannotated-tool"]; !ok {
+		t.Errorf("expected unannotated-tool to be present (but emit a warning)")
+	}
+}

--- a/internal/server/readonly_tools_test.go
+++ b/internal/server/readonly_tools_test.go
@@ -105,8 +105,9 @@ func TestInitializeTools_ReadOnlySuppression(t *testing.T) {
 	}
 
 	testLogger, _ := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	instr, _ := telemetry.CreateTelemetryInstrumentation("test")
 
-	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, nil, testLogger)
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, instr, testLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestInitializeTools_WriteModeNoSuppression(t *testing.T) {
 
 	testLogger, _ := log.NewStdLogger(os.Stdout, os.Stderr, "info")
 
-	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, nil, testLogger)
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, telemetry.NewNoopInstrumentation(), testLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -183,7 +184,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	}
 	l.InfoContext(ctx, fmt.Sprintf("Initialized %d embeddingModels: %s", len(embeddingModelsMap), strings.Join(embeddingModelNames, ", ")))
 
-	toolsMap, err := initializeTools(ctx, cfg, instrumentation, l)
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, instrumentation, l)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
@@ -283,7 +284,7 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 		return nil, nil, fmt.Errorf("failed to get logger from context: %w", err)
 	}
 
-	toolsMap, err := initializeTools(ctx, cfg, instrumentation, l)
+	toolsMap, err := initializeTools(ctx, cfg, nil, instrumentation, l)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -297,7 +298,7 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 }
 
 // initializeTools initializes and validates the tools from the config.
-func initializeTools(ctx context.Context, cfg ServerConfig, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]tools.Tool, error) {
+func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[string]sources.Source, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]tools.Tool, error) {
 	toolsMap := make(map[string]tools.Tool)
 	for name, tc := range cfg.ToolConfigs {
 		t, err := func() (tools.Tool, error) {
@@ -316,6 +317,33 @@ func initializeTools(ctx context.Context, cfg ServerConfig, instrumentation *tel
 		}()
 		if err != nil {
 			return nil, err
+		}
+
+		if sourcesMap != nil {
+			v := reflect.ValueOf(tc)
+			if v.Kind() == reflect.Ptr {
+				v = v.Elem()
+			}
+			if v.Kind() == reflect.Struct {
+				sourceField := v.FieldByName("Source")
+				if sourceField.IsValid() && sourceField.Kind() == reflect.String {
+					sourceName := sourceField.String()
+					if sourceName != "" {
+						if src, ok := sourcesMap[sourceName]; ok {
+							if rs, ok := src.(sources.ReadOnlySource); ok && rs.IsReadOnlyMode() {
+								if t.GetAnnotations() != nil && t.GetAnnotations().ReadOnlyHint != nil {
+									if !*t.GetAnnotations().ReadOnlyHint {
+										l.InfoContext(ctx, fmt.Sprintf("Suppressing write-capable tool %q bound to read-only source %q", name, sourceName))
+										continue
+									}
+								} else {
+									l.WarnContext(ctx, fmt.Sprintf("Tool %q bound to read-only source %q lacks ReadOnlyHint annotation; executing this tool may fail if it attempts write operations. If this tool is meant to be read-only, please add 'readOnlyHint: true' to its annotations. Otherwise, add 'readOnlyHint: false' to suppress it in read-only mode and save agent context window.", name, sourceName))
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 		toolsMap[name] = t
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -321,7 +321,7 @@ func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[strin
 
 		if sourcesMap != nil {
 			v := reflect.ValueOf(tc)
-			if v.Kind() == reflect.Ptr {
+			if v.Kind() == reflect.Pointer {
 				v = v.Elem()
 			}
 			if v.Kind() == reflect.Struct {

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -61,6 +61,7 @@ type Config struct {
 	Password     string         `yaml:"password"`
 	Database     string         `yaml:"database" validate:"required"`
 	SQLCommenter *bool          `yaml:"sqlCommenter"`
+	ReadOnly     bool           `yaml:"readonly"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -68,7 +69,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.ReadOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -98,6 +99,10 @@ func (s *Source) SourceType() string {
 
 func (s *Source) ToConfig() sources.SourceConfig {
 	return s.Config
+}
+
+func (s *Source) IsReadOnlyMode() bool {
+	return s.ReadOnly
 }
 
 func (s *Source) PostgresPool() *pgxpool.Pool {
@@ -151,7 +156,7 @@ func getOpts(ipType, userAgent string, useIAM bool) ([]alloydbconn.Option, error
 	return opts, nil
 }
 
-func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string, bool, error) {
+func getConnectionConfig(ctx context.Context, user, pass, dbname string, readOnly bool) (string, bool, error) {
 	userAgent, err := util.UserAgentFromContext(ctx)
 	if err != nil {
 		userAgent = "genai-toolbox"
@@ -161,6 +166,9 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 	// If username and password both provided, use password authentication
 	if user != "" && pass != "" {
 		dsn := fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable application_name=%s", user, pass, dbname, userAgent)
+		if readOnly {
+			dsn += " options='-c alloydb_session_read_only=locked'"
+		}
 		useIAM = false
 		return dsn, useIAM, nil
 	}
@@ -181,15 +189,18 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 
 	// Construct IAM connection string with username
 	dsn := fmt.Sprintf("user=%s dbname=%s sslmode=disable application_name=%s", user, dbname, userAgent)
+	if readOnly {
+		dsn += " options='-c alloydb_session_read_only=locked'"
+	}
 	return dsn, useIAM, nil
 }
 
-func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ipType, user, pass, dbname string, readOnly bool) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
 
-	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname)
+	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname, readOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get AlloyDB connection config: %w", err)
 	}

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -266,7 +266,7 @@ func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, n
 	}
 
 	if readOnly {
-		dsn += "&cloudsql_session_read_only=locked"
+		dsn += "&session_variables=cloudsql_session_read_only=locked"
 	}
 
 	db, err := sql.Open(

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -61,6 +61,7 @@ type Config struct {
 	Password     string         `yaml:"password"`
 	Database     string         `yaml:"database"`
 	SQLCommenter *bool          `yaml:"sqlCommenter"`
+	ReadOnly     bool           `yaml:"readonly"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -68,7 +69,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initCloudSQLMySQLConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initCloudSQLMySQLConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.ReadOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -98,6 +99,10 @@ func (s *Source) SourceType() string {
 
 func (s *Source) ToConfig() sources.SourceConfig {
 	return s.Config
+}
+
+func (s *Source) IsReadOnlyMode() bool {
+	return s.ReadOnly
 }
 
 func (s *Source) MySQLPool() *sql.DB {
@@ -205,7 +210,7 @@ func getConnectionConfig(ctx context.Context, user, pass string) (string, string
 	return user, pass, useIAM, nil
 }
 
-func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string) (*sql.DB, error) {
+func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string, readOnly bool) (*sql.DB, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
@@ -258,6 +263,10 @@ func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, n
 			dbname,
 			url.QueryEscape(userAgent),
 		)
+	}
+
+	if readOnly {
+		dsn += "&cloudsql_session_read_only=locked"
 	}
 
 	db, err := sql.Open(

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -59,7 +59,7 @@ type Config struct {
 	User         string         `yaml:"user"`
 	Password     string         `yaml:"password"`
 	SQLCommenter *bool          `yaml:"sqlCommenter"`
-	ReadOnly       bool           `yaml:"readonly"`
+	ReadOnly     bool           `yaml:"readonly"`
 }
 
 func (r Config) SourceConfigType() string {

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -59,6 +59,7 @@ type Config struct {
 	User         string         `yaml:"user"`
 	Password     string         `yaml:"password"`
 	SQLCommenter *bool          `yaml:"sqlCommenter"`
+	ReadOnly       bool           `yaml:"readonly"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -66,7 +67,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.ReadOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -106,6 +107,10 @@ func (s *Source) ToConfig() sources.SourceConfig {
 	return s.Config
 }
 
+func (s *Source) IsReadOnlyMode() bool {
+	return s.ReadOnly
+}
+
 func (s *Source) PostgresPool() *pgxpool.Pool {
 	return s.Pool
 }
@@ -138,7 +143,7 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any) (an
 	return out, nil
 }
 
-func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string, bool, error) {
+func getConnectionConfig(ctx context.Context, user, pass, dbname string, readOnly bool) (string, bool, error) {
 	userAgent, err := util.UserAgentFromContext(ctx)
 	if err != nil {
 		userAgent = "genai-toolbox"
@@ -148,6 +153,9 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 	// If username and password both provided, use password authentication
 	if user != "" && pass != "" {
 		dsn := fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable application_name=%s", user, pass, dbname, userAgent)
+		if readOnly {
+			dsn += " options='-c cloudsql_session_read_only=locked'"
+		}
 		useIAM = false
 		return dsn, useIAM, nil
 	}
@@ -168,16 +176,19 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 
 	// Construct IAM connection string with username
 	dsn := fmt.Sprintf("user=%s dbname=%s sslmode=disable application_name=%s", user, dbname, userAgent)
+	if readOnly {
+		dsn += " options='-c cloudsql_session_read_only=locked'"
+	}
 	return dsn, useIAM, nil
 }
 
-func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string, readOnly bool) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
 
 	// Configure the driver to connect to the database
-	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname)
+	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname, readOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get Cloud SQL connection config: %w", err)
 	}

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -68,6 +68,12 @@ type Source interface {
 	ToConfig() SourceConfig
 }
 
+// ReadOnlySource is the interface for a source that supports read-only mode.
+type ReadOnlySource interface {
+	Source
+	IsReadOnlyMode() bool
+}
+
 // InitConnectionSpan adds a span for database pool connection initialization
 func InitConnectionSpan(ctx context.Context, tracer trace.Tracer, sourceType, sourceName string) (context.Context, trace.Span) {
 	ctx, span := tracer.Start(

--- a/internal/sources/spanner/spanner.go
+++ b/internal/sources/spanner/spanner.go
@@ -57,6 +57,7 @@ type Config struct {
 	Dialect        sources.Dialect `yaml:"dialect" validate:"required"`
 	Database       string          `yaml:"database" validate:"required"`
 	UseClientOAuth bool            `yaml:"useClientOAuth"`
+	ReadOnly       bool            `yaml:"readonly"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -100,6 +101,10 @@ func (s *Source) SourceType() string {
 
 func (s *Source) ToConfig() sources.SourceConfig {
 	return s.Config
+}
+
+func (s *Source) IsReadOnlyMode() bool {
+	return s.ReadOnly
 }
 
 func (s *Source) SpannerClient() *spanner.Client {
@@ -174,7 +179,7 @@ func (s *Source) RunSQL(ctx context.Context, readOnly bool, statement string, pa
 		stmt.Params = params
 	}
 
-	if readOnly {
+	if readOnly || s.ReadOnly {
 		iter := s.SpannerClient().Single().Query(ctx, stmt)
 		results, opErr = processRows(iter)
 	} else {

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
@@ -74,6 +74,7 @@ func TestParseFromYamlExecuteSql(t *testing.T) {
 					ConfigBase: tools.ConfigBase{
 						Name:        "custom_write_tool",
 						Description: "custom write query",
+						AuthRequired: []string{},
 					},
 					Type:   "postgres-execute-sql",
 					Source: "my-instance",

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
@@ -72,8 +72,8 @@ func TestParseFromYamlExecuteSql(t *testing.T) {
 			want: server.ToolConfigs{
 				"custom_write_tool": postgresexecutesql.Config{
 					ConfigBase: tools.ConfigBase{
-						Name:        "custom_write_tool",
-						Description: "custom write query",
+						Name:         "custom_write_tool",
+						Description:  "custom write query",
 						AuthRequired: []string{},
 					},
 					Type:   "postgres-execute-sql",

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
@@ -58,6 +58,31 @@ func TestParseFromYamlExecuteSql(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "with annotations",
+			in: `
+            kind: tool
+            name: custom_write_tool
+            type: postgres-execute-sql
+            source: my-instance
+            description: custom write query
+            annotations:
+              readOnlyHint: false
+			`,
+			want: server.ToolConfigs{
+				"custom_write_tool": postgresexecutesql.Config{
+					ConfigBase: tools.ConfigBase{
+						Name:        "custom_write_tool",
+						Description: "custom write query",
+					},
+					Type:   "postgres-execute-sql",
+					Source: "my-instance",
+					Annotations: &tools.ToolAnnotations{
+						ReadOnlyHint: func() *bool { b := false; return &b }(),
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
+++ b/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
@@ -68,6 +68,12 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
 	}
 
+	if cfg.Annotations != nil && cfg.Annotations.ReadOnlyHint != nil {
+		if cfg.ReadOnly != *cfg.Annotations.ReadOnlyHint {
+			return nil, fmt.Errorf("configuration conflict in tool %q: legacy readOnly=%v does not match readOnlyHint=%v", cfg.Name, cfg.ReadOnly, *cfg.Annotations.ReadOnlyHint)
+		}
+	}
+
 	sqlParameter := parameters.NewStringParameter("sql", "The sql to execute.")
 	params := parameters.Parameters{sqlParameter}
 

--- a/internal/tools/spanner/spannerexecutesql/spannerexecutesql_test.go
+++ b/internal/tools/spanner/spannerexecutesql/spannerexecutesql_test.go
@@ -15,6 +15,7 @@
 package spannerexecutesql_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -93,4 +94,92 @@ func TestParseFromYamlExecuteSql(t *testing.T) {
 		})
 	}
 
+}
+
+func TestInitialize_ReadOnlyValidation(t *testing.T) {
+	ctx := context.Background()
+
+	ptr := func(b bool) *bool { return &b }
+
+	tcs := []struct {
+		desc        string
+		cfg         spannerexecutesql.Config
+		wantErr     bool
+		errContains string
+	}{
+		{
+			desc: "no conflict - both true",
+			cfg: spannerexecutesql.Config{
+				ConfigBase:  tools.ConfigBase{Name: "test-tool", Description: "desc"},
+				ReadOnly:    true,
+				Annotations: &tools.ToolAnnotations{ReadOnlyHint: ptr(true)},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "no conflict - both false",
+			cfg: spannerexecutesql.Config{
+				ConfigBase:  tools.ConfigBase{Name: "test-tool", Description: "desc"},
+				ReadOnly:    false,
+				Annotations: &tools.ToolAnnotations{ReadOnlyHint: ptr(false)},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "no conflict - readOnlyHint nil",
+			cfg: spannerexecutesql.Config{
+				ConfigBase:  tools.ConfigBase{Name: "test-tool", Description: "desc"},
+				ReadOnly:    true,
+				Annotations: &tools.ToolAnnotations{ReadOnlyHint: nil},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "conflict - readOnly false, readOnlyHint true",
+			cfg: spannerexecutesql.Config{
+				ConfigBase:  tools.ConfigBase{Name: "test-tool", Description: "desc"},
+				ReadOnly:    false,
+				Annotations: &tools.ToolAnnotations{ReadOnlyHint: ptr(true)},
+			},
+			wantErr:     true,
+			errContains: "configuration conflict in tool \"test-tool\"",
+		},
+		{
+			desc: "conflict - readOnly true, readOnlyHint false",
+			cfg: spannerexecutesql.Config{
+				ConfigBase:  tools.ConfigBase{Name: "test-tool", Description: "desc"},
+				ReadOnly:    true,
+				Annotations: &tools.ToolAnnotations{ReadOnlyHint: ptr(false)},
+			},
+			wantErr:     true,
+			errContains: "configuration conflict in tool \"test-tool\"",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := tc.cfg.Initialize(ctx)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				// Use manual substring check since strings import might not be present
+				errStr := err.Error()
+				found := false
+				for i := 0; i <= len(errStr)-len(tc.errContains); i++ {
+					if errStr[i:i+len(tc.errContains)] == tc.errContains {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected error to contain %q, got: %v", tc.errContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
 }

--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/tests"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -346,5 +347,75 @@ func TestAlloyDBPgIAMConnection(t *testing.T) {
 				t.Fatalf("Expected error but test passed.")
 			}
 		})
+	}
+}
+
+// TestAlloyDBPg_ReadOnlyVulnerabilityBlock verifies that if a custom tool is falsely annotated
+// as readOnlyHint: true (thus bypassing server-level suppression), the database kernel will still
+// reject the write operation because of the alloydb_session_read_only=locked enforcement.
+func TestAlloyDBPg_ReadOnlyVulnerabilityBlock(t *testing.T) {
+	// Skip if not in integration environment
+	if AlloyDBPostgresProject == "" {
+		t.Skip("Skipping integration test: ALLOYDB_POSTGRES_PROJECT not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	args := []string{"--enable-api", "--port", "5002"}
+
+	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableName := "vulnerability_test_" + uniqueID
+
+	toolsFileTemplate := `
+sources:
+  my-readonly-alloydb-instance:
+    type: alloydb-postgres
+    project: %s
+    region: %s
+    cluster: %s
+    instance: %s
+    database: %s
+    user: %s
+    password: %s
+    readonly: true
+tools:
+  vulnerable_write_tool:
+    type: postgres-sql
+    source: my-readonly-alloydb-instance
+    description: I am a tool that tries to write but falsely claims to be read-only!
+    annotations:
+      readOnlyHint: true
+    statement: CREATE TABLE %s (id INT);
+`
+	toolsFileStr := fmt.Sprintf(toolsFileTemplate, AlloyDBPostgresProject, AlloyDBPostgresRegion, AlloyDBPostgresCluster, AlloyDBPostgresInstance, AlloyDBPostgresDatabase, AlloyDBPostgresUser, AlloyDBPostgresPass, tableName)
+
+	var toolsFile map[string]any
+	if err := yaml.Unmarshal([]byte(toolsFileStr), &toolsFile); err != nil {
+		t.Fatalf("failed to unmarshal yaml string: %s", err)
+	}
+
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelWait()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	// Make the API request
+	api := "http://127.0.0.1:5002/api/tool/vulnerable_write_tool/invoke"
+	requestBody := strings.NewReader(`{}`)
+	resp, respBody := tests.RunRequest(t, "POST", api, requestBody, map[string]string{})
+
+	bodyLower := strings.ToLower(string(respBody))
+	if !strings.Contains(bodyLower, "read-only") && !strings.Contains(bodyLower, "read only") {
+		t.Fatalf("Vulnerability check failed! Expected database to reject the write with a 'read only' error, but got response code %d and body:\n%s", resp.StatusCode, string(respBody))
 	}
 }

--- a/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
+++ b/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/tests"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -296,5 +297,74 @@ func TestCloudSQLMySQLIAMConnection(t *testing.T) {
 				t.Fatalf("Expected error but test passed.")
 			}
 		})
+	}
+}
+
+// TestCloudSQLMySql_ReadOnlyVulnerabilityBlock verifies that if a custom tool is falsely annotated
+// as readOnlyHint: true (thus bypassing server-level suppression), the database kernel will still
+// reject the write operation because of the cloudsql_session_read_only=locked enforcement.
+func TestCloudSQLMySql_ReadOnlyVulnerabilityBlock(t *testing.T) {
+	// Skip if not in integration environment
+	if CloudSQLMySQLProject == "" {
+		t.Skip("Skipping integration test: CLOUD_SQL_MYSQL_PROJECT not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	args := []string{"--enable-api", "--port", "5002"}
+
+	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableName := "vulnerability_test_" + uniqueID
+
+	toolsFileTemplate := `
+sources:
+  my-readonly-mysql-instance:
+    type: cloud-sql-mysql
+    project: %s
+    region: %s
+    instance: %s
+    database: %s
+    user: %s
+    password: %s
+    readonly: true
+tools:
+  vulnerable_write_tool:
+    type: mysql-sql
+    source: my-readonly-mysql-instance
+    description: I am a tool that tries to write but falsely claims to be read-only!
+    annotations:
+      readOnlyHint: true
+    statement: CREATE TABLE %s (id INT);
+`
+	toolsFileStr := fmt.Sprintf(toolsFileTemplate, CloudSQLMySQLProject, CloudSQLMySQLRegion, CloudSQLMySQLInstance, CloudSQLMySQLDatabase, CloudSQLMySQLUser, CloudSQLMySQLPass, tableName)
+
+	var toolsFile map[string]any
+	if err := yaml.Unmarshal([]byte(toolsFileStr), &toolsFile); err != nil {
+		t.Fatalf("failed to unmarshal yaml string: %s", err)
+	}
+
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelWait()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	// Make the API request
+	api := "http://127.0.0.1:5002/api/tool/vulnerable_write_tool/invoke"
+	requestBody := strings.NewReader(`{}`)
+	resp, respBody := tests.RunRequest(t, "POST", api, requestBody, map[string]string{})
+
+	bodyLower := strings.ToLower(string(respBody))
+	if !strings.Contains(bodyLower, "read-only") && !strings.Contains(bodyLower, "read only") && !strings.Contains(bodyLower, "not allowed") {
+		t.Fatalf("Vulnerability check failed! Expected database to reject the write with a 'read only' error, but got response code %d and body:\n%s", resp.StatusCode, string(respBody))
 	}
 }

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -362,7 +362,7 @@ tools:
 	resp, respBody := tests.RunRequest(t, "POST", api, requestBody, map[string]string{})
 
 	// Even if it returns 500 (internal server error from the db driver), we just need to verify the body contains the DB error
-	if !strings.Contains(string(respBody), "read-only transaction") {
-		t.Fatalf("Vulnerability check failed! Expected database to reject the write with a 'read-only transaction' error, but got response code %d and body:\n%s", resp.StatusCode, string(respBody))
+	if !strings.Contains(string(respBody), "read-only transaction") && !strings.Contains(string(respBody), "read only") {
+		t.Fatalf("Vulnerability check failed! Expected database to reject the write with a 'read only' error, but got response code %d and body:\n%s", resp.StatusCode, string(respBody))
 	}
 }

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -328,7 +328,7 @@ sources:
     readonly: true
 tools:
   vulnerable_write_tool:
-    type: postgres-execute-sql
+    type: postgres-sql
     source: my-readonly-pg-instance
     description: I am a tool that tries to write but falsely claims to be read-only!
     annotations:

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/tests"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -294,5 +295,75 @@ func TestCloudSQLPgIAMConnection(t *testing.T) {
 				t.Fatalf("Expected error but test passed.")
 			}
 		})
+	}
+}
+
+// TestCloudSQLPg_ReadOnlyVulnerabilityBlock verifies that if a custom tool is falsely annotated
+// as readOnlyHint: true (thus bypassing server-level suppression), the database kernel will still
+// reject the write operation because of the cloudsql_session_read_only=locked enforcement.
+func TestCloudSQLPg_ReadOnlyVulnerabilityBlock(t *testing.T) {
+	// Skip if not in integration environment
+	if CloudSQLPostgresProject == "" {
+		t.Skip("Skipping integration test: CLOUD_SQL_POSTGRES_PROJECT not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	args := []string{"--enable-api"}
+
+	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableName := "vulnerability_test_" + uniqueID
+
+	toolsFileTemplate := `
+kind: source
+name: my-readonly-pg-instance
+type: cloud-sql-postgres
+project: %s
+region: %s
+instance: %s
+database: %s
+user: %s
+password: %s
+readonly: true
+---
+kind: tool
+name: vulnerable_write_tool
+type: postgres-execute-sql
+source: my-readonly-pg-instance
+description: I am a tool that tries to write but falsely claims to be read-only!
+annotations:
+  readOnlyHint: true
+statement: CREATE TABLE %s (id INT);
+`
+	toolsFileStr := fmt.Sprintf(toolsFileTemplate, CloudSQLPostgresProject, CloudSQLPostgresRegion, CloudSQLPostgresInstance, CloudSQLPostgresDatabase, CloudSQLPostgresUser, CloudSQLPostgresPass, tableName)
+
+	var toolsFile map[string]any
+	if err := yaml.Unmarshal([]byte(toolsFileStr), &toolsFile); err != nil {
+		t.Fatalf("failed to unmarshal yaml string: %s", err)
+	}
+
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelWait()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	// Make the API request
+	api := "http://127.0.0.1:5000/api/tool/vulnerable_write_tool/invoke"
+	requestBody := strings.NewReader(`{}`)
+	resp, respBody := tests.RunRequest(t, "POST", api, requestBody, map[string]string{})
+
+	// Even if it returns 500 (internal server error from the db driver), we just need to verify the body contains the DB error
+	if !strings.Contains(string(respBody), "read-only transaction") {
+		t.Fatalf("Vulnerability check failed! Expected database to reject the write with a 'read-only transaction' error, but got response code %d and body:\n%s", resp.StatusCode, string(respBody))
 	}
 }

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -310,7 +310,7 @@ func TestCloudSQLPg_ReadOnlyVulnerabilityBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	args := []string{"--enable-api"}
+	args := []string{"--enable-api", "--port", "5002"}
 
 	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
 	tableName := "vulnerability_test_" + uniqueID
@@ -357,7 +357,7 @@ tools:
 	}
 
 	// Make the API request
-	api := "http://127.0.0.1:5000/api/tool/vulnerable_write_tool/invoke"
+	api := "http://127.0.0.1:5002/api/tool/vulnerable_write_tool/invoke"
 	requestBody := strings.NewReader(`{}`)
 	resp, respBody := tests.RunRequest(t, "POST", api, requestBody, map[string]string{})
 

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -316,25 +316,24 @@ func TestCloudSQLPg_ReadOnlyVulnerabilityBlock(t *testing.T) {
 	tableName := "vulnerability_test_" + uniqueID
 
 	toolsFileTemplate := `
-kind: source
-name: my-readonly-pg-instance
-type: cloud-sql-postgres
-project: %s
-region: %s
-instance: %s
-database: %s
-user: %s
-password: %s
-readonly: true
----
-kind: tool
-name: vulnerable_write_tool
-type: postgres-execute-sql
-source: my-readonly-pg-instance
-description: I am a tool that tries to write but falsely claims to be read-only!
-annotations:
-  readOnlyHint: true
-statement: CREATE TABLE %s (id INT);
+sources:
+  my-readonly-pg-instance:
+    type: cloud-sql-postgres
+    project: %s
+    region: %s
+    instance: %s
+    database: %s
+    user: %s
+    password: %s
+    readonly: true
+tools:
+  vulnerable_write_tool:
+    type: postgres-execute-sql
+    source: my-readonly-pg-instance
+    description: I am a tool that tries to write but falsely claims to be read-only!
+    annotations:
+      readOnlyHint: true
+    statement: CREATE TABLE %s (id INT);
 `
 	toolsFileStr := fmt.Sprintf(toolsFileTemplate, CloudSQLPostgresProject, CloudSQLPostgresRegion, CloudSQLPostgresInstance, CloudSQLPostgresDatabase, CloudSQLPostgresUser, CloudSQLPostgresPass, tableName)
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -54,12 +54,18 @@ func GetToolsConfig(sourceConfig map[string]any, toolType, paramToolStatement, i
 				"source":      "my-instance",
 				"description": "Simple tool to test end to end functionality.",
 				"statement":   "SELECT 1",
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 			},
 			"my-tool": map[string]any{
 				"type":        toolType,
 				"source":      "my-instance",
 				"description": "Tool to test invocation with params.",
 				"statement":   paramToolStatement,
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 				"parameters": []any{
 					map[string]any{
 						"name":        "id",
@@ -78,6 +84,9 @@ func GetToolsConfig(sourceConfig map[string]any, toolType, paramToolStatement, i
 				"source":      "my-instance",
 				"description": "Tool to test invocation with params.",
 				"statement":   idParamToolStmt,
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 				"parameters": []any{
 					map[string]any{
 						"name":        "id",
@@ -91,6 +100,9 @@ func GetToolsConfig(sourceConfig map[string]any, toolType, paramToolStatement, i
 				"source":      "my-instance",
 				"description": "Tool to test invocation with params.",
 				"statement":   nameParamToolStmt,
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 				"parameters": []any{
 					map[string]any{
 						"name":        "name",
@@ -105,6 +117,9 @@ func GetToolsConfig(sourceConfig map[string]any, toolType, paramToolStatement, i
 				"source":      "my-instance",
 				"description": "Tool to test invocation with array params.",
 				"statement":   arrayToolStatement,
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 				"parameters": []any{
 					map[string]any{
 						"name":        "idArray",
@@ -134,6 +149,9 @@ func GetToolsConfig(sourceConfig map[string]any, toolType, paramToolStatement, i
 				"description": "Tool to test authenticated parameters.",
 				// statement to auto-fill authenticated parameter
 				"statement": authToolStatement,
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 				"parameters": []map[string]any{
 					{
 						"name":        "email",
@@ -153,6 +171,9 @@ func GetToolsConfig(sourceConfig map[string]any, toolType, paramToolStatement, i
 				"source":      "my-instance",
 				"description": "Tool to test auth required invocation.",
 				"statement":   "SELECT 1",
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 				"authRequired": []string{
 					"my-google-auth",
 				},
@@ -162,6 +183,9 @@ func GetToolsConfig(sourceConfig map[string]any, toolType, paramToolStatement, i
 				"source":      "my-instance",
 				"description": "Tool to test statement with incorrect syntax.",
 				"statement":   "SELEC 1;",
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Overview
This PR implements the foundation for Read-Only Tools for Spanner, Cloud SQL (PostgreSQL & MySQL), and AlloyDB PostgreSQL. It introduces kernel-level locks to prevent LLM mutations, server-side tool suppression to save token budgets and avoid planning errors, and comprehensive updates to prebuilt configurations and documentation.

## Changes
- **Kernel-Level Enforcement (Fail-Closed Security):**
  - **Spanner:** Forced all read-only queries to use the native `spanner.Single().Query()` API, completely eliminating mutation capabilities.
  - **Cloud SQL & AlloyDB PostgreSQL:** Injected `-c cloudsql_session_read_only=locked` and `-c alloydb_session_read_only=locked` into the startup DSN.
    - This uses the engine's startup packet to guarantee a fail-closed connection if the parameters are not supported, bypassing vulnerabilities present in OSS `default_transaction_read_only`.
  - **Cloud SQL MySQL:** Injected `cloudsql_session_read_only=locked` into the DSN to securely lock MySQL sessions via the driver connection pool.
  
- **Dynamic Server-Side Tool Suppression:**
  - Evaluates `readOnlyHint` on all prebuilt and custom tools. 
  - If a tool explicitly permits writes (`readOnlyHint: false`) and is bound to a `readonly: true` source, the server securely suppresses the tool, hiding it entirely from the LLM.
  - **Unannotated Tools Warning:** If a custom tool does not define a `readOnlyHint`, the server allows the tool to pass through (letting the database kernel enforce security) but emits a prominent warning to the server logs instructing the developer to add appropriate annotations.

- **Prebuilt Configurations Updates:**
  - Split `execute_sql` into `execute_sql` (destructive) and `execute_sql_readonly` (or `execute_sql_dql` for Spanner).
  - Hardcoded `readOnlyHint: false` on destructive tools and `readOnlyHint: true` on schema exploration and DQL tools.
  - Enabled dynamic `readonly: true` evaluation for prebuilt templates via environment variables (`CLOUDSQL_PG_READONLY`, `ALLOYDB_READONLY`, `SPANNER_READONLY`, `CLOUDSQL_MYSQL_READONLY`).

- **Testing & Documentation:**
  - **Integration Testing:** Added `TestCloudSQLPg_ReadOnlyVulnerabilityBlock` to ensure custom tools that falsely annotate themselves as read-only are still successfully blocked from writing by the database kernel lock.
  - **Unit Testing:** Added robust coverage for YAML unmarshaling and the unannotated tool warning bypass logic (`readonly_tools_test.go`).
  - **Docs:** Updated database-specific READMEs with the new environment variables and expanded the main `README.md` to guide developers on configuring custom tool `annotations`.