### PR TITLE
fix(server): reject non-string group names

### DIFF
--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -2477,13 +2477,14 @@ description: the default group
 			wantErr: false,
 		},
 		{
-			description: "group with null name is accepted as default group",
+			description: "group with null name is rejected",
 			in: `
 kind: group
 name: ~
 description: the default group
 `,
-			wantErr: false,
+			wantErr:     true,
+			errContains: "missing 'name' field or it is not a string",
 		},
 		{
 			description: "non-group resource with integer name is rejected",

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -2486,6 +2486,14 @@ description: the default group
 			wantErr: false,
 		},
 		{
+			description: "group with quoted numeric name is accepted",
+			in: `
+kind: group
+name: "123"
+`,
+			wantErr: false,
+		},
+		{
 			description: "non-group resource with integer name is rejected",
 			in: `
 kind: tool

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -2438,3 +2438,83 @@ tools:
 		})
 	}
 }
+
+func TestParseConfigGroupNameValidation(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tcs := []struct {
+		description string
+		in          string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			description: "group with integer name is rejected",
+			in: `
+kind: group
+name: 123
+`,
+			wantErr:     true,
+			errContains: "missing 'name' field or it is not a string",
+		},
+		{
+			description: "group with boolean name is rejected",
+			in: `
+kind: group
+name: true
+`,
+			wantErr:     true,
+			errContains: "missing 'name' field or it is not a string",
+		},
+		{
+			description: "group with absent name is accepted as default group",
+			in: `
+kind: group
+description: the default group
+`,
+			wantErr: false,
+		},
+		{
+			description: "group with null name is accepted as default group",
+			in: `
+kind: group
+name: ~
+description: the default group
+`,
+			wantErr: false,
+		},
+		{
+			description: "non-group resource with integer name is rejected",
+			in: `
+kind: tool
+name: 42
+type: postgres-sql
+source: my-pg-instance
+description: some description
+statement: SELECT 1
+`,
+			wantErr:     true,
+			errContains: "missing 'name' field or it is not a string",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			parser := ConfigParser{}
+			_, err := parser.ParseConfig(ctx, testutils.FormatYaml(tc.in))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -2477,14 +2477,13 @@ description: the default group
 			wantErr: false,
 		},
 		{
-			description: "group with null name is rejected",
+			description: "group with null name is accepted as default group",
 			in: `
 kind: group
 name: ~
 description: the default group
 `,
-			wantErr:     true,
-			errContains: "missing 'name' field or it is not a string",
+			wantErr: false,
 		},
 		{
 			description: "non-group resource with integer name is rejected",

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -205,7 +205,7 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 		if name, ok = resource["name"].(string); !ok {
 			// A `kind: group` may omit `name` (or leave it empty) to target the
 			// default nameless group; every other resource requires a name.
-			if kind == "group" {
+			if rawName, present := resource["name"]; kind == "group" && (!present || rawName == nil) {
 				name, ok = "", true
 			}
 		}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -206,7 +206,7 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 			// A `kind: group` may omit `name` to target the default nameless group;
 			// every other resource requires a name.
 			if kind == "group" {
-				if _, present := resource["name"]; !present {
+				if rawName, present := resource["name"]; !present || rawName == nil {
 					name, ok = "", true
 				}
 			}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -203,10 +203,12 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 			return nil, nil, nil, nil, nil, nil, fmt.Errorf("missing 'kind' field or it is not a string: %v", resource)
 		}
 		if name, ok = resource["name"].(string); !ok {
-			// A `kind: group` may omit `name` (or leave it empty) to target the
-			// default nameless group; every other resource requires a name.
-			if rawName, present := resource["name"]; kind == "group" && (!present || rawName == nil) {
-				name, ok = "", true
+			// A `kind: group` may omit `name` to target the default nameless group;
+			// every other resource requires a name.
+			if kind == "group" {
+				if _, present := resource["name"]; !present {
+					name, ok = "", true
+				}
 			}
 		}
 		if !ok {


### PR DESCRIPTION
## Description

Reinstates the `(!present || rawName == nil)` guard in `UnmarshalResourceConfig` that was accidentally dropped during the merge of the groups stack into `feat/groups`.

Without the guard, a config like:

```yaml
kind: group
name: 123
```

would silently default to the empty (default) group instead of returning a parse error. Deeven Seru flagged this in the review of #3575.

The fix ensures non-string name values (`name: 123`, `name: true`) are rejected with `"missing 'name' field or it is not a string"`, while legitimately absent or null names are still accepted as the default group.

Adds regression tests to `TestParseConfigGroupNameValidation` covering all four cases.