### PR TITLE
chore: add resultType to draft specs results

### DIFF
--- a/internal/server/mcp/vdraft/manifests.go
+++ b/internal/server/mcp/vdraft/manifests.go
@@ -114,6 +114,9 @@ func GenerateListToolsResult(srcs map[string]sources.Source, t tools.Toolset, to
 	}
 	res := ListToolsResult{
 		Tools: mcpManifest,
+		Result: Result{
+			ResultType: resultTypeComplete,
+		},
 		CacheableResult: CacheableResult{
 			TtlMs:      300000, // 5 minutes
 			CacheScope: cacheScopePublic,
@@ -153,6 +156,9 @@ func GenerateListPromptsResult(p prompts.Promptset, promptsMap map[string]prompt
 	}
 	res := ListPromptsResult{
 		Prompts: mcpManifest,
+		Result: Result{
+			ResultType: resultTypeComplete,
+		},
 		CacheableResult: CacheableResult{
 			TtlMs:      300000, // 5 minutes
 			CacheScope: cacheScopePublic,

--- a/internal/server/mcp/vdraft/manifests_test.go
+++ b/internal/server/mcp/vdraft/manifests_test.go
@@ -254,6 +254,9 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}
 	want := ListToolsResult{
+		Result: Result{
+			ResultType: resultTypeComplete,
+		},
 		CacheableResult: CacheableResult{
 			TtlMs:      300000,
 			CacheScope: cacheScopePublic,
@@ -371,6 +374,9 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		t.Fatalf("unable to generate list prompt result: %s", err)
 	}
 	want := ListPromptsResult{
+		Result: Result{
+			ResultType: resultTypeComplete,
+		},
 		CacheableResult: CacheableResult{
 			TtlMs:      300000,
 			CacheScope: cacheScopePublic,

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -145,6 +145,9 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 	toolsListChanged := false
 	promptsListChanged := false
 	result := DiscoverResult{
+		Result: Result{
+			ResultType: resultTypeComplete,
+		},
 		SupportedVersions: mcputil.GetSupportedVersions(enableDraft),
 		Capabilities: ServerCapabilities{
 			Tools: &ListChanged{
@@ -416,7 +419,13 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 				return jsonrpc.JSONRPCResponse{
 					Jsonrpc: jsonrpc.JSONRPC_VERSION,
 					Id:      id,
-					Result:  CallToolResult{Content: []TextContent{text}, IsError: true},
+					Result: CallToolResult{
+						Result: Result{
+							ResultType: resultTypeComplete,
+						},
+						Content: []TextContent{text},
+						IsError: true,
+					},
 				}, nil
 
 			case util.CategoryServer:
@@ -463,7 +472,12 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	return jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,
 		Id:      id,
-		Result:  CallToolResult{Content: content},
+		Result: CallToolResult{
+			Result: Result{
+				ResultType: resultTypeComplete,
+			},
+			Content: content,
+		},
 	}, nil
 }
 
@@ -589,6 +603,9 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prom
 	}
 
 	result := GetPromptResult{
+		Result: Result{
+			ResultType: resultTypeComplete,
+		},
 		Description: prompt.Manifest().Description,
 		Messages:    promptMessages,
 	}

--- a/internal/server/mcp/vdraft/types.go
+++ b/internal/server/mcp/vdraft/types.go
@@ -118,7 +118,7 @@ type DiscoverRequest struct {
 
 // The result returned by the server for a {@link DiscoverRequest | server/discover} request.
 type DiscoverResult struct {
-	jsonrpc.Result
+	Result
 	/**
 	 * MCP Protocol Versions this server supports. The client should choose a
 	 * version from this list for use in subsequent requests.
@@ -179,7 +179,7 @@ type ListChanged struct {
 /* Empty result */
 
 // EmptyResult represents a response that indicates success but carries no data.
-type EmptyResult jsonrpc.Result
+type EmptyResult Result
 
 /* Pagination */
 
@@ -242,6 +242,27 @@ type CacheableResult struct {
 	CacheScope cacheScope `json:"cacheScope"`
 }
 
+type resultType string
+
+const (
+	resultTypeComplete      resultType = "complete"       // the request completed successfully and the result contains the final content.
+	resultTypeInputRequired resultType = "input_required" // the request is incomplete and the result contains an {@link InputRequiredResult} object
+)
+
+type Result struct {
+	jsonrpc.Result
+	/**
+	* Indicates the type of the result, which allows the client to determine
+	* how to parse the result object.
+	*
+	* Servers implementing this protocol version MUST include this field.
+	* For backward compatibility, when a client receives a result from a
+	* server implementing an earlier protocol version (which does not include
+	* `resultType`), the client MUST treat the absent field as `"complete"`.
+	 */
+	ResultType resultType `json:"resultType"`
+}
+
 /* Tools */
 
 // Sent from the client to request a list of tools the server has.
@@ -251,7 +272,7 @@ type ListToolsRequest struct {
 
 // The server's response to a tools/list request from the client.
 type ListToolsResult struct {
-	jsonrpc.Result
+	Result
 	PaginatedResult
 	CacheableResult
 	Tools []Tool `json:"tools"`
@@ -346,7 +367,7 @@ type TextContent struct {
 // server does not support tool calls, or any other exceptional conditions,
 // should be reported as an MCP error response.
 type CallToolResult struct {
-	jsonrpc.Result
+	Result
 	// Could be either a TextContent, ImageContent, or EmbeddedResources
 	// For Toolbox, we will only be sending TextContent
 	Content []TextContent `json:"content"`
@@ -407,7 +428,7 @@ type ListPromptsRequest struct {
 
 // The server's response to a prompts/list request from the client.
 type ListPromptsResult struct {
-	jsonrpc.Result
+	Result
 	PaginatedResult
 	CacheableResult
 	Prompts []Prompt `json:"prompts"`
@@ -428,7 +449,7 @@ type GetPromptRequestParams struct {
 
 // The server's response to a prompts/get request from the client.
 type GetPromptResult struct {
-	jsonrpc.Result
+	Result
 	Description string          `json:"description,omitempty"`
 	Messages    []PromptMessage `json:"messages"`
 }

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -477,8 +477,11 @@ func TestMcpEndpoint(t *testing.T) {
 		meta                      map[string]any
 		wantToolsList             map[string]any
 		wantPromptsList           map[string]any
+		wantPromptsGet            map[string]any
 		wantToolsListOnTool1      map[string]any
+		wantToolsCallOnTool1      map[string]any
 		wantToolsListWithURLParam map[string]any
+		wantToolsCallWithURLParam map[string]any
 	}{
 		{
 			name:     "version 2024-11-05",
@@ -573,6 +576,7 @@ func TestMcpEndpoint(t *testing.T) {
 				"jsonrpc": "2.0",
 				"id":      "tools-list",
 				"result": map[string]any{
+					"resultType": "complete",
 					"tools": []any{
 						map[string]any{
 							"name":        "no_params",
@@ -609,6 +613,7 @@ func TestMcpEndpoint(t *testing.T) {
 				"jsonrpc": "2.0",
 				"id":      "prompts-list",
 				"result": map[string]any{
+					"resultType": "complete",
 					"prompts": []any{
 						map[string]any{
 							"name": "prompt1",
@@ -622,10 +627,27 @@ func TestMcpEndpoint(t *testing.T) {
 					"cacheScope": "public",
 				},
 			},
+			wantPromptsGet: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "prompts-get-prompt2",
+				"result": map[string]any{
+					"resultType": "complete",
+					"messages": []any{
+						map[string]any{
+							"role": "user",
+							"content": map[string]any{
+								"type": "text",
+								"text": "substituted prompt2",
+							},
+						},
+					},
+				},
+			},
 			wantToolsListOnTool1: map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "tools-list-tool1",
 				"result": map[string]any{
+					"resultType": "complete",
 					"tools": []any{
 						map[string]any{
 							"name":        "no_params",
@@ -636,10 +658,24 @@ func TestMcpEndpoint(t *testing.T) {
 					"cacheScope": "public",
 				},
 			},
+			wantToolsCallOnTool1: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "tools-call-tool1",
+				"result": map[string]any{
+					"resultType": "complete",
+					"content": []any{
+						map[string]any{
+							"type": "text",
+							"text": `"no_params"`,
+						},
+					},
+				},
+			},
 			wantToolsListWithURLParam: map[string]any{
 				"jsonrpc": "2.0",
 				"id":      "tools-list-url-binding",
 				"result": map[string]any{
+					"resultType": "complete",
 					"tools": []any{
 						map[string]any{
 							"name":        "no_params",
@@ -676,6 +712,47 @@ func TestMcpEndpoint(t *testing.T) {
 					},
 					"ttlMs":      300000.0,
 					"cacheScope": "public",
+				},
+			},
+			wantToolsCallWithURLParam: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "tools-call-url-binding",
+				"result": map[string]any{
+					"resultType": "complete",
+					"content": []any{
+						map[string]any{
+							"type": "text",
+							"text": `"url_binding_tool"`,
+						},
+						map[string]any{
+							"type": "text",
+							"text": `"bound-string"`,
+						},
+						map[string]any{
+							"type": "text",
+							"text": `42`,
+						},
+						map[string]any{
+							"type": "text",
+							"text": `true`,
+						},
+						map[string]any{
+							"type": "text",
+							"text": `3.14`,
+						},
+						map[string]any{
+							"type": "text",
+							"text": `"unbound-value"`,
+						},
+						map[string]any{
+							"type": "text",
+							"text": `["a","b"]`,
+						},
+						map[string]any{
+							"type": "text",
+							"text": `{"k":"v"}`,
+						},
+					},
 				},
 			},
 		},
@@ -743,6 +820,7 @@ func TestMcpEndpoint(t *testing.T) {
 						"jsonrpc": "2.0",
 						"id":      "server-discover",
 						"result": map[string]any{
+							"resultType":        "complete",
 							"supportedVersions": []any{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25", "DRAFT-2026-v1"},
 							"capabilities": map[string]any{
 								"tools":   map[string]any{"listChanged": false},
@@ -862,6 +940,7 @@ func TestMcpEndpoint(t *testing.T) {
 							},
 						},
 					},
+					wantOverwrite: vtc.wantPromptsGet,
 				},
 				{
 					name: "tools/list on tool1_only",
@@ -1032,6 +1111,7 @@ func TestMcpEndpoint(t *testing.T) {
 							},
 						},
 					},
+					wantOverwrite: vtc.wantToolsCallOnTool1,
 				},
 				{
 					name: "call tool4 unauthorized tool",
@@ -1193,6 +1273,7 @@ func TestMcpEndpoint(t *testing.T) {
 							},
 						},
 					},
+					wantOverwrite: vtc.wantToolsCallWithURLParam,
 				},
 			}
 			for i := range testCases {


### PR DESCRIPTION
Tested with the official MCP SDKs with the `2026-07-28` specs.

Found that we are missing the resultType. This requirement was added in [SEP-2322](https://modelcontextprotocol.io/seps/2322-MRTR) that we missed since it was for MRTR that Toolbox is not currently supported.