### PR TITLE
fix(config): reject duplicate flat primitive names

### DIFF
--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -853,6 +853,33 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsDuplicatePrimitiveNames(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	raw := []byte(`kind: authService
+name: duplicate
+type: google
+clientId: first
+---
+kind: authService
+name: duplicate
+type: google
+clientId: second
+`)
+
+	parser := ConfigParser{}
+	_, err = parser.ParseConfig(ctx, raw)
+	if err == nil {
+		t.Fatal("ParseConfig() accepted duplicate authService names")
+	}
+	want := `document 2 (line 7, column 1): duplicate authService name "duplicate"`
+	if err.Error() != want {
+		t.Fatalf("ParseConfig() error = %q, want %q", err, want)
+	}
+}
+
 func TestParseConfigWithAuth(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
 	if err != nil {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -179,6 +179,7 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 	}
 
 	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	seenPrimitiveNames := make(map[string]map[string]struct{})
 	for index, doc := range file.Docs {
 		if doc == nil || doc.Body == nil {
 			continue
@@ -221,6 +222,9 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 				}
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
+			if err := registerPrimitiveName(seenPrimitiveNames, kind, name, docIndex, doc.Body); err != nil {
+				return nil, nil, nil, nil, nil, nil, err
+			}
 			if sourceConfigs == nil {
 				sourceConfigs = make(SourceConfigs)
 			}
@@ -232,6 +236,9 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
 				}
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
+			}
+			if err := registerPrimitiveName(seenPrimitiveNames, kind, name, docIndex, doc.Body); err != nil {
+				return nil, nil, nil, nil, nil, nil, err
 			}
 			if authServiceConfigs == nil {
 				authServiceConfigs = make(AuthServiceConfigs)
@@ -248,6 +255,9 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 			if c == nil {
 				continue
 			}
+			if err := registerPrimitiveName(seenPrimitiveNames, kind, name, docIndex, doc.Body); err != nil {
+				return nil, nil, nil, nil, nil, nil, err
+			}
 			if toolConfigs == nil {
 				toolConfigs = make(ToolConfigs)
 			}
@@ -259,6 +269,9 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
 				}
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
+			}
+			if err := registerPrimitiveName(seenPrimitiveNames, kind, name, docIndex, doc.Body); err != nil {
+				return nil, nil, nil, nil, nil, nil, err
 			}
 			if toolsetConfigs == nil {
 				toolsetConfigs = make(ToolsetConfigs)
@@ -272,6 +285,9 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 				}
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
 			}
+			if err := registerPrimitiveName(seenPrimitiveNames, kind, name, docIndex, doc.Body); err != nil {
+				return nil, nil, nil, nil, nil, nil, err
+			}
 			if embeddingModelConfigs == nil {
 				embeddingModelConfigs = make(EmbeddingModelConfigs)
 			}
@@ -283,6 +299,9 @@ func UnmarshalPrimitiveConfig(ctx context.Context, raw []byte) (SourceConfigs, A
 					return nil, nil, nil, nil, nil, nil, fmt.Errorf("document %d: error unmarshaling %s %q: %w", docIndex, kind, name, err)
 				}
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("error unmarshaling %s: %w", kind, err)
+			}
+			if err := registerPrimitiveName(seenPrimitiveNames, kind, name, docIndex, doc.Body); err != nil {
+				return nil, nil, nil, nil, nil, nil, err
 			}
 			if promptConfigs == nil {
 				promptConfigs = make(PromptConfigs)
@@ -564,5 +583,18 @@ func keyToken(body ast.Node, key string) *token.Token {
 			return token
 		}
 	}
+	return nil
+}
+
+func registerPrimitiveName(seen map[string]map[string]struct{}, kind, name string, docIndex int, body ast.Node) error {
+	names := seen[kind]
+	if _, exists := names[name]; exists {
+		return fmt.Errorf("%s duplicate %s name %q", formatDocLocation(docIndex, keyToken(body, "name"), body), kind, name)
+	}
+	if names == nil {
+		names = make(map[string]struct{})
+		seen[kind] = names
+	}
+	names[name] = struct{}{}
 	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1245,6 +1245,47 @@ mcpEnabled: true
 	}
 }
 
+func TestUnmarshalPrimitiveConfigRejectsDuplicateNames(t *testing.T) {
+	ctx := context.Background()
+	raw := []byte(`kind: authService
+name: duplicate
+type: google
+clientId: first
+---
+kind: authService
+name: duplicate
+type: google
+clientId: second
+`)
+
+	_, _, _, _, _, _, err := server.UnmarshalPrimitiveConfig(ctx, raw)
+	if err == nil {
+		t.Fatal("UnmarshalPrimitiveConfig() accepted duplicate authService names")
+	}
+	want := `document 2 (line 7, column 1): duplicate authService name "duplicate"`
+	if err.Error() != want {
+		t.Fatalf("UnmarshalPrimitiveConfig() error = %q, want %q", err, want)
+	}
+}
+
+func TestUnmarshalPrimitiveConfigAllowsNameAcrossKinds(t *testing.T) {
+	ctx := context.Background()
+	raw := []byte(`kind: authService
+name: shared
+type: google
+clientId: test
+---
+kind: toolset
+name: shared
+tools: []
+`)
+
+	_, _, _, _, _, _, err := server.UnmarshalPrimitiveConfig(ctx, raw)
+	if err != nil {
+		t.Fatalf("UnmarshalPrimitiveConfig() rejected a name shared across kinds: %v", err)
+	}
+}
+
 func TestGenericAuthConfigValidation(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

Flat-format configuration files currently allow a later primitive with the same kind and name to silently overwrite the earlier definition. This change tracks successfully unmarshaled primitive names per kind and fails at the second definition with its YAML document, line, and column.

The validation remains kind-scoped, so resources of different kinds can continue to share a name. Unknown tools skipped through `ignoreUnknownTools` are not registered and retain the existing behavior.

## Validation

- Unit: `TestUnmarshalPrimitiveConfigRejectsDuplicateNames`
- Compatibility: `TestUnmarshalPrimitiveConfigAllowsNameAcrossKinds`
- Integration: `TestParseConfigRejectsDuplicatePrimitiveNames`
- `go test -race ./internal/server ./cmd/internal`
- `go test -cover ./internal/server ./cmd/internal` (62.0% statements in both packages)
- `go vet ./internal/server ./cmd/internal`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`

`golangci-lint` was not available locally and is left to CI.

## PR Checklist

- [x] Reviewed CONTRIBUTING.md
- [x] Existing issue describes and scopes the change
- [x] Relevant tests and available local static checks pass
- [x] Code coverage does not decrease
- [x] No documentation update is necessary
- [x] This is not a breaking change

## AI assistance

Codex assisted with issue investigation, implementation, and test execution. The resulting patch and validation output were reviewed before submission.

Fixes #3648
