### PR TITLE
docs: update hugo for release

### DIFF
--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -80,6 +80,10 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 # The order of versions in this file is mirrored into the dropdown
 
 [[params.versions]]
+  version = "v1.7.0"
+  url = "https://mcp-toolbox.dev/v1.7.0/"
+
+[[params.versions]]
   version = "v1.6.0"
   url = "https://mcp-toolbox.dev/v1.6.0/"
 

--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -64,6 +64,10 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
 # The order of versions in this file is mirrored into the dropdown
 
 [[params.versions]]
+  version = "v1.7.0"
+  url = "https://mcp-toolbox.dev/v1.7.0/"
+
+[[params.versions]]
   version = "v1.6.0"
   url = "https://mcp-toolbox.dev/v1.6.0/"
 


### PR DESCRIPTION
Skipped removing v1.0.0 docs from cloudflare since it seems like it will not be exceeding 20k files in deployment