### PR TITLE
chore(tool/conversational-analytics): migrate conversational analytics tools entry point from v1beta to v1

### DIFF
--- a/internal/sources/looker/looker.go
+++ b/internal/sources/looker/looker.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	geminidataanalytics "cloud.google.com/go/geminidataanalytics/apiv1beta"
+	geminidataanalytics "cloud.google.com/go/geminidataanalytics/apiv1"
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"

--- a/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
+++ b/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
@@ -37,7 +37,7 @@ import (
 const resourceType string = "bigquery-conversational-analytics"
 
 func getGDAURLFormat() string {
-	return util.GetGDAEndpoint() + "/v1beta/projects/%s/locations/%s:chat"
+	return util.GetGDAEndpoint() + "/v1/projects/%s/locations/%s:chat"
 }
 
 const instructions = `**INSTRUCTIONS - FOLLOW THESE RULES:**
@@ -105,7 +105,6 @@ type InlineContext struct {
 }
 
 type CAPayload struct {
-	Project       string        `json:"project"`
 	Messages      []Message     `json:"messages"`
 	InlineContext InlineContext `json:"inlineContext"`
 	ClientIdEnum  string        `json:"clientIdEnum"`
@@ -220,7 +219,6 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	}
 
 	payload := CAPayload{
-		Project:  fmt.Sprintf("projects/%s", projectID),
 		Messages: []Message{{UserMessage: UserMessage{Text: finalQueryText}}},
 		InlineContext: InlineContext{
 			DatasourceReferences: DatasourceReferences{

--- a/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
+++ b/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
@@ -101,7 +101,6 @@ type Options struct {
 }
 type InlineContext struct {
 	DatasourceReferences DatasourceReferences `json:"datasourceReferences"`
-	Options              Options              `json:"options"`
 }
 
 type CAPayload struct {
@@ -224,7 +223,6 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 			DatasourceReferences: DatasourceReferences{
 				BQ: BQDatasource{TableReferences: tableRefs},
 			},
-			Options: Options{Chart: ChartOptions{Image: ImageOptions{NoImage: map[string]any{}}}},
 		},
 		ClientIdEnum: util.GDAClientID,
 	}

--- a/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
@@ -78,7 +78,6 @@ type DataAgentContext struct {
 }
 
 type CAPayload struct {
-	Project          string           `json:"project"`
 	Messages         []Message        `json:"messages"`
 	DataAgentContext DataAgentContext `json:"dataAgentContext"`
 	ClientIdEnum     string           `json:"clientIdEnum"`
@@ -196,7 +195,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 	// Construct URL, headers, and payload
 	projectID := source.GetProjectID()
-	caURL := fmt.Sprintf("%s/v1beta/projects/%s/locations/%s:chat", util.GetGDAEndpoint(), projectID, t.Cfg.Location)
+	caURL := fmt.Sprintf("%s/v1/projects/%s/locations/%s:chat", util.GetGDAEndpoint(), projectID, t.Cfg.Location)
 
 	headers := map[string]string{
 		"Content-Type":      "application/json",
@@ -206,7 +205,6 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	dataAgentName := fmt.Sprintf("projects/%s/locations/%s/dataAgents/%s", projectID, t.Cfg.Location, dataAgentId)
 
 	payload := CAPayload{
-		Project:  fmt.Sprintf("projects/%s", projectID),
 		Messages: []Message{{UserMessage: UserMessage{Text: userQuery}}},
 		DataAgentContext: DataAgentContext{
 			DataAgent: dataAgentName,

--- a/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
@@ -163,7 +163,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 	// Construct URL
 	projectID := source.GetProjectID()
-	caURL := fmt.Sprintf("%s/v1beta/projects/%s/locations/%s/dataAgents/%s", util.GetGDAEndpoint(), projectID, t.Cfg.Location, url.PathEscape(dataAgentId))
+	caURL := fmt.Sprintf("%s/v1/projects/%s/locations/%s/dataAgents/%s", util.GetGDAEndpoint(), projectID, t.Cfg.Location, url.PathEscape(dataAgentId))
 
 	req, err := http.NewRequest("GET", caURL, nil)
 	if err != nil {

--- a/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
@@ -157,7 +157,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 	// Construct URL
 	projectID := source.GetProjectID()
-	caURL := fmt.Sprintf("%s/v1beta/projects/%s/locations/%s/dataAgents:listAccessible", util.GetGDAEndpoint(), projectID, t.Cfg.Location)
+	caURL := fmt.Sprintf("%s/v1/projects/%s/locations/%s/dataAgents:listAccessible", util.GetGDAEndpoint(), projectID, t.Cfg.Location)
 
 	req, err := http.NewRequest("GET", caURL, nil)
 	if err != nil {

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -78,7 +78,6 @@ type LookerExploreReference struct {
 }
 type LookerExploreReferences struct {
 	ExploreReferences []LookerExploreReference `json:"exploreReferences"`
-	Credentials       Credentials              `json:"credentials,omitzero"`
 }
 type SecretBased struct {
 	ClientId     string `json:"clientId"`
@@ -116,11 +115,11 @@ type ConversationOptions struct {
 type InlineContext struct {
 	SystemInstruction    string               `json:"systemInstruction"`
 	DatasourceReferences DatasourceReferences `json:"datasourceReferences"`
-	Options              ConversationOptions  `json:"options"`
 }
 type CAPayload struct {
 	Messages      []Message     `json:"messages"`
 	InlineContext InlineContext `json:"inlineContext"`
+	Credentials   *Credentials  `json:"credentials,omitempty"`
 	ClientIdEnum  string        `json:"clientIdEnum"`
 }
 
@@ -249,9 +248,6 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 	lers := LookerExploreReferences{
 		ExploreReferences: ler,
-		Credentials: Credentials{
-			OAuth: oauth_creds,
-		},
 	}
 
 	// Construct URL, headers, and payload
@@ -271,7 +267,9 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 			DatasourceReferences: DatasourceReferences{
 				Looker: lers,
 			},
-			Options: ConversationOptions{Chart: ChartOptions{Image: ImageOptions{NoImage: map[string]any{}}}},
+		},
+		Credentials: &Credentials{
+			OAuth: oauth_creds,
 		},
 		ClientIdEnum: util.GDAClientID,
 	}

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -257,7 +257,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	// Construct URL, headers, and payload
 	projectID := source.GoogleCloudProject()
 	location := source.GoogleCloudLocation()
-	caURL := fmt.Sprintf("%s/v1beta/projects/%s/locations/%s:chat", util.GetGDAEndpoint(), url.PathEscape(projectID), url.PathEscape(location))
+	caURL := fmt.Sprintf("%s/v1/projects/%s/locations/%s:chat", util.GetGDAEndpoint(), url.PathEscape(projectID), url.PathEscape(location))
 
 	headers := map[string]string{
 		"Content-Type":      "application/json",

--- a/tests/cloudgda/cloud_gda_integration_test.go
+++ b/tests/cloudgda/cloud_gda_integration_test.go
@@ -326,7 +326,7 @@ func setupDataAgent(t *testing.T, ctx context.Context, projectID, datasetID, tab
 
 	dataAgentId := "test" + strings.ReplaceAll(uuid.New().String(), "-", "")
 	parent := fmt.Sprintf("projects/%s/locations/global", projectID)
-	url := fmt.Sprintf("%s/v1beta/%s/dataAgents?dataAgentId=%s", util.GetGDAEndpoint(), parent, dataAgentId)
+	url := fmt.Sprintf("%s/v1/%s/dataAgents?dataAgentId=%s", util.GetGDAEndpoint(), parent, dataAgentId)
 
 	requestBody := map[string]any{
 		"displayName": dataAgentDisplayName,
@@ -402,7 +402,7 @@ func setupDataAgent(t *testing.T, ctx context.Context, projectID, datasetID, tab
 		case <-timeout:
 			t.Fatalf("timed out waiting for data agent creation")
 		case <-ticker.C:
-			opUrl := fmt.Sprintf("%s/v1beta/%s", util.GetGDAEndpoint(), opName)
+			opUrl := fmt.Sprintf("%s/v1/%s", util.GetGDAEndpoint(), opName)
 			opReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, opUrl, nil)
 			opResp, err := client.Do(opReq)
 			if err != nil {
@@ -429,7 +429,7 @@ func setupDataAgent(t *testing.T, ctx context.Context, projectID, datasetID, tab
 
 	teardown := func(t *testing.T) {
 		agentName := fmt.Sprintf("%s/dataAgents/%s", parent, dataAgentId)
-		deleteUrl := fmt.Sprintf("%s/v1beta/%s", util.GetGDAEndpoint(), agentName)
+		deleteUrl := fmt.Sprintf("%s/v1/%s", util.GetGDAEndpoint(), agentName)
 		delReq, _ := http.NewRequest(http.MethodDelete, deleteUrl, nil)
 		delResp, err := client.Do(delReq)
 		if err != nil {


### PR DESCRIPTION
## Description

This migration switches the hardcoded API paths in the tool invocations from v1beta to v1.

Affected tools:
- bigquery-conversational-analytics
- conversational-analytics-ask-data-agent
- conversational-analytics-get-data-agent-info
- conversational-analytics-list-accessible-data-agents
- looker-conversational-analytics

Also updates looker source and cloudgda integration tests to utilize v1 entry points.


## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
