### PR TITLE
fix: update notice message

### DIFF
--- a/internal/sources/odata/odata.go
+++ b/internal/sources/odata/odata.go
@@ -194,11 +194,11 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	// Attempt initial metadata fetch at startup; if unauthenticated (e.g. user OAuth token required), lazy-load on first request.
 	if err := source.fetchMetadata(ctx, ""); err != nil {
-		logger, err := util.LoggerFromContext(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
+		logger, logErr := util.LoggerFromContext(ctx)
+		if logErr != nil {
+			return nil, fmt.Errorf("unable to get logger from ctx: %w", logErr)
 		}
-		noticeMsg := fmt.Sprintf("Notice: SAP OData metadata will be lazily fetched on first user request: %v\n", err)
+		noticeMsg := fmt.Sprintf("Notice: SAP OData metadata will be lazily fetched on first user request: %v", err)
 		logger.InfoContext(ctx, noticeMsg)
 	}
 

--- a/internal/sources/odata/odata.go
+++ b/internal/sources/odata/odata.go
@@ -194,7 +194,12 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	// Attempt initial metadata fetch at startup; if unauthenticated (e.g. user OAuth token required), lazy-load on first request.
 	if err := source.fetchMetadata(ctx, ""); err != nil {
-		fmt.Printf("Notice: SAP OData metadata will be lazily fetched on first user request: %v\n", err)
+		logger, err := util.LoggerFromContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
+		}
+		noticeMsg := fmt.Sprintf("Notice: SAP OData metadata will be lazily fetched on first user request: %v\n", err)
+		logger.InfoContext(ctx, noticeMsg)
 	}
 
 	return source, nil

--- a/internal/sources/odata/odata_test.go
+++ b/internal/sources/odata/odata_test.go
@@ -61,7 +61,7 @@ func TestParseFromYamlOData(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, _, _, _, _, _, err := server.UnmarshalResourceConfig(context.Background(), testutils.FormatYaml(tc.in))
+			got, _, _, _, _, _, err := server.UnmarshalPrimitiveConfig(context.Background(), testutils.FormatYaml(tc.in))
 			if err != nil {
 				t.Fatalf("unable to unmarshal: %s", err)
 			}
@@ -113,7 +113,7 @@ func TestFailParseFromYaml(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, _, _, _, _, _, err := server.UnmarshalResourceConfig(context.Background(), testutils.FormatYaml(tc.in))
+			_, _, _, _, _, _, err := server.UnmarshalPrimitiveConfig(context.Background(), testutils.FormatYaml(tc.in))
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.err)
 			}


### PR DESCRIPTION
This PR updates the notice message to an Info log. Using `fmt.Printf` directly will cause an error if user is using the stdio transport protocol. 