### PR TITLE
chore: add metadata to result

### DIFF
--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -117,14 +117,51 @@ func validateHeader(id jsonrpc.RequestId, header http.Header, method, name strin
 	return nil, nil
 }
 
-func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, header http.Header) (any, error) {
+// getResultMetadata append the resultMetaObject on existing metadata
+func getResultMetadata(ctx context.Context, curMeta map[string]any) (map[string]any, error) {
 	v, err := util.ToolboxVersionFromContext(ctx)
 	if err != nil {
-		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		return nil, err
 	}
+
+	resMetaObj := ResultMetaObject{
+		ServerInfo: Implementation{
+			BaseMetadata: BaseMetadata{
+				Name: SERVER_NAME,
+			},
+			Version: v,
+		},
+	}
+	jsonData, err := json.Marshal(resMetaObj)
+	if err != nil {
+		return nil, err
+	}
+	resMeta := make(map[string]any)
+	if err := json.Unmarshal(jsonData, &resMeta); err != nil {
+		return nil, err
+	}
+	// if there are no existing metadata field, we can just return the
+	// ResultMetaObject
+	if curMeta == nil {
+		return resMeta, nil
+	}
+
+	newMeta := make(map[string]any)
+	// copy current Metadata into the new meta obj
+	for k, v := range curMeta {
+		newMeta[k] = v
+	}
+	// copy the ResultMetaObject items over
+	for k, v := range resMeta {
+		newMeta[k] = v
+	}
+	return newMeta, nil
+}
+
+func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byte, header http.Header) (any, error) {
 	enableDraft, ok := util.EnableDraftSpecsFromContext(ctx)
 	if !ok {
-		err = fmt.Errorf("unable to retrieve enableDraftSpecs from context")
+		err := fmt.Errorf("unable to retrieve enableDraftSpecs from context")
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
 
@@ -144,9 +181,16 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 
 	toolsListChanged := false
 	promptsListChanged := false
+	meta, err := getResultMetadata(ctx, nil)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
 	result := DiscoverResult{
 		Result: Result{
 			ResultType: resultTypeComplete,
+			Result: jsonrpc.Result{
+				Meta: meta,
+			},
 		},
 		SupportedVersions: mcputil.GetSupportedVersions(enableDraft),
 		Capabilities: ServerCapabilities{
@@ -156,12 +200,6 @@ func serverDiscoverHandler(ctx context.Context, id jsonrpc.RequestId, body []byt
 			Prompts: &ListChanged{
 				ListChanged: &promptsListChanged,
 			},
-		},
-		ServerInfo: Implementation{
-			BaseMetadata: BaseMetadata{
-				Name: SERVER_NAME,
-			},
-			Version: v,
 		},
 	}
 	res := jsonrpc.JSONRPCResponse{
@@ -194,6 +232,11 @@ func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr *p
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
+	meta, err := getResultMetadata(ctx, listToolsResult.Meta)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	listToolsResult.Meta = meta
 	return jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,
 		Id:      id,
@@ -207,6 +250,10 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 
 	// retrieve logger from context
 	logger, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	meta, err := getResultMetadata(ctx, nil)
 	if err != nil {
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
@@ -422,6 +469,9 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 					Result: CallToolResult{
 						Result: Result{
 							ResultType: resultTypeComplete,
+							Result: jsonrpc.Result{
+								Meta: meta,
+							},
 						},
 						Content: []TextContent{text},
 						IsError: true,
@@ -475,6 +525,9 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		Result: CallToolResult{
 			Result: Result{
 				ResultType: resultTypeComplete,
+				Result: jsonrpc.Result{
+					Meta: meta,
+				},
 			},
 			Content: content,
 		},
@@ -511,6 +564,11 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr 
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
 	}
 	logger.DebugContext(ctx, fmt.Sprintf("returning %d prompts", len(listPromptsResult.Prompts)))
+	meta, err := getResultMetadata(ctx, listPromptsResult.Meta)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+	listPromptsResult.Meta = meta
 	return jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,
 		Id:      id,
@@ -601,15 +659,20 @@ func promptsGetHandler(ctx context.Context, id jsonrpc.RequestId, promptset prom
 			},
 		}
 	}
-
+	meta, err := getResultMetadata(ctx, nil)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
 	result := GetPromptResult{
 		Result: Result{
 			ResultType: resultTypeComplete,
+			Result: jsonrpc.Result{
+				Meta: meta,
+			},
 		},
 		Description: prompt.Manifest().Description,
 		Messages:    promptMessages,
 	}
-
 	return jsonrpc.JSONRPCResponse{
 		Jsonrpc: jsonrpc.JSONRPC_VERSION,
 		Id:      id,

--- a/internal/server/mcp/vdraft/method_test.go
+++ b/internal/server/mcp/vdraft/method_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -400,6 +401,9 @@ func TestServerDiscoverHandler(t *testing.T) {
 }
 
 func TestToolsListHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = util.WithToolboxVersionKey(ctx, "v0.0.0")
 	// Initialize tools using provided testutils mock instances
 	mockTools := []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}
 	toolsMap, toolsets, promptsMap, promptsets := testutils.SetUpResources(t, mockTools, nil)
@@ -510,7 +514,7 @@ func TestToolsListHandler(t *testing.T) {
 					t.Fatalf("unexpected error during marshaling")
 				}
 			}
-			got, err := toolsListHandler(context.Background(), dummyID, primitiveMgr, tt.toolset, body, tt.header)
+			got, err := toolsListHandler(ctx, dummyID, primitiveMgr, tt.toolset, body, tt.header)
 
 			if tt.wantErr {
 				if err == nil {
@@ -534,6 +538,7 @@ func TestToolsListHandler(t *testing.T) {
 func TestToolsCallHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx = util.WithToolboxVersionKey(ctx, "v0.0.0")
 	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
 	if err != nil {
 		t.Fatalf("unable to initialize logger: %s", err)
@@ -700,6 +705,7 @@ func TestToolsCallHandler(t *testing.T) {
 func TestPromptsListHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx = util.WithToolboxVersionKey(ctx, "v0.0.0")
 	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
 	if err != nil {
 		t.Fatalf("unable to initialize logger: %s", err)
@@ -784,6 +790,7 @@ func TestPromptsListHandler(t *testing.T) {
 func TestPromptsGetHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx = util.WithToolboxVersionKey(ctx, "v0.0.0")
 	testLogger, err := log.NewStdLogger(os.Stdout, os.Stderr, "info")
 	if err != nil {
 		t.Fatalf("unable to initialize logger: %s", err)
@@ -909,6 +916,95 @@ func TestPromptsGetHandler(t *testing.T) {
 				if got == nil {
 					t.Errorf("expected valid response, got nil")
 				}
+			}
+		})
+	}
+}
+
+func TestGetResultMetadata(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxWithVersion := util.WithToolboxVersionKey(ctx, "v0.0.0")
+	server_name := "Toolbox"
+	// Define the table structure for our test cases
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		curMeta    map[string]any
+		want       map[string]any
+		wantErr    bool
+		errMessage string // Optional: check for specific error messages
+	}{
+		{
+			name: "Success - Merge with existing metadata",
+			ctx:  ctxWithVersion,
+			curMeta: map[string]any{
+				"existing_key": "existing_value",
+				"another_key":  123,
+			},
+			want: map[string]any{
+				"existing_key": "existing_value",
+				"another_key":  123,
+				"io.modelcontextprotocol/serverInfo": map[string]any{
+					"name":    server_name,
+					"version": "v0.0.0",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Success - Nil current metadata",
+			ctx:     ctxWithVersion,
+			curMeta: nil,
+			want: map[string]any{
+				"io.modelcontextprotocol/serverInfo": map[string]any{
+					"name":    server_name,
+					"version": "v0.0.0",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success - Overwrites duplicate keys in metadata",
+			ctx:  ctxWithVersion,
+			curMeta: map[string]any{
+				"io.modelcontextprotocol/serverInfo": "old_data",
+				"other_key":                          true,
+			},
+			want: map[string]any{
+				"other_key": true,
+				"io.modelcontextprotocol/serverInfo": map[string]any{
+					"name":    server_name,
+					"version": "v0.0.0",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Failure - Context error (version retrieval fails)",
+			ctx:  context.Background(),
+			curMeta: map[string]any{
+				"some_data": "value",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.ctx
+			got, err := getResultMetadata(ctx, tt.curMeta)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getResultMetadata() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getResultMetadata() got =\n%v\nwant =\n%v", got, tt.want)
 			}
 		})
 	}

--- a/internal/server/mcp/vdraft/types.go
+++ b/internal/server/mcp/vdraft/types.go
@@ -91,6 +91,26 @@ type RequestMetaObject struct {
 	MetaClientCapabilities *ClientCapabilities `json:"io.modelcontextprotocol/clientCapabilities"`
 }
 
+/**
+ * Extends {@link MetaObject} with additional result-specific fields. All key naming rules from `MetaObject` apply.
+ */
+type ResultMetaObject struct {
+	/**
+	 * Identifies the server software producing the response. Servers SHOULD
+	 * include this field on every response unless specifically configured not
+	 * to do so.
+	 *
+	 * The {@link Implementation} schema requires `name` and `version`; other
+	 * fields are optional.
+	 *
+	 * The value is self-reported by the server and is not verified by the
+	 * protocol. It is intended for display, logging, and debugging. Clients
+	 * SHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for
+	 * security decisions.
+	 */
+	ServerInfo Implementation `json:"io.modelcontextprotocol/serverInfo,omitempty"`
+}
+
 // ClientCapabilities represents capabilities a client may support. Known
 // capabilities are defined here, in this schema, but this is not a closed set: any
 // client can define its own, additional capabilities.
@@ -128,10 +148,6 @@ type DiscoverResult struct {
 	 * The capabilities of the server.
 	 */
 	Capabilities ServerCapabilities `json:"capabilities"`
-	/**
-	 * Information about the server software implementation.
-	 */
-	ServerInfo Implementation `json:"serverInfo"`
 	/**
 	 * Natural-language guidance describing the server and its features.
 	 *

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -607,6 +607,9 @@ func TestMcpEndpoint(t *testing.T) {
 					},
 					"ttlMs":      300000.0,
 					"cacheScope": "public",
+					"_meta": map[string]any{
+						"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+					},
 				},
 			},
 			wantPromptsList: map[string]any{
@@ -625,6 +628,9 @@ func TestMcpEndpoint(t *testing.T) {
 					},
 					"ttlMs":      300000.0,
 					"cacheScope": "public",
+					"_meta": map[string]any{
+						"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+					},
 				},
 			},
 			wantPromptsGet: map[string]any{
@@ -641,6 +647,9 @@ func TestMcpEndpoint(t *testing.T) {
 							},
 						},
 					},
+					"_meta": map[string]any{
+						"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+					},
 				},
 			},
 			wantToolsListOnTool1: map[string]any{
@@ -656,6 +665,9 @@ func TestMcpEndpoint(t *testing.T) {
 					},
 					"ttlMs":      300000.0,
 					"cacheScope": "public",
+					"_meta": map[string]any{
+						"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+					},
 				},
 			},
 			wantToolsCallOnTool1: map[string]any{
@@ -668,6 +680,9 @@ func TestMcpEndpoint(t *testing.T) {
 							"type": "text",
 							"text": `"no_params"`,
 						},
+					},
+					"_meta": map[string]any{
+						"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 					},
 				},
 			},
@@ -709,6 +724,9 @@ func TestMcpEndpoint(t *testing.T) {
 								"required": []any{"param5"},
 							},
 						},
+					},
+					"_meta": map[string]any{
+						"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 					},
 					"ttlMs":      300000.0,
 					"cacheScope": "public",
@@ -752,6 +770,9 @@ func TestMcpEndpoint(t *testing.T) {
 							"type": "text",
 							"text": `{"k":"v"}`,
 						},
+					},
+					"_meta": map[string]any{
+						"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
 					},
 				},
 			},
@@ -826,7 +847,9 @@ func TestMcpEndpoint(t *testing.T) {
 								"tools":   map[string]any{"listChanged": false},
 								"prompts": map[string]any{"listChanged": false},
 							},
-							"serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+							"_meta": map[string]any{
+								"io.modelcontextprotocol/serverInfo": map[string]any{"name": serverName, "version": testutils.MockVersionString},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Added change regarding to this PR: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002/changes

**Per-response protocol fields:**

Servers **SHOULD** include the following `io.modelcontextprotocol/*` field in
every result's `_meta`, unless specifically configured not to do so, to
identify themselves without relying on any prior connection state:

| Key                                  | Type             | Required | Description             |
| ------------------------------------ | ---------------- | -------- | ----------------------- |
| `io.modelcontextprotocol/serverInfo` | `Implementation` | No       | Server name and version |