### PR TITLE
refactor: remove getPromptMap from primitive manager

### DIFF
--- a/internal/server/mcp/v20241105/manifests.go
+++ b/internal/server/mcp/v20241105/manifests.go
@@ -143,10 +143,10 @@ func generatePromptManifest(name, desc string, args prompts.Arguments) Prompt {
 }
 
 // GenerateListPromptsResult generates the list/prompts result
-func GenerateListPromptsResult(g group.Group, promptsMap map[string]prompts.Prompt) (ListPromptsResult, error) {
+func GenerateListPromptsResult(pMgr *primitives.PrimitiveManager, g group.Group) (ListPromptsResult, error) {
 	mcpManifest := make([]Prompt, 0, len(g.PromptNames))
 	for _, promptName := range g.PromptNames {
-		prompt, ok := promptsMap[promptName]
+		prompt, ok := pMgr.GetPrompt(promptName)
 		if !ok {
 			return ListPromptsResult{}, fmt.Errorf("prompt does not exist: %s", promptName)
 		}

--- a/internal/server/mcp/v20241105/manifests_test.go
+++ b/internal/server/mcp/v20241105/manifests_test.go
@@ -355,8 +355,11 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	})
-
-	got, err := GenerateListPromptsResult(g, promptsMap)
+	gMap := map[string]group.Group{
+		g.Name: g,
+	}
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, promptsMap, gMap)
+	got, err := GenerateListPromptsResult(pMgr, g)
 	if err != nil {
 		t.Fatalf("unable to generate list prompt result: %s", err)
 	}

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -429,8 +429,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr 
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	promptsMap := primitiveMgr.GetPromptsMap()
-	listPromptsResult, err := GenerateListPromptsResult(g, promptsMap)
+	listPromptsResult, err := GenerateListPromptsResult(primitiveMgr, g)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/v20250326/manifests.go
+++ b/internal/server/mcp/v20250326/manifests.go
@@ -142,10 +142,10 @@ func generatePromptManifest(name, desc string, args prompts.Arguments) Prompt {
 }
 
 // GenerateListPromptsResult generates the list/prompts result
-func GenerateListPromptsResult(g group.Group, promptsMap map[string]prompts.Prompt) (ListPromptsResult, error) {
+func GenerateListPromptsResult(pMgr *primitives.PrimitiveManager, g group.Group) (ListPromptsResult, error) {
 	mcpManifest := make([]Prompt, 0, len(g.PromptNames))
 	for _, promptName := range g.PromptNames {
-		prompt, ok := promptsMap[promptName]
+		prompt, ok := pMgr.GetPrompt(promptName)
 		if !ok {
 			return ListPromptsResult{}, fmt.Errorf("prompt does not exist: %s", promptName)
 		}

--- a/internal/server/mcp/v20250326/manifests_test.go
+++ b/internal/server/mcp/v20250326/manifests_test.go
@@ -356,8 +356,11 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	})
-
-	got, err := GenerateListPromptsResult(g, promptsMap)
+	gMap := map[string]group.Group{
+		g.Name: g,
+	}
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, promptsMap, gMap)
+	got, err := GenerateListPromptsResult(pMgr, g)
 	if err != nil {
 		t.Fatalf("unable to generate list prompt result: %s", err)
 	}

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -428,8 +428,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr 
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	promptsMap := primitiveMgr.GetPromptsMap()
-	listPromptsResult, err := GenerateListPromptsResult(g, promptsMap)
+	listPromptsResult, err := GenerateListPromptsResult(primitiveMgr, g)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/v20250618/manifests.go
+++ b/internal/server/mcp/v20250618/manifests.go
@@ -144,10 +144,10 @@ func generatePromptManifest(name, desc string, args prompts.Arguments) Prompt {
 }
 
 // GenerateListPromptsResult generates the list/prompts result
-func GenerateListPromptsResult(g group.Group, promptsMap map[string]prompts.Prompt) (ListPromptsResult, error) {
+func GenerateListPromptsResult(pMgr *primitives.PrimitiveManager, g group.Group) (ListPromptsResult, error) {
 	mcpManifest := make([]Prompt, 0, len(g.PromptNames))
 	for _, promptName := range g.PromptNames {
-		prompt, ok := promptsMap[promptName]
+		prompt, ok := pMgr.GetPrompt(promptName)
 		if !ok {
 			return ListPromptsResult{}, fmt.Errorf("prompt does not exist: %s", promptName)
 		}

--- a/internal/server/mcp/v20250618/manifests_test.go
+++ b/internal/server/mcp/v20250618/manifests_test.go
@@ -356,8 +356,11 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	})
-
-	got, err := GenerateListPromptsResult(g, promptsMap)
+	gMap := map[string]group.Group{
+		g.Name: g,
+	}
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, promptsMap, gMap)
+	got, err := GenerateListPromptsResult(pMgr, g)
 	if err != nil {
 		t.Fatalf("unable to generate list prompt result: %s", err)
 	}

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -428,8 +428,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr 
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	promptsMap := primitiveMgr.GetPromptsMap()
-	listPromptsResult, err := GenerateListPromptsResult(g, promptsMap)
+	listPromptsResult, err := GenerateListPromptsResult(primitiveMgr, g)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/v20251125/manifests.go
+++ b/internal/server/mcp/v20251125/manifests.go
@@ -144,10 +144,10 @@ func generatePromptManifest(name, desc string, args prompts.Arguments) Prompt {
 }
 
 // GenerateListPromptsResult generates the list/prompts result
-func GenerateListPromptsResult(g group.Group, promptsMap map[string]prompts.Prompt) (ListPromptsResult, error) {
+func GenerateListPromptsResult(pMgr *primitives.PrimitiveManager, g group.Group) (ListPromptsResult, error) {
 	mcpManifest := make([]Prompt, 0, len(g.PromptNames))
 	for _, promptName := range g.PromptNames {
-		prompt, ok := promptsMap[promptName]
+		prompt, ok := pMgr.GetPrompt(promptName)
 		if !ok {
 			return ListPromptsResult{}, fmt.Errorf("prompt does not exist: %s", promptName)
 		}

--- a/internal/server/mcp/v20251125/manifests_test.go
+++ b/internal/server/mcp/v20251125/manifests_test.go
@@ -356,8 +356,11 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	})
-
-	got, err := GenerateListPromptsResult(g, promptsMap)
+	gMap := map[string]group.Group{
+		g.Name: g,
+	}
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, promptsMap, gMap)
+	got, err := GenerateListPromptsResult(pMgr, g)
 	if err != nil {
 		t.Fatalf("unable to generate list prompt result: %s", err)
 	}

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -428,8 +428,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr 
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	promptsMap := primitiveMgr.GetPromptsMap()
-	listPromptsResult, err := GenerateListPromptsResult(g, promptsMap)
+	listPromptsResult, err := GenerateListPromptsResult(primitiveMgr, g)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/vdraft/manifests.go
+++ b/internal/server/mcp/vdraft/manifests.go
@@ -155,10 +155,10 @@ func generatePromptManifest(name, desc string, args prompts.Arguments) Prompt {
 }
 
 // GenerateListPromptsResult generates the list/prompts result
-func GenerateListPromptsResult(g group.Group, promptsMap map[string]prompts.Prompt) (ListPromptsResult, error) {
+func GenerateListPromptsResult(pMgr *primitives.PrimitiveManager, g group.Group) (ListPromptsResult, error) {
 	mcpManifest := make([]Prompt, 0, len(g.PromptNames))
 	for _, promptName := range g.PromptNames {
-		prompt, ok := promptsMap[promptName]
+		prompt, ok := pMgr.GetPrompt(promptName)
 		if !ok {
 			return ListPromptsResult{}, fmt.Errorf("prompt does not exist: %s", promptName)
 		}
@@ -205,7 +205,7 @@ func GenerateGetGroupResult(pMgr *primitives.PrimitiveManager, g group.Group, ur
 	if err != nil {
 		return GetGroupResult{}, fmt.Errorf("error generating tools manifest: %w", err)
 	}
-	listPromptsResult, err := GenerateListPromptsResult(g, pMgr.GetPromptsMap())
+	listPromptsResult, err := GenerateListPromptsResult(pMgr, g)
 	if err != nil {
 		return GetGroupResult{}, fmt.Errorf("error generating prompts manifest: %w", err)
 	}

--- a/internal/server/mcp/vdraft/manifests_test.go
+++ b/internal/server/mcp/vdraft/manifests_test.go
@@ -363,8 +363,11 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	})
-
-	got, err := GenerateListPromptsResult(g, promptsMap)
+	gMap := map[string]group.Group{
+		g.Name: g,
+	}
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, promptsMap, gMap)
+	got, err := GenerateListPromptsResult(pMgr, g)
 	if err != nil {
 		t.Fatalf("unable to generate list prompt result: %s", err)
 	}

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -573,8 +573,7 @@ func promptsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr 
 		return validateErr, err
 	}
 
-	promptsMap := primitiveMgr.GetPromptsMap()
-	listPromptsResult, err := GenerateListPromptsResult(g, promptsMap)
+	listPromptsResult, err := GenerateListPromptsResult(primitiveMgr, g)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/primitives/primitives.go
+++ b/internal/server/primitives/primitives.go
@@ -134,16 +134,6 @@ func (r *PrimitiveManager) GetEmbeddingModelMap() map[string]embeddingmodels.Emb
 	return copiedMap
 }
 
-func (r *PrimitiveManager) GetPromptsMap() map[string]prompts.Prompt {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	copiedMap := make(map[string]prompts.Prompt, len(r.prompts))
-	for k, v := range r.prompts {
-		copiedMap[k] = v
-	}
-	return copiedMap
-}
-
 func (r *PrimitiveManager) GetGroupsMap() map[string]group.Group {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -67,9 +67,9 @@ func (t Toolset) BuildManifest(srcMgr SourceManager) (ToolsetManifest, error) {
 		var src sources.Source
 		var ok bool
 		if srcName != "" {
-			src, ok = srcMgr.GetSource((*tool).GetSourceName())
+			src, ok = srcMgr.GetSource(srcName)
 			if !ok {
-				return ToolsetManifest{}, fmt.Errorf("unable to retrieve %s source for tool %q", (*tool).GetSourceName(), (*tool).GetName())
+				return ToolsetManifest{}, fmt.Errorf("unable to retrieve %s source for tool %q", srcName, (*tool).GetName())
 			}
 		}
 		m, err := (*tool).Manifest(src)


### PR DESCRIPTION
This PR does the following: 
1. remove `GetPromptsMap` from primitive manager.