### PR TITLE
docs: add Python SDK usage examples for URL parameter binding

### DIFF
--- a/docs/en/documentation/configuration/tools/_index.md
+++ b/docs/en/documentation/configuration/tools/_index.md
@@ -342,6 +342,12 @@ Annotations appear in the `tools/list` MCP response:
 }
 ```
 
+## URL Parameter Binding
+
+You can bind specific arguments to tools at the transport level using URL query parameters. This allows you to restrict clients to specific database instances, projects, or environments dynamically without modifying the server configuration.
+
+For a comprehensive guide, see the [URL Parameter Binding](./url_parameter_binding.md) documentation.
+
 ## Using tools with MCP Toolbox Client SDKs
 
 Once your tools are defined in your configuration, you can retrieve them directly from your application code.

--- a/docs/en/documentation/configuration/tools/url_parameter_binding.md
+++ b/docs/en/documentation/configuration/tools/url_parameter_binding.md
@@ -88,6 +88,27 @@ The client calls the tool without providing `project` in the body:
 
 The server automatically injects `project: "my-project"` and executes the tool.
 
+## Using with MCP Toolbox Client SDKs
+
+When using the MCP Toolbox Client SDKs, you can pass URL parameters directly in the server connection string. The SDK will automatically retain these parameters when communicating with the server.
+
+### Python
+
+```python
+from toolbox_core import ToolboxClient
+
+# Initialize the client with the full scoped connection string
+# The `project` parameter will be sent with all MCP requests
+client = ToolboxClient("http://localhost:5000?project=my-project")
+
+# When loading tools, the 'project' parameter is automatically omitted 
+# from the required schema by the server
+tool = await client.load_tool("my_tool")
+
+# The server will automatically inject `project: "my-project"` upon execution
+result = await tool(other_param="value")
+```
+
 ## Safety Warning
 
 > [!WARNING]


### PR DESCRIPTION
## Overview
This PR updages docs for the URL Parameter Binding feature by showing how it can be utilized through the Python SDK clients, ensuring a smoother UX. 

## Changes
* Added a new "Using with MCP Toolbox Client SDKs" section.
  * This includes concrete code snippets demonstrating how to append query parameters to the connection string when initializing a `ToolboxClient`.
* Added a dedicated section linking to the URL Parameter Binding page to improve feature discoverability from the main Tools configuration index.

> [!NOTE]
> Depends on SDK updates in https://github.com/googleapis/mcp-toolbox-sdk-python/pull/717.
