### PR TITLE
Refactor(odata): generalize OData source and tool implementation

### DIFF
--- a/docs/en/integrations/odata/source.md
+++ b/docs/en/integrations/odata/source.md
@@ -4,13 +4,13 @@ type: docs
 linkTitle: "Source"
 weight: 1
 description: >
-  An "odata" source connects to an OData service (v2 or v4), supporting SAP-specific gateway strategies, CSRF handshakes, and dynamic principal propagation.
+  An "odata" source connects to an OData service (v2 or v4), supporting OData-specific gateway strategies, CSRF handshakes, and dynamic principal propagation.
 no_list: true
 ---
 
 ## About
 
-An `odata` source establishes a connection to an OData service. It supports standard v2 and v4 OData protocol features, including batch processing, deep inserts, and server-side pagination, as well as SAP Gateway strategies (such as automatic fetching and recycling of CSRF security tokens).
+An `odata` source establishes a connection to an OData service. It supports standard v2 and v4 OData protocol features, including batch processing, deep inserts, and server-side pagination, as well as OData Gateway strategies (such as automatic fetching and recycling of CSRF security tokens).
 
 ## Available Tools
 
@@ -27,9 +27,9 @@ Toolbox supports multiple authentication methods for OData sources:
 3.  **TLS Client Certificates (x509):** Password-encrypted or unencrypted client certificates for mutual TLS (mTLS) environments.
 4.  **Dynamic User OAuth (Principal Propagation):** Forwards the user's OAuth access token from the client application dynamically to the OData backend.
 
-### SAP Gateway Strategy
+### OData Gateway Strategy
 
-When `authStrategy` is configured to `sap-gateway`, Toolbox automatically performs a pre-flight `HEAD` request with the client credentials to fetch the necessary CSRF security tokens and session cookies. It manages session persistence per user using an LRU cache and handles token eviction seamlessly if a request fails with a `403 CSRF token validation` error.
+When `authStrategy` is configured to `OData-gateway`, Toolbox automatically performs a pre-flight `HEAD` request with the client credentials to fetch the necessary CSRF security tokens and session cookies. It manages session persistence per user using an LRU cache and handles token eviction seamlessly if a request fails with a `403 CSRF token validation` error.
 
 ## Example
 
@@ -37,30 +37,30 @@ Initialize an OData source with Basic authentication:
 
 ```yaml
 kind: source
-name: sap-sales-order-srv
+name: odata-sales-order-srv
 type: "odata"
-baseUrl: "https://sap-gateway.example.com/sap/opu/odata/sap/API_SALES_ORDER_SRV"
+baseUrl: "https://gateway.example.com/odata/v2/SalesOrderService"
 disableSslVerification: true # Set to true to skip server certificate verification for development
 auth:
   type: "basic"
-  username: "MY_SAP_USER"
-  password: "MY_SAP_PASSWORD"
-authStrategy: "sap-gateway"
+  username: "MY_ODATA_USER"
+  password: "MY_ODATA_PASSWORD"
+authStrategy: "gateway"
 compatibility:
-  sapUrlQuoting: true
+  urlQuoting: true
 ```
 
 Initialize an OData source with dynamic pass-through client authorization (OAuth 2.0):
 
 ```yaml
 kind: source
-name: sap-sales-order-srv-oauth
+name: odata-sales-order-srv-oauth
 type: "odata"
-baseUrl: "https://sap-gateway.example.com/sap/opu/odata/sap/API_SALES_ORDER_SRV"
+baseUrl: "https://gateway.example.com/odata/v2/SalesOrderService"
 useClientOauth: "true"
-authStrategy: "sap-gateway"
+authStrategy: "gateway"
 compatibility:
-  sapUrlQuoting: true
+  urlQuoting: true
 ```
 
 ## Reference
@@ -74,6 +74,6 @@ compatibility:
 | queryParams | map[string]string | false | Custom query parameters to include in all requests. |
 | disableSslVerification | boolean | false | If true, skips TLS certificate verification (equivalent to `curl -k`). |
 | auth | object | false | Optional credential configuration for static auth (Basic, Bearer, or x509). |
-| useClientOauth | string | false | Enables dynamic pass-through of the user's OAuth token. Set to `'true'` to read the token from the default `Authorization` header, or set to a custom header name (e.g., `X-SAP-OAuth-Token`). |
-| authStrategy | string | false | Specifies a special pre-flight or caching strategy. Set to `'sap-gateway'` to enable automatic CSRF handshakes and cookie jar session tracking. |
+| useClientOauth | string | false | Enables dynamic pass-through of the user's OAuth token. Set to `'true'` to read the token from the default `Authorization` header, or set to a custom header name (e.g., `X-OData-OAuth-Token`). |
+| authStrategy | string | false | Specifies a special pre-flight or caching strategy. Set to `'OData-gateway'` to enable automatic CSRF handshakes and cookie jar session tracking. |
 | compatibility | object | false | Special configuration flags for non-standard OData implementations. |

--- a/docs/en/integrations/odata/tools/odata.md
+++ b/docs/en/integrations/odata/tools/odata.md
@@ -24,7 +24,7 @@ An example of a `CREATE` tool to create a sales order header:
 kind: tool
 name: create_sales_order_header
 type: odata
-source: sap-sales-order-srv
+source: odata-sales-order-srv
 entitySet: A_SalesOrder
 operation: CREATE
 description: Create a new sales order header entity.
@@ -46,7 +46,7 @@ An example of a `READ` tool to query sales order headers:
 kind: tool
 name: read_sales_order_header
 type: odata
-source: sap-sales-order-srv
+source: odata-sales-order-srv
 entitySet: A_SalesOrder
 operation: READ
 description: Retrieve and query sales order headers.

--- a/internal/sources/odata/auth_test.go
+++ b/internal/sources/odata/auth_test.go
@@ -74,9 +74,9 @@ func TestBearerTokenStrategy_Authorize(t *testing.T) {
 }
 
 func TestDynamicUserOauthStrategy_Authorize(t *testing.T) {
-	strategy := &DynamicUserOauthStrategy{AuthTokenHeaderName: "X-SAP-Auth"}
+	strategy := &DynamicUserOauthStrategy{AuthTokenHeaderName: "X-OData-Token"}
 	req, _ := http.NewRequest("GET", "https://example.com", nil)
-	req.Header.Set("X-SAP-Auth", "user-dynamic-token")
+	req.Header.Set("X-OData-Token", "user-dynamic-token")
 
 	if err := strategy.Authorize(context.Background(), req, nil); err != nil {
 		t.Fatalf("Authorize failed: %v", err)
@@ -85,7 +85,7 @@ func TestDynamicUserOauthStrategy_Authorize(t *testing.T) {
 	if got := req.Header.Get("Authorization"); got != "Bearer user-dynamic-token" {
 		t.Errorf("unexpected Authorization header: %q", got)
 	}
-	if got := req.Header.Get("X-SAP-Auth"); got != "Bearer user-dynamic-token" {
-		t.Errorf("unexpected X-SAP-Auth header: %q", got)
+	if got := req.Header.Get("X-OData-Token"); got != "Bearer user-dynamic-token" {
+		t.Errorf("unexpected X-OData-Token header: %q", got)
 	}
 }

--- a/internal/sources/odata/gateway_strategy.go
+++ b/internal/sources/odata/gateway_strategy.go
@@ -111,8 +111,8 @@ func (c *sessionLRUCache) removeOldest() {
 	}
 }
 
-// SapGatewayStrategy is the decorator strategy that handles CSRF token retrieval and cookie session management.
-type SapGatewayStrategy struct {
+// GatewayStrategy is the decorator strategy that handles CSRF token retrieval and cookie session management.
+type GatewayStrategy struct {
 	BaseURL             string
 	DefaultHeaders      map[string]string
 	Primary             AuthStrategy // Underlying credential strategy (Basic, mTLS, Bearer)
@@ -121,8 +121,8 @@ type SapGatewayStrategy struct {
 	sessionCache        *sessionLRUCache
 }
 
-func NewSapGatewayStrategy(baseURL string, defaultHeaders map[string]string, primary AuthStrategy, dynamicOauth AuthStrategy, authTokenHeaderName string) *SapGatewayStrategy {
-	return &SapGatewayStrategy{
+func NewGatewayStrategy(baseURL string, defaultHeaders map[string]string, primary AuthStrategy, dynamicOauth AuthStrategy, authTokenHeaderName string) *GatewayStrategy {
+	return &GatewayStrategy{
 		BaseURL:             baseURL,
 		DefaultHeaders:      defaultHeaders,
 		Primary:             primary,
@@ -132,7 +132,7 @@ func NewSapGatewayStrategy(baseURL string, defaultHeaders map[string]string, pri
 	}
 }
 
-func (s *SapGatewayStrategy) Authorize(ctx context.Context, req *http.Request, client *http.Client) error {
+func (s *GatewayStrategy) Authorize(ctx context.Context, req *http.Request, client *http.Client) error {
 	// 1. Apply Credentials using Dynamic OAuth or Fallback Primary
 	if s.DynamicOauth != nil && req.Header.Get(s.AuthTokenHeaderName) != "" {
 		if err := s.DynamicOauth.Authorize(ctx, req, client); err != nil {
@@ -153,7 +153,7 @@ func (s *SapGatewayStrategy) Authorize(ctx context.Context, req *http.Request, c
 			var err error
 			session, err = s.fetchUserCsrf(ctx, req, client, sessionKey)
 			if err != nil {
-				return fmt.Errorf("sap gateway csrf pre-flight failed: %w", err)
+				return fmt.Errorf("OData gateway csrf pre-flight failed: %w", err)
 			}
 		}
 		req.Header.Set("X-CSRF-Token", session.CsrfToken)
@@ -170,12 +170,12 @@ func (s *SapGatewayStrategy) Authorize(ctx context.Context, req *http.Request, c
 	return nil
 }
 
-func (s *SapGatewayStrategy) Evict(ctx context.Context, req *http.Request) {
+func (s *GatewayStrategy) Evict(ctx context.Context, req *http.Request) {
 	sessionKey := HashCredentialsWithHeader(req, s.AuthTokenHeaderName)
 	s.sessionCache.Remove(sessionKey)
 }
 
-func (s *SapGatewayStrategy) fetchUserCsrf(ctx context.Context, req *http.Request, client *http.Client, sessionKey string) (*UserSession, error) {
+func (s *GatewayStrategy) fetchUserCsrf(ctx context.Context, req *http.Request, client *http.Client, sessionKey string) (*UserSession, error) {
 	fetchReq, err := http.NewRequestWithContext(ctx, "HEAD", s.BaseURL, nil)
 	if err != nil {
 		return nil, err

--- a/internal/sources/odata/gateway_strategy_test.go
+++ b/internal/sources/odata/gateway_strategy_test.go
@@ -53,7 +53,7 @@ func TestSessionLRUCache(t *testing.T) {
 	}
 }
 
-func TestSapGatewayStrategy_AuthorizeAndEvict(t *testing.T) {
+func TestGatewayStrategy_AuthorizeAndEvict(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-CSRF-Token", "mock-csrf-token")
 		w.WriteHeader(http.StatusOK)
@@ -61,7 +61,7 @@ func TestSapGatewayStrategy_AuthorizeAndEvict(t *testing.T) {
 	defer ts.Close()
 
 	primary := &BearerTokenStrategy{Token: "test-token"}
-	strategy := NewSapGatewayStrategy(ts.URL, nil, primary, nil, "Authorization")
+	strategy := NewGatewayStrategy(ts.URL, nil, primary, nil, "Authorization")
 
 	req, _ := http.NewRequest("POST", ts.URL+"/FlightCollection", nil)
 	client := ts.Client()

--- a/internal/sources/odata/metadata.go
+++ b/internal/sources/odata/metadata.go
@@ -38,7 +38,7 @@ type Property struct {
 	Type      string
 	Nullable  bool
 	MaxLength string
-	Label  string
+	Label     string
 }
 
 type EntitySet struct {
@@ -87,7 +87,7 @@ type xmlProperty struct {
 	Type      string `xml:"Type,attr"`
 	Nullable  string `xml:"Nullable,attr"`
 	MaxLength string `xml:"MaxLength,attr"`
-	Label     string `xml:"label,attr"` // label
+	Label     string `xml:"label,attr"` // label annotation
 }
 
 type xmlEntityContainer struct {
@@ -134,7 +134,7 @@ func ParseMetadata(data []byte) (*ODataMetadata, error) {
 	} else if root.Version == "4.0" || root.DataServices.DataServiceVersion == "4.0" {
 		meta.Version = "4.0"
 	} else {
-		// Default to 2.0 if ambiguous but usually OData provides it here.
+		// Default to 2.0 if ambiguous but usually OData services provide it here.
 		meta.Version = "2.0"
 	}
 
@@ -156,7 +156,7 @@ func ParseMetadata(data []byte) (*ODataMetadata, error) {
 					Type:      prop.Type,
 					Nullable:  nullable,
 					MaxLength: prop.MaxLength,
-					Label:  prop.Label,
+					Label:     prop.Label,
 				})
 			}
 			meta.EntityTypes[et.Name] = t

--- a/internal/sources/odata/metadata.go
+++ b/internal/sources/odata/metadata.go
@@ -38,7 +38,7 @@ type Property struct {
 	Type      string
 	Nullable  bool
 	MaxLength string
-	SAPLabel  string
+	Label  string
 }
 
 type EntitySet struct {
@@ -87,7 +87,7 @@ type xmlProperty struct {
 	Type      string `xml:"Type,attr"`
 	Nullable  string `xml:"Nullable,attr"`
 	MaxLength string `xml:"MaxLength,attr"`
-	Label     string `xml:"label,attr"` // sap:label
+	Label     string `xml:"label,attr"` // label
 }
 
 type xmlEntityContainer struct {
@@ -134,7 +134,7 @@ func ParseMetadata(data []byte) (*ODataMetadata, error) {
 	} else if root.Version == "4.0" || root.DataServices.DataServiceVersion == "4.0" {
 		meta.Version = "4.0"
 	} else {
-		// Default to 2.0 if ambiguous but usually SAP provides it here.
+		// Default to 2.0 if ambiguous but usually OData provides it here.
 		meta.Version = "2.0"
 	}
 
@@ -156,7 +156,7 @@ func ParseMetadata(data []byte) (*ODataMetadata, error) {
 					Type:      prop.Type,
 					Nullable:  nullable,
 					MaxLength: prop.MaxLength,
-					SAPLabel:  prop.Label,
+					Label:  prop.Label,
 				})
 			}
 			meta.EntityTypes[et.Name] = t

--- a/internal/sources/odata/metadata_test.go
+++ b/internal/sources/odata/metadata_test.go
@@ -20,13 +20,13 @@ import (
 
 func TestParseMetadata(t *testing.T) {
 	xmlData := []byte(`
-<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:sap="http://www.sap.com/Protocols/SAPData">
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:OData="http://www.OData.com/Protocols/ODataData">
     <edmx:DataServices m:DataServiceVersion="2.0">
         <Schema Namespace="API_SALES_ORDER_SRV" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
-            <EntityType Name="A_SalesOrderType" sap:label="Sales Order">
-                <Property Name="SalesOrder" Type="Edm.String" Nullable="false" MaxLength="10" sap:label="Sales Order ID" />
-                <Property Name="TotalNetAmount" Type="Edm.Decimal" Nullable="true" sap:label="Net Amount" />
-                <Property Name="CreationDate" Type="Edm.DateTime" sap:label="Created On" />
+            <EntityType Name="A_SalesOrderType" label="Sales Order">
+                <Property Name="SalesOrder" Type="Edm.String" Nullable="false" MaxLength="10" label="Sales Order ID" />
+                <Property Name="TotalNetAmount" Type="Edm.Decimal" Nullable="true" label="Net Amount" />
+                <Property Name="CreationDate" Type="Edm.DateTime" label="Created On" />
             </EntityType>
             <EntityContainer Name="API_SALES_ORDER_SRV_Entities" m:IsDefaultEntityContainer="true">
                 <EntitySet Name="A_SalesOrder" EntityType="API_SALES_ORDER_SRV.A_SalesOrderType" />
@@ -66,7 +66,7 @@ func TestParseMetadata(t *testing.T) {
 	}
 
 	// Check specific property
-	if et.Properties[0].Name != "SalesOrder" || et.Properties[0].Type != "Edm.String" || et.Properties[0].SAPLabel != "Sales Order ID" {
+	if et.Properties[0].Name != "SalesOrder" || et.Properties[0].Type != "Edm.String" || et.Properties[0].Label != "Sales Order ID" {
 		t.Errorf("Property 0 mapped incorrectly: %+v", et.Properties[0])
 	}
 	if et.Properties[0].Nullable {

--- a/internal/sources/odata/odata.go
+++ b/internal/sources/odata/odata.go
@@ -58,7 +58,7 @@ type AuthConfig struct {
 }
 
 type CompatibilityConfig struct {
-	SapUrlQuoting       bool `yaml:"sapUrlQuoting"`       // Double single-quotes in string URL parameters for OData v2
+	UrlQuoting       bool `yaml:"urlQuoting"`       // Double single-quotes in string URL parameters for OData v2
 	UseTunnelingHeaders bool `yaml:"useTunnelingHeaders"` // POST with X-HTTP-Method header for PATCH/MERGE
 }
 
@@ -70,7 +70,7 @@ type Config struct {
 	DefaultHeaders         map[string]string   `yaml:"headers"`
 	QueryParams            map[string]string   `yaml:"queryParams"`
 	DisableSslVerification bool                `yaml:"disableSslVerification"`
-	Auth                   AuthConfig          `yaml:"auth"` // SAP specific auth
+	Auth                   AuthConfig          `yaml:"auth"` // OData specific auth
 	UseClientOauth         string              `yaml:"useClientOauth"`
 	AuthStrategy           string              `yaml:"authStrategy"`
 	Compatibility          CompatibilityConfig `yaml:"compatibility"`
@@ -175,8 +175,8 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 	}
 
 	var authStrategy AuthStrategy
-	if c.AuthStrategy == "sap-gateway" {
-		authStrategy = NewSapGatewayStrategy(c.BaseURL, c.DefaultHeaders, primary, dynamic, headerName)
+	if c.AuthStrategy == "gateway" {
+		authStrategy = NewGatewayStrategy(c.BaseURL, c.DefaultHeaders, primary, dynamic, headerName)
 	} else {
 		if dynamic != nil {
 			authStrategy = dynamic
@@ -194,7 +194,7 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	// Attempt initial metadata fetch at startup; if unauthenticated (e.g. user OAuth token required), lazy-load on first request.
 	if err := source.fetchMetadata(ctx, ""); err != nil {
-		fmt.Printf("Notice: SAP OData metadata will be lazily fetched on first user request: %v\n", err)
+		fmt.Printf("Notice: OData OData metadata will be lazily fetched on first user request: %v\n", err)
 	}
 
 	return source, nil
@@ -289,8 +289,8 @@ func (s *Source) fetchMetadata(ctx context.Context, accessToken tools.AccessToke
 	return nil
 }
 
-// RunSAPRequest attaches auth and CSRF headers via AuthStrategy before executing.
-func (s *Source) RunSAPRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
+// RunODataRequest attaches auth and CSRF headers via AuthStrategy before executing.
+func (s *Source) RunODataRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
 	ctx := req.Context()
 
 	// 1. Pass context token via header so DynamicUserOauthStrategy can read it
@@ -300,7 +300,7 @@ func (s *Source) RunSAPRequest(req *http.Request, accessToken tools.AccessToken)
 
 	// 2. Delegate Authentication and Handshake to Strategy
 	if err := s.authStrategy.Authorize(ctx, req, s.client); err != nil {
-		return nil, fmt.Errorf("sap authorization failed: %w", err)
+		return nil, fmt.Errorf("OData authorization failed: %w", err)
 	}
 
 	// Inject Default Headers
@@ -312,7 +312,7 @@ func (s *Source) RunSAPRequest(req *http.Request, accessToken tools.AccessToken)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("sap http execution failed: %v", err)
+		return nil, fmt.Errorf("OData http execution failed: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -326,7 +326,7 @@ func (s *Source) RunSAPRequest(req *http.Request, accessToken tools.AccessToken)
 		if resp.StatusCode == 403 && req.Method != "GET" && req.Method != "HEAD" {
 			s.authStrategy.Evict(ctx, req)
 		}
-		return nil, fmt.Errorf("sap http error %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("OData http error %d: %s", resp.StatusCode, string(body))
 	}
 
 	// If 204 No Content, return empty

--- a/internal/sources/odata/odata.go
+++ b/internal/sources/odata/odata.go
@@ -25,7 +25,10 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
+
+	"log/slog"
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
@@ -175,7 +178,7 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 	}
 
 	var authStrategy AuthStrategy
-	if c.AuthStrategy == "gateway" {
+	if c.AuthStrategy == "gateway" || c.AuthStrategy == "csrf-token" {
 		authStrategy = NewGatewayStrategy(c.BaseURL, c.DefaultHeaders, primary, dynamic, headerName)
 	} else {
 		if dynamic != nil {
@@ -194,7 +197,12 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	// Attempt initial metadata fetch at startup; if unauthenticated (e.g. user OAuth token required), lazy-load on first request.
 	if err := source.fetchMetadata(ctx, ""); err != nil {
-		fmt.Printf("Notice: OData metadata will be lazily fetched on first user request: %v\n", err)
+		logger, _ := util.LoggerFromContext(ctx)
+		if logger != nil {
+			logger.InfoContext(ctx, "OData metadata will be lazily fetched on first user request", "err", err)
+		} else {
+			slog.InfoContext(ctx, "OData metadata will be lazily fetched on first user request", "err", err)
+		}
 	}
 
 	return source, nil
@@ -202,6 +210,7 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 type Source struct {
 	Config
+	mu                  sync.RWMutex
 	client              *http.Client
 	metadata            *ODataMetadata
 	authStrategy        AuthStrategy
@@ -234,6 +243,8 @@ func (s *Source) GetAuthTokenHeaderName() string {
 }
 
 func (s *Source) Metadata() *ODataMetadata {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.metadata
 }
 
@@ -284,7 +295,9 @@ func (s *Source) fetchMetadata(ctx context.Context, accessToken tools.AccessToke
 	if err != nil {
 		return fmt.Errorf("failed to parse metadata XML: %v", err)
 	}
+	s.mu.Lock()
 	s.metadata = meta
+	s.mu.Unlock()
 
 	return nil
 }
@@ -293,6 +306,10 @@ func (s *Source) fetchMetadata(ctx context.Context, accessToken tools.AccessToke
 func (s *Source) RunODataRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
 	ctx := req.Context()
 
+	if s.Metadata() == nil {
+		_ = s.fetchMetadata(ctx, accessToken)
+	}
+
 	// 1. Pass context token via header so DynamicUserOauthStrategy can read it
 	if accessToken != "" {
 		req.Header.Set(s.GetAuthTokenHeaderName(), string(accessToken))
@@ -300,7 +317,7 @@ func (s *Source) RunODataRequest(req *http.Request, accessToken tools.AccessToke
 
 	// 2. Delegate Authentication and Handshake to Strategy
 	if err := s.authStrategy.Authorize(ctx, req, s.client); err != nil {
-		return nil, fmt.Errorf("OData authorization failed: %w", err)
+		return nil, fmt.Errorf("authorization failed: %w", err)
 	}
 
 	// Inject Default Headers
@@ -312,7 +329,7 @@ func (s *Source) RunODataRequest(req *http.Request, accessToken tools.AccessToke
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("OData http execution failed: %v", err)
+		return nil, fmt.Errorf("http execution failed: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -326,7 +343,7 @@ func (s *Source) RunODataRequest(req *http.Request, accessToken tools.AccessToke
 		if resp.StatusCode == 403 && req.Method != "GET" && req.Method != "HEAD" {
 			s.authStrategy.Evict(ctx, req)
 		}
-		return nil, fmt.Errorf("OData http error %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("http error %d: %s", resp.StatusCode, string(body))
 	}
 
 	// If 204 No Content, return empty

--- a/internal/sources/odata/odata.go
+++ b/internal/sources/odata/odata.go
@@ -194,7 +194,7 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	// Attempt initial metadata fetch at startup; if unauthenticated (e.g. user OAuth token required), lazy-load on first request.
 	if err := source.fetchMetadata(ctx, ""); err != nil {
-		fmt.Printf("Notice: OData OData metadata will be lazily fetched on first user request: %v\n", err)
+		fmt.Printf("Notice: OData metadata will be lazily fetched on first user request: %v\n", err)
 	}
 
 	return source, nil

--- a/internal/sources/odata/odata.go
+++ b/internal/sources/odata/odata.go
@@ -61,7 +61,7 @@ type AuthConfig struct {
 }
 
 type CompatibilityConfig struct {
-	UrlQuoting       bool `yaml:"urlQuoting"`       // Double single-quotes in string URL parameters for OData v2
+	UrlQuoting          bool `yaml:"urlQuoting"`          // Double single-quotes in string URL parameters for OData v2
 	UseTunnelingHeaders bool `yaml:"useTunnelingHeaders"` // POST with X-HTTP-Method header for PATCH/MERGE
 }
 

--- a/internal/sources/odata/odata_test.go
+++ b/internal/sources/odata/odata_test.go
@@ -37,7 +37,7 @@ func TestParseFromYamlOData(t *testing.T) {
 				kind: source
 				name: my-instance
 				type: odata
-				baseUrl: https://example.com/sap/opu/odata
+				baseUrl: https://example.com/OData/opu/odata
 				timeout: 10s
 				auth:
 				  type: basic
@@ -48,7 +48,7 @@ func TestParseFromYamlOData(t *testing.T) {
 				"my-instance": Config{
 					Name:    "my-instance",
 					Type:    SourceType,
-					BaseURL: "https://example.com/sap/opu/odata",
+					BaseURL: "https://example.com/OData/opu/odata",
 					Timeout: "10s",
 					Auth: AuthConfig{
 						Type:     "basic",
@@ -61,7 +61,7 @@ func TestParseFromYamlOData(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, _, _, _, _, _, err := server.UnmarshalResourceConfig(context.Background(), testutils.FormatYaml(tc.in))
+			got, _, _, _, _, _, err := server.UnmarshalPrimitiveConfig(context.Background(), testutils.FormatYaml(tc.in))
 			if err != nil {
 				t.Fatalf("unable to unmarshal: %s", err)
 			}
@@ -84,7 +84,7 @@ func TestFailParseFromYaml(t *testing.T) {
 				kind: source
 				name: my-instance
 				type: odata
-				baseUrl: https://example.com/sap/opu/odata
+				baseUrl: https://example.com/OData/opu/odata
 				foo: bar
 			`,
 			err: "unknown field \"foo\"",
@@ -104,7 +104,7 @@ func TestFailParseFromYaml(t *testing.T) {
 				kind: source
 				name: my-instance
 				type: odata
-				baseUrl: https://example.com/sap/opu/odata
+				baseUrl: https://example.com/OData/opu/odata
 				auth:
 				  type: invalid_auth
 			`,
@@ -113,7 +113,7 @@ func TestFailParseFromYaml(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, _, _, _, _, _, err := server.UnmarshalResourceConfig(context.Background(), testutils.FormatYaml(tc.in))
+			_, _, _, _, _, _, err := server.UnmarshalPrimitiveConfig(context.Background(), testutils.FormatYaml(tc.in))
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.err)
 			}

--- a/internal/tools/odata/odata.go
+++ b/internal/tools/odata/odata.go
@@ -107,10 +107,10 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
-// applyODataFormatting automatically applies OData syntax transformations to values, incorporating OData-specific compatibility flags.
+// applyODataFormatting automatically applies OData syntax transformations to values, incorporating OData compatibility flags.
 func applyODataFormatting(value string, paramName string, paramType string, mdVersion string, isUrlParam bool, compat odata.CompatibilityConfig) string {
 	if compat.UrlQuoting {
-		// Intelligent Casing Heuristic for OData
+		// Casing heuristic for OData properties
 		upperNames := []string{"ID", "CODE", "CARRID", "CONNID", "KEY", "NUM", "CITY", "COUNTRY", "PLANT", "COMPANY", "CURRENCY"}
 		upper := strings.ToUpper(paramName)
 		shouldUpper := false
@@ -126,7 +126,8 @@ func applyODataFormatting(value string, paramName string, paramType string, mdVe
 
 		// OData v2 requires string literals in the URL to be single quoted.
 		if isUrlParam && mdVersion == "2.0" && paramType == "string" {
-			if !strings.HasPrefix(value, "'") && !strings.HasSuffix(value, "'") {
+			isFullyQuoted := strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") && len(value) >= 2
+			if !isFullyQuoted {
 				// Escape single quotes by doubling them for OData v2
 				escapedValue := strings.ReplaceAll(value, "'", "''")
 				value = fmt.Sprintf("'%s'", escapedValue)
@@ -135,7 +136,8 @@ func applyODataFormatting(value string, paramName string, paramType string, mdVe
 	} else {
 		// Standard OData string quoting (single-quoted string literals in URLs)
 		if isUrlParam && paramType == "string" {
-			if !strings.HasPrefix(value, "'") && !strings.HasSuffix(value, "'") {
+			isFullyQuoted := strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") && len(value) >= 2
+			if !isFullyQuoted {
 				escapedValue := strings.ReplaceAll(value, "'", "''")
 				value = fmt.Sprintf("'%s'", escapedValue)
 			}
@@ -159,8 +161,10 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 	}
 
 	// 1. Build URL
-	baseURL := strings.TrimRight(source.HttpBaseURL(), "/")
-	reqURL := fmt.Sprintf("%s/%s", baseURL, t.Cfg.EntitySet)
+	reqURL, err := url.JoinPath(source.HttpBaseURL(), t.Cfg.EntitySet)
+	if err != nil {
+		return nil, util.NewClientServerError("invalid url path", http.StatusInternalServerError, err)
+	}
 
 	parsedURL, err := url.Parse(reqURL)
 	if err != nil {
@@ -217,10 +221,18 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		}
 	}
 
-	// 4. Execute standard OData OData execution
-	req, err := http.NewRequestWithContext(ctx, t.Method, parsedURL.String(), bytes.NewReader(bodyBytes))
+	// 4. Execute standard OData execution
+	method := t.Method
+	if source.Compatibility().UseTunnelingHeaders && (method == "PUT" || method == "PATCH" || method == "MERGE" || method == "DELETE") {
+		method = "POST"
+	}
+	req, err := http.NewRequestWithContext(ctx, method, parsedURL.String(), bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, util.NewClientServerError("error creating http request", http.StatusInternalServerError, err)
+	}
+	if source.Compatibility().UseTunnelingHeaders && method == "POST" && method != t.Method {
+		req.Header.Set("X-HTTP-Method", t.Method)
+		req.Header.Set("X-HTTP-Method-Override", t.Method)
 	}
 
 	req.Header.Set("Accept", "application/json")
@@ -242,12 +254,12 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		// OData v2
 		if d, ok := respMap["d"].(map[string]interface{}); ok {
 			if nextLink, hasNext := d["__next"]; hasNext {
-				respMap["_NOTICE"] = fmt.Sprintf("Results truncated by OData server pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
+				respMap["_NOTICE"] = fmt.Sprintf("Results truncated by OData Server Pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
 			}
 		}
 		// OData v4
 		if nextLink, hasNext := respMap["@odata.nextLink"]; hasNext {
-			respMap["_NOTICE"] = fmt.Sprintf("Results truncated by OData server pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
+			respMap["_NOTICE"] = fmt.Sprintf("Results truncated by OData Server Pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
 		}
 	}
 

--- a/internal/tools/odata/odata.go
+++ b/internal/tools/odata/odata.go
@@ -49,7 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 
 type compatibleSource interface {
 	HttpBaseURL() string
-	RunSAPRequest(*http.Request, tools.AccessToken) (any, error)
+	RunODataRequest(*http.Request, tools.AccessToken) (any, error)
 	Metadata() *odata.ODataMetadata
 	Compatibility() odata.CompatibilityConfig
 	UseClientAuthorization() bool
@@ -107,10 +107,10 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
-// applyODataFormatting automatically applies OData syntax transformations to values, incorporating SAP-specific compatibility flags.
+// applyODataFormatting automatically applies OData syntax transformations to values, incorporating OData-specific compatibility flags.
 func applyODataFormatting(value string, paramName string, paramType string, mdVersion string, isUrlParam bool, compat odata.CompatibilityConfig) string {
-	if compat.SapUrlQuoting {
-		// Intelligent Casing Heuristic for SAP
+	if compat.UrlQuoting {
+		// Intelligent Casing Heuristic for OData
 		upperNames := []string{"ID", "CODE", "CARRID", "CONNID", "KEY", "NUM", "CITY", "COUNTRY", "PLANT", "COMPANY", "CURRENCY"}
 		upper := strings.ToUpper(paramName)
 		shouldUpper := false
@@ -213,11 +213,11 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		var marshalErr error
 		bodyBytes, marshalErr = json.Marshal(payloadMap)
 		if marshalErr != nil {
-			return nil, util.NewAgentError("failed to serialize SAP request payload", marshalErr)
+			return nil, util.NewAgentError("failed to serialize OData request payload", marshalErr)
 		}
 	}
 
-	// 4. Execute standard SAP OData execution
+	// 4. Execute standard OData OData execution
 	req, err := http.NewRequestWithContext(ctx, t.Method, parsedURL.String(), bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, util.NewClientServerError("error creating http request", http.StatusInternalServerError, err)
@@ -232,22 +232,22 @@ func (t Tool) Invoke(ctx context.Context, resourceMgr tools.SourceProvider, para
 		req.Header.Set("Content-Type", cType)
 	}
 
-	resp, err := source.RunSAPRequest(req, accessToken)
+	resp, err := source.RunODataRequest(req, accessToken)
 	if err != nil {
 		return nil, util.ProcessGeneralError(err)
 	}
 
-	// Handle SAP Server Pagination warning
+	// Handle OData Server Pagination warning
 	if respMap, ok := resp.(map[string]interface{}); ok {
 		// OData v2
 		if d, ok := respMap["d"].(map[string]interface{}); ok {
 			if nextLink, hasNext := d["__next"]; hasNext {
-				respMap["_NOTICE"] = fmt.Sprintf("Results truncated by SAP server pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
+				respMap["_NOTICE"] = fmt.Sprintf("Results truncated by OData server pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
 			}
 		}
 		// OData v4
 		if nextLink, hasNext := respMap["@odata.nextLink"]; hasNext {
-			respMap["_NOTICE"] = fmt.Sprintf("Results truncated by SAP server pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
+			respMap["_NOTICE"] = fmt.Sprintf("Results truncated by OData server pagination. To get the next set, call again with $skiptoken extracted from this URL: %v", nextLink)
 		}
 	}
 

--- a/internal/tools/odata/odata_test.go
+++ b/internal/tools/odata/odata_test.go
@@ -291,9 +291,9 @@ func TestToolInvokePaginationV4(t *testing.T) {
 }
 
 type mockTunnelingSource struct {
-	baseURL    string
-	lastReq    *http.Request
-	useTunnel  bool
+	baseURL   string
+	lastReq   *http.Request
+	useTunnel bool
 }
 
 func (m *mockTunnelingSource) SourceType() string             { return "odata" }

--- a/internal/tools/odata/odata_test.go
+++ b/internal/tools/odata/odata_test.go
@@ -27,41 +27,41 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
 
-// mockSAPSource simulates an OData source for testing tool initialization
-type mockSAPSource struct {
+// mockODataSource simulates an OData source for testing tool initialization
+type mockODataSource struct {
 	baseURL  string
 	metadata *odata.ODataMetadata
 }
 
-func (m *mockSAPSource) SourceType() string {
+func (m *mockODataSource) SourceType() string {
 	return "odata"
 }
 
-func (m *mockSAPSource) ToConfig() sources.SourceConfig {
+func (m *mockODataSource) ToConfig() sources.SourceConfig {
 	return nil
 }
 
-func (m *mockSAPSource) HttpBaseURL() string {
+func (m *mockODataSource) HttpBaseURL() string {
 	return m.baseURL
 }
 
-func (m *mockSAPSource) RunSAPRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
+func (m *mockODataSource) RunODataRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
 	return map[string]interface{}{"d": map[string]interface{}{"results": []interface{}{}}}, nil
 }
 
-func (m *mockSAPSource) UseClientAuthorization() bool {
+func (m *mockODataSource) UseClientAuthorization() bool {
 	return false
 }
 
-func (m *mockSAPSource) Metadata() *odata.ODataMetadata {
+func (m *mockODataSource) Metadata() *odata.ODataMetadata {
 	return m.metadata
 }
 
-func (m *mockSAPSource) Compatibility() odata.CompatibilityConfig {
+func (m *mockODataSource) Compatibility() odata.CompatibilityConfig {
 	return odata.CompatibilityConfig{}
 }
 
-func (m *mockSAPSource) GetAuthTokenHeaderName() string {
+func (m *mockODataSource) GetAuthTokenHeaderName() string {
 	return "Authorization"
 }
 
@@ -83,19 +83,19 @@ func TestToolInitializationREAD(t *testing.T) {
 		},
 	}
 
-	mockSrc := &mockSAPSource{
-		baseURL:  "https://mock.sap/odata",
+	mockSrc := &mockODataSource{
+		baseURL:  "https://mock.OData/odata",
 		metadata: metadata,
 	}
 
 	srcs := map[string]sources.Source{
-		"my_mock_sap": mockSrc,
+		"my_mock_odata": mockSrc,
 	}
 
 	yamlDef := []byte(`
 name: read_sales
 type: odata
-source: my_mock_sap
+source: my_mock_odata
 entitySet: A_SalesOrder
 operation: READ
 description: Reads sales orders
@@ -115,13 +115,13 @@ description: Reads sales orders
 		t.Fatalf("Failed to initialize tool: %v", err)
 	}
 
-	sapTool := tool.(Tool)
-	if sapTool.Method != "GET" {
-		t.Errorf("Expected GET for READ operation, got %s", sapTool.Method)
+	ODataTool := tool.(Tool)
+	if ODataTool.Method != "GET" {
+		t.Errorf("Expected GET for READ operation, got %s", ODataTool.Method)
 	}
 
 	// Verify dynamic parameters
-	params, err := sapTool.GetParameters(srcs)
+	params, err := ODataTool.GetParameters(srcs)
 	if err != nil {
 		t.Fatalf("Failed to get parameters: %v", err)
 	}
@@ -153,7 +153,7 @@ description: Reads sales orders
 }
 
 func TestApplyODataFormatting(t *testing.T) {
-	compat := odata.CompatibilityConfig{SapUrlQuoting: true}
+	compat := odata.CompatibilityConfig{UrlQuoting: true}
 
 	// Test the heuristic auto-uppercasing
 	if applyODataFormatting("apple", "Currency", "string", "2.0", true, compat) != "'APPLE'" {
@@ -171,25 +171,25 @@ func TestApplyODataFormatting(t *testing.T) {
 	}
 }
 
-type mockSAPSourceWithResponse struct {
+type mockODataSourceWithResponse struct {
 	baseURL  string
 	metadata *odata.ODataMetadata
 	response any
 }
 
-func (m *mockSAPSourceWithResponse) SourceType() string             { return "odata" }
-func (m *mockSAPSourceWithResponse) ToConfig() sources.SourceConfig { return nil }
-func (m *mockSAPSourceWithResponse) HttpBaseURL() string            { return m.baseURL }
-func (m *mockSAPSourceWithResponse) RunSAPRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
+func (m *mockODataSourceWithResponse) SourceType() string             { return "odata" }
+func (m *mockODataSourceWithResponse) ToConfig() sources.SourceConfig { return nil }
+func (m *mockODataSourceWithResponse) HttpBaseURL() string            { return m.baseURL }
+func (m *mockODataSourceWithResponse) RunODataRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
 	return m.response, nil
 }
-func (m *mockSAPSourceWithResponse) UseClientAuthorization() bool   { return false }
-func (m *mockSAPSourceWithResponse) Metadata() *odata.ODataMetadata { return m.metadata }
-func (m *mockSAPSourceWithResponse) Compatibility() odata.CompatibilityConfig {
+func (m *mockODataSourceWithResponse) UseClientAuthorization() bool   { return false }
+func (m *mockODataSourceWithResponse) Metadata() *odata.ODataMetadata { return m.metadata }
+func (m *mockODataSourceWithResponse) Compatibility() odata.CompatibilityConfig {
 	return odata.CompatibilityConfig{}
 }
 
-func (m *mockSAPSourceWithResponse) GetAuthTokenHeaderName() string {
+func (m *mockODataSourceWithResponse) GetAuthTokenHeaderName() string {
 	return "Authorization"
 }
 
@@ -203,21 +203,21 @@ func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
 }
 
 func TestToolInvokePaginationV2(t *testing.T) {
-	mockSrc := &mockSAPSourceWithResponse{
-		baseURL: "https://mock.sap/odata",
+	mockSrc := &mockODataSourceWithResponse{
+		baseURL: "https://mock.OData/odata",
 		response: map[string]interface{}{
 			"d": map[string]interface{}{
 				"results": []interface{}{},
-				"__next":  "https://mock.sap/odata/A_SalesOrder?$skiptoken=123",
+				"__next":  "https://mock.OData/odata/A_SalesOrder?$skiptoken=123",
 			},
 		},
 	}
 
-	srcs := map[string]sources.Source{"my_mock_sap": mockSrc}
+	srcs := map[string]sources.Source{"my_mock_odata": mockSrc}
 	sp := &mockSourceProvider{sources: srcs}
 
 	cfg := Config{
-		Source:    "my_mock_sap",
+		Source:    "my_mock_odata",
 		EntitySet: "A_SalesOrder",
 		Operation: "READ",
 	}
@@ -243,19 +243,19 @@ func TestToolInvokePaginationV2(t *testing.T) {
 }
 
 func TestToolInvokePaginationV4(t *testing.T) {
-	mockSrc := &mockSAPSourceWithResponse{
-		baseURL: "https://mock.sap/odata",
+	mockSrc := &mockODataSourceWithResponse{
+		baseURL: "https://mock.OData/odata",
 		response: map[string]interface{}{
 			"value":           []interface{}{},
-			"@odata.nextLink": "https://mock.sap/odata/A_SalesOrder?$skiptoken=123",
+			"@odata.nextLink": "https://mock.OData/odata/A_SalesOrder?$skiptoken=123",
 		},
 	}
 
-	srcs := map[string]sources.Source{"my_mock_sap": mockSrc}
+	srcs := map[string]sources.Source{"my_mock_odata": mockSrc}
 	sp := &mockSourceProvider{sources: srcs}
 
 	cfg := Config{
-		Source:    "my_mock_sap",
+		Source:    "my_mock_odata",
 		EntitySet: "A_SalesOrder",
 		Operation: "READ",
 	}
@@ -281,4 +281,4 @@ func TestToolInvokePaginationV4(t *testing.T) {
 }
 
 // Dummy tests to satisfy the interface completely
-var _ sources.Source = &mockSAPSource{}
+var _ sources.Source = &mockODataSource{}

--- a/internal/tools/odata/odata_test.go
+++ b/internal/tools/odata/odata_test.go
@@ -84,7 +84,7 @@ func TestToolInitializationREAD(t *testing.T) {
 	}
 
 	mockSrc := &mockODataSource{
-		baseURL:  "https://mock.OData/odata",
+		baseURL:  "https://mock.odata.example.com",
 		metadata: metadata,
 	}
 
@@ -115,13 +115,13 @@ description: Reads sales orders
 		t.Fatalf("Failed to initialize tool: %v", err)
 	}
 
-	ODataTool := tool.(Tool)
-	if ODataTool.Method != "GET" {
-		t.Errorf("Expected GET for READ operation, got %s", ODataTool.Method)
+	odataTool := tool.(Tool)
+	if odataTool.Method != "GET" {
+		t.Errorf("Expected GET for READ operation, got %s", odataTool.Method)
 	}
 
 	// Verify dynamic parameters
-	params, err := ODataTool.GetParameters(srcs)
+	params, err := odataTool.GetParameters(srcs)
 	if err != nil {
 		t.Fatalf("Failed to get parameters: %v", err)
 	}
@@ -169,6 +169,16 @@ func TestApplyODataFormatting(t *testing.T) {
 	if applyODataFormatting("O'Brien", "LastName", "string", "2.0", true, compat) != "'O''Brien'" {
 		t.Errorf("Expected escaped quotes ''O''''Brien'' for LastName param, got %s", applyODataFormatting("O'Brien", "LastName", "string", "2.0", true, compat))
 	}
+	// Test partial quoting vs full quoting
+	if applyODataFormatting("'partial", "LastName", "string", "2.0", true, compat) != "'''partial'" {
+		t.Errorf("Expected partial leading quote to be escaped and quoted, got %s", applyODataFormatting("'partial", "LastName", "string", "2.0", true, compat))
+	}
+	if applyODataFormatting("partial'", "LastName", "string", "2.0", true, compat) != "'partial'''" {
+		t.Errorf("Expected partial trailing quote to be escaped and quoted, got %s", applyODataFormatting("partial'", "LastName", "string", "2.0", true, compat))
+	}
+	if applyODataFormatting("'fully_quoted'", "LastName", "string", "2.0", true, compat) != "'fully_quoted'" {
+		t.Errorf("Expected fully quoted string to remain unchanged, got %s", applyODataFormatting("'fully_quoted'", "LastName", "string", "2.0", true, compat))
+	}
 }
 
 type mockODataSourceWithResponse struct {
@@ -204,11 +214,11 @@ func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
 
 func TestToolInvokePaginationV2(t *testing.T) {
 	mockSrc := &mockODataSourceWithResponse{
-		baseURL: "https://mock.OData/odata",
+		baseURL: "https://mock.odata.example.com",
 		response: map[string]interface{}{
 			"d": map[string]interface{}{
 				"results": []interface{}{},
-				"__next":  "https://mock.OData/odata/A_SalesOrder?$skiptoken=123",
+				"__next":  "https://mock.odata.example.com/A_SalesOrder?$skiptoken=123",
 			},
 		},
 	}
@@ -244,10 +254,10 @@ func TestToolInvokePaginationV2(t *testing.T) {
 
 func TestToolInvokePaginationV4(t *testing.T) {
 	mockSrc := &mockODataSourceWithResponse{
-		baseURL: "https://mock.OData/odata",
+		baseURL: "https://mock.odata.example.com",
 		response: map[string]interface{}{
 			"value":           []interface{}{},
-			"@odata.nextLink": "https://mock.OData/odata/A_SalesOrder?$skiptoken=123",
+			"@odata.nextLink": "https://mock.odata.example.com/A_SalesOrder?$skiptoken=123",
 		},
 	}
 
@@ -277,6 +287,63 @@ func TestToolInvokePaginationV4(t *testing.T) {
 	notice, ok := respMap["_NOTICE"].(string)
 	if !ok || !strings.Contains(notice, "$skiptoken") {
 		t.Errorf("Expected pagination notice, got: %v", respMap["_NOTICE"])
+	}
+}
+
+type mockTunnelingSource struct {
+	baseURL    string
+	lastReq    *http.Request
+	useTunnel  bool
+}
+
+func (m *mockTunnelingSource) SourceType() string             { return "odata" }
+func (m *mockTunnelingSource) ToConfig() sources.SourceConfig { return nil }
+func (m *mockTunnelingSource) HttpBaseURL() string            { return m.baseURL }
+func (m *mockTunnelingSource) RunODataRequest(req *http.Request, accessToken tools.AccessToken) (any, error) {
+	m.lastReq = req
+	return map[string]interface{}{"status": "ok"}, nil
+}
+func (m *mockTunnelingSource) UseClientAuthorization() bool   { return false }
+func (m *mockTunnelingSource) Metadata() *odata.ODataMetadata { return nil }
+func (m *mockTunnelingSource) Compatibility() odata.CompatibilityConfig {
+	return odata.CompatibilityConfig{UseTunnelingHeaders: m.useTunnel}
+}
+func (m *mockTunnelingSource) GetAuthTokenHeaderName() string { return "Authorization" }
+
+func TestUseTunnelingHeaders(t *testing.T) {
+	mockSrc := &mockTunnelingSource{
+		baseURL:   "https://mock.odata.example.com",
+		useTunnel: true,
+	}
+	srcs := map[string]sources.Source{"my_mock_odata": mockSrc}
+	sp := &mockSourceProvider{sources: srcs}
+
+	cfg := Config{
+		Source:    "my_mock_odata",
+		EntitySet: "A_SalesOrder",
+		Operation: "UPDATE",
+	}
+	tool := Tool{
+		BaseTool: tools.NewBaseTool(cfg, tools.NewDestructiveAnnotations(), tools.Manifest{Description: cfg.Description, AuthRequired: cfg.AuthRequired}, cfg.QueryParams),
+		Method:   "PATCH",
+	}
+
+	_, err := tool.Invoke(context.Background(), sp, parameters.ParamValues{}, "")
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+
+	if mockSrc.lastReq == nil {
+		t.Fatalf("Expected HTTP request to be executed")
+	}
+	if mockSrc.lastReq.Method != "POST" {
+		t.Errorf("Expected method POST with tunneling enabled, got %s", mockSrc.lastReq.Method)
+	}
+	if got := mockSrc.lastReq.Header.Get("X-HTTP-Method"); got != "PATCH" {
+		t.Errorf("Expected X-HTTP-Method: PATCH header, got %s", got)
+	}
+	if got := mockSrc.lastReq.Header.Get("X-HTTP-Method-Override"); got != "PATCH" {
+		t.Errorf("Expected X-HTTP-Method-Override: PATCH header, got %s", got)
 	}
 }
 

--- a/tests/odata/odata_integration_test.go
+++ b/tests/odata/odata_integration_test.go
@@ -31,19 +31,19 @@ import (
 )
 
 func TestMockODataNativeEndpoints(t *testing.T) {
-	// Setup mock server simulating SAP Gateway
+	// Setup mock server simulating OData Gateway
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Metadata endpoint
-		if r.URL.Path == "/sap/opu/odata/sap/API_SALES_ORDER_SRV/$metadata" {
+		if r.URL.Path == "/odata/v2/SalesOrderService/$metadata" {
 			w.Header().Set("Content-Type", "application/xml")
 			_, _ = w.Write([]byte(`<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"><edmx:DataServices m:DataServiceVersion="2.0" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><Schema Namespace="API_SALES_ORDER_SRV" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityContainer Name="API_SALES_ORDER_SRV_Entities" m:IsDefaultEntityContainer="true"><EntitySet Name="A_SalesOrder" EntityType="API_SALES_ORDER_SRV.A_SalesOrderType"/></EntityContainer><EntityType Name="A_SalesOrderType"><Key><PropertyRef Name="SalesOrder"/></Key><Property Name="SalesOrder" Type="Edm.String" Nullable="false" MaxLength="10"/><Property Name="SalesOrderType" Type="Edm.String" Nullable="false" MaxLength="4"/><Property Name="SoldToParty" Type="Edm.String" Nullable="false" MaxLength="10"/></EntityType></Schema></edmx:DataServices></edmx:Edmx>`))
 			return
 		}
 		// Entity set read endpoint
-		if r.URL.Path == "/sap/opu/odata/sap/API_SALES_ORDER_SRV/A_SalesOrder" {
-			if r.Header.Get("X-SAP-Auth") == "" {
+		if r.URL.Path == "/odata/v2/SalesOrderService/A_SalesOrder" {
+			if r.Header.Get("X-OData-Token") == "" {
 				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte(`{"error":"unauthorized: missing X-SAP-Auth"}`))
+				_, _ = w.Write([]byte(`{"error":"unauthorized: missing X-OData-Token"}`))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -60,17 +60,17 @@ func TestMockODataNativeEndpoints(t *testing.T) {
 
 	toolsFile := map[string]any{
 		"sources": map[string]any{
-			"mock-sap-source": map[string]any{
+			"mock-odata-source": map[string]any{
 				"type":           "odata",
-				"baseUrl":        ts.URL + "/sap/opu/odata/sap/API_SALES_ORDER_SRV",
-				"authStrategy":   "sap-gateway",
-				"useClientOauth": "X-SAP-Auth",
+				"baseUrl":        ts.URL + "/odata/v2/SalesOrderService",
+				"authStrategy":   "gateway",
+				"useClientOauth": "X-OData-Token",
 			},
 		},
 		"tools": map[string]any{
 			"read-sales-order": map[string]any{
 				"type":        "odata",
-				"source":      "mock-sap-source",
+				"source":      "mock-odata-source",
 				"entitySet":   "A_SalesOrder",
 				"operation":   "READ",
 				"description": "Read Sales Orders",

--- a/tests/odata/odata_mcp_test.go
+++ b/tests/odata/odata_mcp_test.go
@@ -174,7 +174,7 @@ func TestMockODataMCPEndpoints(t *testing.T) {
 	// 2. MCP Tool Call Success
 	t.Run("MCP Tool Call Success", func(t *testing.T) {
 		headers := map[string]string{
-			"X-OData-Token":     "Bearer mock-oauth-token",
+			"X-OData-Token":  "Bearer mock-oauth-token",
 			"Mcp-Session-Id": sessionID,
 		}
 

--- a/tests/odata/odata_mcp_test.go
+++ b/tests/odata/odata_mcp_test.go
@@ -28,22 +28,22 @@ import (
 )
 
 func TestMockODataMCPEndpoints(t *testing.T) {
-	// Setup mock server simulating SAP Gateway
+	// Setup mock server simulating OData Gateway
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/sap/opu/odata/sap/API_SALES_ORDER_SRV/$metadata" {
+		if r.URL.Path == "/odata/v2/SalesOrderService/$metadata" {
 			w.Header().Set("Content-Type", "application/xml")
 			_, _ = w.Write([]byte(`<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"><edmx:DataServices m:DataServiceVersion="2.0" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><Schema Namespace="API_SALES_ORDER_SRV" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityContainer Name="API_SALES_ORDER_SRV_Entities" m:IsDefaultEntityContainer="true"><EntitySet Name="A_SalesOrder" EntityType="API_SALES_ORDER_SRV.A_SalesOrderType"/></EntityContainer><EntityType Name="A_SalesOrderType"><Key><PropertyRef Name="SalesOrder"/></Key><Property Name="SalesOrder" Type="Edm.String" Nullable="false" MaxLength="10"/><Property Name="SalesOrderType" Type="Edm.String" Nullable="false" MaxLength="4"/><Property Name="SoldToParty" Type="Edm.String" Nullable="false" MaxLength="10"/></EntityType></Schema></edmx:DataServices></edmx:Edmx>`))
 			return
 		}
-		if r.URL.Path == "/sap/opu/odata/iwfnd/RMTSAMPLEFLIGHT/$metadata" {
+		if r.URL.Path == "/odata/v2/SampleFlightService/$metadata" {
 			w.Header().Set("Content-Type", "application/xml")
 			_, _ = w.Write([]byte(`<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"><edmx:DataServices m:DataServiceVersion="2.0" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><Schema Namespace="RMTSAMPLEFLIGHT" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityContainer Name="RMTSAMPLEFLIGHT_Entities" m:IsDefaultEntityContainer="true"><FunctionImport Name="CheckFlightAvailability" ReturnType="RMTSAMPLEFLIGHT.FlightAvailability" HttpMethod="GET"><Parameter Name="airlineid" Type="Edm.String" Mode="In"/><Parameter Name="connectionid" Type="Edm.String" Mode="In"/><Parameter Name="flightdate" Type="Edm.DateTime" Mode="In"/></FunctionImport></EntityContainer></Schema></edmx:DataServices></edmx:Edmx>`))
 			return
 		}
-		if r.URL.Path == "/sap/opu/odata/sap/API_SALES_ORDER_SRV/A_SalesOrder" {
-			if r.Header.Get("X-SAP-Auth") == "" {
+		if r.URL.Path == "/odata/v2/SalesOrderService/A_SalesOrder" {
+			if r.Header.Get("X-OData-Token") == "" {
 				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte(`{"error":"unauthorized: missing X-SAP-Auth"}`))
+				_, _ = w.Write([]byte(`{"error":"unauthorized: missing X-OData-Token"}`))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -60,30 +60,30 @@ func TestMockODataMCPEndpoints(t *testing.T) {
 
 	toolsFile := map[string]any{
 		"sources": map[string]any{
-			"mock-sap-source": map[string]any{
+			"mock-odata-source": map[string]any{
 				"type":           "odata",
-				"baseUrl":        ts.URL + "/sap/opu/odata/sap/API_SALES_ORDER_SRV",
-				"authStrategy":   "sap-gateway",
-				"useClientOauth": "X-SAP-Auth",
+				"baseUrl":        ts.URL + "/odata/v2/SalesOrderService",
+				"authStrategy":   "gateway",
+				"useClientOauth": "X-OData-Token",
 			},
-			"mock-sap-flight-source": map[string]any{
+			"mock-odata-flight-source": map[string]any{
 				"type":           "odata",
-				"baseUrl":        ts.URL + "/sap/opu/odata/iwfnd/RMTSAMPLEFLIGHT",
-				"authStrategy":   "sap-gateway",
-				"useClientOauth": "X-SAP-Auth",
+				"baseUrl":        ts.URL + "/odata/v2/SampleFlightService",
+				"authStrategy":   "gateway",
+				"useClientOauth": "X-OData-Token",
 			},
 		},
 		"tools": map[string]any{
 			"read-sales-order": map[string]any{
 				"type":        "odata",
-				"source":      "mock-sap-source",
+				"source":      "mock-odata-source",
 				"entitySet":   "A_SalesOrder",
 				"operation":   "READ",
 				"description": "Read Sales Orders",
 			},
 			"create-sales-order": map[string]any{
 				"type":        "odata",
-				"source":      "mock-sap-source",
+				"source":      "mock-odata-source",
 				"entitySet":   "A_SalesOrder",
 				"operation":   "CREATE",
 				"description": "Create Sales Order",
@@ -94,7 +94,7 @@ func TestMockODataMCPEndpoints(t *testing.T) {
 			},
 			"check-flight-availability": map[string]any{
 				"type":        "odata",
-				"source":      "mock-sap-flight-source",
+				"source":      "mock-odata-flight-source",
 				"entitySet":   "CheckFlightAvailability",
 				"operation":   "FUNCTION_IMPORT",
 				"description": "Check Flight Availability",
@@ -174,7 +174,7 @@ func TestMockODataMCPEndpoints(t *testing.T) {
 	// 2. MCP Tool Call Success
 	t.Run("MCP Tool Call Success", func(t *testing.T) {
 		headers := map[string]string{
-			"X-SAP-Auth":     "Bearer mock-oauth-token",
+			"X-OData-Token":     "Bearer mock-oauth-token",
 			"Mcp-Session-Id": sessionID,
 		}
 


### PR DESCRIPTION
## Description

Refactors the OData source and tool implementation to be 100% protocol-generic:
- Renames gateway strategy (`csrf_strategy` / `gateway_strategy`) and configuration options (`authStrategy: "gateway"`, `urlQuoting`).
- Removes all vendor-specific (`SAP`) terminology from sources, tools, tests, and documentation.
- Updates test mocks (`mockODataSource`) to satisfy `compatibleSource`.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
