### PR TITLE
fix(server): set ReadHeaderTimeout to prevent Slowloris attacks

### DIFF
--- a/internal/server/constants.go
+++ b/internal/server/constants.go
@@ -14,5 +14,13 @@
 
 package server
 
+import "time"
+
 // DefaultHTTPMaxRequestBytes is the default max size (in bytes) for MCP HTTP request bodies.
 const DefaultHTTPMaxRequestBytes int64 = 10 << 20
+
+// DefaultReadHeaderTimeout is the maximum time allowed to receive the complete
+// HTTP request header from a client. A short deadline prevents Slowloris
+// attacks where an attacker trickles headers to hold connections open
+// indefinitely without consuming server resources for legitimate requests.
+const DefaultReadHeaderTimeout = 10 * time.Second

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -447,7 +447,11 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*Server, error) {
 	}
 
 	addr := net.JoinHostPort(cfg.Address, strconv.Itoa(cfg.Port))
-	srv := &http.Server{Addr: addr, Handler: r}
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           r,
+		ReadHeaderTimeout: DefaultReadHeaderTimeout,
+	}
 
 	sseManager := newSseManager(ctx)
 

--- a/internal/server/timeouts_test.go
+++ b/internal/server/timeouts_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+// Internal-package tests for HTTP server timeout configuration.
+// The internal package is used so tests can inspect the unexported srv field.
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/googleapis/mcp-toolbox/internal/log"
+	"github.com/googleapis/mcp-toolbox/internal/telemetry"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+// TestHTTPServerReadHeaderTimeoutIsSet verifies that NewServer sets a non-zero
+// ReadHeaderTimeout on the underlying http.Server to prevent Slowloris attacks.
+// Without ReadHeaderTimeout an attacker can trickle request headers
+// indefinitely, consuming a goroutine per connection until the server is
+// exhausted.
+//
+// ReadTimeout is intentionally omitted: in Go, http.Server.ReadTimeout sets an
+// absolute read deadline that is not cleared when the handler starts. The
+// server's background connection-monitoring goroutine then hits that deadline
+// and cancels r.Context(), prematurely terminating SSE streams after the
+// timeout period regardless of active subscribers.
+func TestHTTPServerReadHeaderTimeoutIsSet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
+	if err != nil {
+		t.Fatalf("unexpected error creating logger: %s", err)
+	}
+	ctx = util.WithLogger(ctx, testLogger)
+
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation("0.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error creating instrumentation: %s", err)
+	}
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+
+	cfg := ServerConfig{
+		Version:      "0.0.0",
+		Address:      "127.0.0.1",
+		Port:         0,
+		AllowedHosts: []string{"*"},
+	}
+
+	s, err := NewServer(ctx, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error from NewServer: %s", err)
+	}
+
+	if s.srv.ReadHeaderTimeout == 0 {
+		t.Error("srv.ReadHeaderTimeout is 0: server is vulnerable to Slowloris attacks")
+	}
+	if s.srv.ReadHeaderTimeout != DefaultReadHeaderTimeout {
+		t.Errorf("srv.ReadHeaderTimeout = %v, want %v", s.srv.ReadHeaderTimeout, DefaultReadHeaderTimeout)
+	}
+
+	if s.srv.ReadTimeout != 0 {
+		t.Errorf("srv.ReadTimeout = %v, want 0: a non-zero ReadTimeout breaks SSE streams", s.srv.ReadTimeout)
+	}
+}


### PR DESCRIPTION
## Problem

`NewServer` created an `http.Server` with no read timeouts, leaving the
server vulnerable to Slowloris attacks: an attacker opens many connections
and trickles HTTP headers indefinitely, holding a goroutine per connection
until the server is exhausted.

## Fix

Set `ReadHeaderTimeout` on the `http.Server`. This closes the Slowloris
window (which targets the header phase) without affecting in-flight requests
or SSE streams.

`ReadTimeout` is **intentionally omitted**. In Go, `http.Server.ReadTimeout`
sets an absolute read deadline on the underlying TCP connection that is
*not* cleared when the request handler starts. The server's background
goroutine (used to detect client disconnects via `io.ReadAll`) hits that
deadline and cancels `r.Context()`, prematurely terminating SSE streams
after the timeout period. `ReadHeaderTimeout` alone is sufficient.

## Changes

| File | Change |
|---|---|
| `internal/server/constants.go` | Add `DefaultReadHeaderTimeout = 10s` |
| `internal/server/server.go` | Set `ReadHeaderTimeout` on `http.Server`; omit `ReadTimeout` |
| `internal/server/timeouts_test.go` | Assert `ReadHeaderTimeout` is set; assert `ReadTimeout` is zero |

## Test plan

- [ ] `go test ./internal/server/... -run TestHTTPServerReadHeaderTimeoutIsSet -v`
- [ ] Manual: start the server and verify SSE connections are not terminated after 10 s