### PR TITLE
fix: re-add tool validation during startup

### DIFF
--- a/cmd/internal/skills/generator_test.go
+++ b/cmd/internal/skills/generator_test.go
@@ -175,7 +175,7 @@ func TestFormatParameters(t *testing.T) {
 
 func TestGenerateSkillMarkdown(t *testing.T) {
 	toolsMap := map[string]tools.Tool{
-		"tool1": testutils.NewMockTool("tool1", "First tool",
+		"tool1": testutils.NewMockTool("tool1", "First tool", "",
 			[]parameters.Parameter{
 				parameters.NewStringParameter("p1", "d1"),
 			}, false, false),

--- a/internal/group/group_test.go
+++ b/internal/group/group_test.go
@@ -29,8 +29,8 @@ import (
 
 func testFixtures() (map[string]tools.Tool, map[string]prompts.Prompt) {
 	toolsMap := map[string]tools.Tool{
-		"tool1": testutils.NewMockTool("tool1", "first tool", []parameters.Parameter{}, false, false),
-		"tool2": testutils.NewMockTool("tool2", "second tool", []parameters.Parameter{}, false, false),
+		"tool1": testutils.NewMockTool("tool1", "first tool", "", []parameters.Parameter{}, false, false),
+		"tool2": testutils.NewMockTool("tool2", "second tool", "", []parameters.Parameter{}, false, false),
 	}
 	promptsMap := map[string]prompts.Prompt{
 		"prompt1": testutils.NewMockPrompt("prompt1", "first prompt", prompts.Arguments{}),

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -54,7 +54,7 @@ func TestToolsetEndpoint(t *testing.T) {
 			want: wantResponse{
 				statusCode: http.StatusOK,
 				version:    testutils.MockVersionString,
-				tools:      []string{testutils.MockTool1.Name, testutils.MockTool2.Name},
+				tools:      []string{testutils.MockTool1.GetName(), testutils.MockTool2.GetName()},
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestToolsetEndpoint(t *testing.T) {
 			want: wantResponse{
 				statusCode: http.StatusOK,
 				version:    testutils.MockVersionString,
-				tools:      []string{testutils.MockTool1.Name},
+				tools:      []string{testutils.MockTool1.GetName()},
 			},
 		},
 		{
@@ -80,7 +80,7 @@ func TestToolsetEndpoint(t *testing.T) {
 			want: wantResponse{
 				statusCode: http.StatusOK,
 				version:    testutils.MockVersionString,
-				tools:      []string{testutils.MockTool2.Name},
+				tools:      []string{testutils.MockTool2.GetName()},
 			},
 		},
 	}
@@ -147,20 +147,20 @@ func TestToolGetEndpoint(t *testing.T) {
 	}{
 		{
 			name:     "tool1",
-			toolName: testutils.MockTool1.Name,
+			toolName: testutils.MockTool1.GetName(),
 			want: wantResponse{
 				statusCode: http.StatusOK,
 				version:    testutils.MockVersionString,
-				tools:      []string{testutils.MockTool1.Name},
+				tools:      []string{testutils.MockTool1.GetName()},
 			},
 		},
 		{
 			name:     "tool2",
-			toolName: testutils.MockTool2.Name,
+			toolName: testutils.MockTool2.GetName(),
 			want: wantResponse{
 				statusCode: http.StatusOK,
 				version:    testutils.MockVersionString,
-				tools:      []string{testutils.MockTool2.Name},
+				tools:      []string{testutils.MockTool2.GetName()},
 			},
 		},
 		{
@@ -229,14 +229,14 @@ func TestToolInvokeEndpoint(t *testing.T) {
 	}{
 		{
 			name:        "tool1",
-			toolName:    testutils.MockTool1.Name,
+			toolName:    testutils.MockTool1.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "{result:[no_params]}\n",
 			isErr:       false,
 		},
 		{
 			name:        "tool2",
-			toolName:    testutils.MockTool2.Name,
+			toolName:    testutils.MockTool2.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{"param1": 1, "param2": 2}`)),
 			want:        "{result:[some_params]}\n",
 			isErr:       false,
@@ -250,14 +250,14 @@ func TestToolInvokeEndpoint(t *testing.T) {
 		},
 		{
 			name:        "tool4",
-			toolName:    testutils.MockTool4.Name,
+			toolName:    testutils.MockTool4.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "",
 			isErr:       true,
 		},
 		{
 			name:        "tool5",
-			toolName:    testutils.MockTool5.Name,
+			toolName:    testutils.MockTool5.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "",
 			isErr:       true,
@@ -307,7 +307,7 @@ func TestApiRequestBodyLimit(t *testing.T) {
 
 	limit := int(DefaultHTTPMaxRequestBytes)
 	tooLarge := []byte(fmt.Sprintf(`{"param":"%s"}`, strings.Repeat("x", limit)))
-	resp, body, err := runRequest(ts, http.MethodPost, fmt.Sprintf("/tool/%s/invoke", testutils.MockTool1.Name), bytes.NewReader(tooLarge), nil)
+	resp, body, err := runRequest(ts, http.MethodPost, fmt.Sprintf("/tool/%s/invoke", testutils.MockTool1.GetName()), bytes.NewReader(tooLarge), nil)
 	if err != nil {
 		t.Fatalf("unexpected error during request: %s", err)
 	}
@@ -339,7 +339,7 @@ func TestApiRequestBodyLimitOverride(t *testing.T) {
 	defer ts.Close()
 
 	tooLarge := []byte(fmt.Sprintf(`{"param":"%s"}`, strings.Repeat("x", int(customLimit))))
-	resp, body, err := runRequest(ts, http.MethodPost, fmt.Sprintf("/tool/%s/invoke", testutils.MockTool1.Name), bytes.NewReader(tooLarge), nil)
+	resp, body, err := runRequest(ts, http.MethodPost, fmt.Sprintf("/tool/%s/invoke", testutils.MockTool1.GetName()), bytes.NewReader(tooLarge), nil)
 	if err != nil {
 		t.Fatalf("unexpected error during request: %s", err)
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -228,14 +228,14 @@ func TestToolInvokeEndpoint(t *testing.T) {
 		isErr       bool
 	}{
 		{
-			name:        "tool1",
+			name:        "tool without param",
 			toolName:    testutils.MockTool1.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "{result:[no_params]}\n",
 			isErr:       false,
 		},
 		{
-			name:        "tool2",
+			name:        "tool with params",
 			toolName:    testutils.MockTool2.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{"param1": 1, "param2": 2}`)),
 			want:        "{result:[some_params]}\n",
@@ -249,14 +249,14 @@ func TestToolInvokeEndpoint(t *testing.T) {
 			isErr:       true,
 		},
 		{
-			name:        "tool4",
+			name:        "unauthorized tools",
 			toolName:    testutils.MockTool4.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "",
 			isErr:       true,
 		},
 		{
-			name:        "tool5",
+			name:        "tool requiring client auth",
 			toolName:    testutils.MockTool5.GetName(),
 			requestBody: bytes.NewBuffer([]byte(`{}`)),
 			want:        "",

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -101,6 +101,8 @@ type ServerConfig struct {
 	HttpMaxRequestBytes int64
 	// EnableDraftSpecs allow users to opt-in and test upcoming draft MCP specs.
 	EnableDraftSpecs bool
+	// SkipSourceValidation skips source validation during server startup
+	SkipSourceValidation bool
 }
 
 type logFormat string

--- a/internal/server/mcp/v20241105/manifests_test.go
+++ b/internal/server/mcp/v20241105/manifests_test.go
@@ -231,17 +231,17 @@ func TestParamManifest(t *testing.T) {
 }
 
 func TestGenerateListToolsResult(t *testing.T) {
-	tool1 := testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+	tool1 := testutils.NewMockTool("no_params", "", "", []parameters.Parameter{}, false, false)
 	tool2 := testutils.NewMockTool(
 		"some_params",
-		"",
+		"", "",
 		parameters.Parameters{
 			parameters.NewIntParameter("param1", "This is the first parameter."),
 			parameters.NewIntParameter("param2", "This is the second parameter."),
 		}, false, false)
 	toolsMap := make(map[string]tools.Tool)
-	toolsMap[tool1.Name] = tool1
-	toolsMap[tool2.Name] = tool2
+	toolsMap[tool1.GetName()] = tool1
+	toolsMap[tool2.GetName()] = tool2
 	g := group.NewGroup(group.GroupConfig{
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},

--- a/internal/server/mcp/v20250326/manifests_test.go
+++ b/internal/server/mcp/v20250326/manifests_test.go
@@ -231,17 +231,17 @@ func TestParamManifest(t *testing.T) {
 }
 
 func TestGenerateListToolsResult(t *testing.T) {
-	tool1 := testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+	tool1 := testutils.NewMockTool("no_params", "", "", []parameters.Parameter{}, false, false)
 	tool2 := testutils.NewMockTool(
 		"some_params",
-		"",
+		"", "",
 		parameters.Parameters{
 			parameters.NewIntParameter("param1", "This is the first parameter."),
 			parameters.NewIntParameter("param2", "This is the second parameter."),
 		}, false, false)
 	toolsMap := make(map[string]tools.Tool)
-	toolsMap[tool1.Name] = tool1
-	toolsMap[tool2.Name] = tool2
+	toolsMap[tool1.GetName()] = tool1
+	toolsMap[tool2.GetName()] = tool2
 	g := group.NewGroup(group.GroupConfig{
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},

--- a/internal/server/mcp/v20250618/manifests_test.go
+++ b/internal/server/mcp/v20250618/manifests_test.go
@@ -231,17 +231,17 @@ func TestParamManifest(t *testing.T) {
 }
 
 func TestGenerateListToolsResult(t *testing.T) {
-	tool1 := testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+	tool1 := testutils.NewMockTool("no_params", "", "", []parameters.Parameter{}, false, false)
 	tool2 := testutils.NewMockTool(
 		"some_params",
-		"",
+		"", "",
 		parameters.Parameters{
 			parameters.NewIntParameter("param1", "This is the first parameter."),
 			parameters.NewIntParameter("param2", "This is the second parameter."),
 		}, false, false)
 	toolsMap := make(map[string]tools.Tool)
-	toolsMap[tool1.Name] = tool1
-	toolsMap[tool2.Name] = tool2
+	toolsMap[tool1.GetName()] = tool1
+	toolsMap[tool2.GetName()] = tool2
 	g := group.NewGroup(group.GroupConfig{
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},

--- a/internal/server/mcp/v20251125/manifests_test.go
+++ b/internal/server/mcp/v20251125/manifests_test.go
@@ -231,17 +231,17 @@ func TestParamManifest(t *testing.T) {
 }
 
 func TestGenerateListToolsResult(t *testing.T) {
-	tool1 := testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+	tool1 := testutils.NewMockTool("no_params", "", "", []parameters.Parameter{}, false, false)
 	tool2 := testutils.NewMockTool(
 		"some_params",
-		"",
+		"", "",
 		parameters.Parameters{
 			parameters.NewIntParameter("param1", "This is the first parameter."),
 			parameters.NewIntParameter("param2", "This is the second parameter."),
 		}, false, false)
 	toolsMap := make(map[string]tools.Tool)
-	toolsMap[tool1.Name] = tool1
-	toolsMap[tool2.Name] = tool2
+	toolsMap[tool1.GetName()] = tool1
+	toolsMap[tool2.GetName()] = tool2
 	g := group.NewGroup(group.GroupConfig{
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},

--- a/internal/server/mcp/v20260728/manifests_test.go
+++ b/internal/server/mcp/v20260728/manifests_test.go
@@ -231,17 +231,17 @@ func TestParamManifest(t *testing.T) {
 }
 
 func TestGenerateListToolsResult(t *testing.T) {
-	tool1 := testutils.NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+	tool1 := testutils.NewMockTool("no_params", "", "", []parameters.Parameter{}, false, false)
 	tool2 := testutils.NewMockTool(
 		"some_params",
-		"",
+		"", "",
 		parameters.Parameters{
 			parameters.NewIntParameter("param1", "This is the first parameter."),
 			parameters.NewIntParameter("param2", "This is the second parameter."),
 		}, false, false)
 	toolsMap := make(map[string]tools.Tool)
-	toolsMap[tool1.Name] = tool1
-	toolsMap[tool2.Name] = tool2
+	toolsMap[tool1.GetName()] = tool1
+	toolsMap[tool2.GetName()] = tool2
 	g := group.NewGroup(group.GroupConfig{
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -241,7 +241,8 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get logger from context: %w", err)
 	}
-
+	// Automatically skip source validation
+	cfg.SkipSourceValidation = true
 	toolsMap, err := initializeTools(ctx, cfg, map[string]sources.Source{}, instrumentation, l)
 	if err != nil {
 		return nil, nil, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -183,7 +183,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	}
 	l.InfoContext(ctx, fmt.Sprintf("Initialized %d embeddingModels: %s", len(embeddingModelsMap), strings.Join(embeddingModelNames, ", ")))
 
-	toolsMap, err := initializeTools(ctx, cfg, instrumentation, l)
+	toolsMap, err := initializeTools(ctx, cfg, sourcesMap, instrumentation, l)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}
@@ -242,7 +242,7 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 		return nil, nil, fmt.Errorf("failed to get logger from context: %w", err)
 	}
 
-	toolsMap, err := initializeTools(ctx, cfg, instrumentation, l)
+	toolsMap, err := initializeTools(ctx, cfg, map[string]sources.Source{}, instrumentation, l)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -266,7 +266,7 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 }
 
 // initializeTools initializes and validates the tools from the config.
-func initializeTools(ctx context.Context, cfg ServerConfig, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]tools.Tool, error) {
+func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[string]sources.Source, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]tools.Tool, error) {
 	toolsMap := make(map[string]tools.Tool)
 	for name, tc := range cfg.ToolConfigs {
 		t, err := func() (tools.Tool, error) {
@@ -280,6 +280,21 @@ func initializeTools(ctx context.Context, cfg ServerConfig, instrumentation *tel
 			t, err := tc.Initialize(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("unable to initialize tool %q: %w", name, err)
+			}
+			if !cfg.SkipSourceValidation {
+				srcName := t.GetSourceName()
+				var src sources.Source
+				var ok bool
+				if srcName != "" {
+					src, ok = sourcesMap[srcName]
+					if !ok {
+						return nil, fmt.Errorf("unable to retrieve source %s for tool %s", srcName, name)
+					}
+				}
+				err = t.ValidateSource(src)
+				if err != nil {
+					return nil, err
+				}
 			}
 			return t, nil
 		}()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1842,6 +1842,7 @@ func TestInitializeOfflineConfigs(t *testing.T) {
 		ToolConfigs: server.ToolConfigs{
 			"my-tool": offlineToolConfig{name: "my-tool"},
 		},
+		SkipSourceValidation: true,
 	}
 
 	toolsMap, groupsMap, err := server.InitializeOfflineConfigs(ctx, cfg)
@@ -1932,6 +1933,7 @@ func TestDefaultToolsetIsAlphabeticallySorted(t *testing.T) {
 			"apple":  offlineToolConfig{name: "apple"},
 			"banana": offlineToolConfig{name: "banana"},
 		},
+		SkipSourceValidation: true,
 	}
 
 	_, toolsetsMap, err := server.InitializeOfflineConfigs(ctx, cfg)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/http"
 	"github.com/googleapis/mcp-toolbox/internal/util"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Helper function to create temporary self-signed certs for the test
@@ -1801,25 +1800,61 @@ prompts:
 	}
 }
 
-type offlineSourceConfig struct {
-	initialized *bool
-}
-
-func (c offlineSourceConfig) SourceConfigType() string { return "offline-test-source" }
-
-func (c offlineSourceConfig) Initialize(context.Context, trace.Tracer) (sources.Source, error) {
-	*c.initialized = true
-	return nil, fmt.Errorf("source Initialize should not be called during offline init")
-}
-
-type offlineToolConfig struct {
-	name string
-}
-
-func (c offlineToolConfig) ToolConfigType() string { return "offline-test-tool" }
-
-func (c offlineToolConfig) Initialize(context.Context) (tools.Tool, error) {
-	return testutils.NewMockTool(c.name, "offline tool", nil, false, false), nil
+func TestInitializeConfigs(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("error setting up logger: %s", err)
+	}
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation("0.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+	t.Run("valid initialization", func(t *testing.T) {
+		sourceConfig1 := testutils.MockSourceConfig{Name: "my-source", Type: "mock-source"}
+		source1, _ := sourceConfig1.Initialize(ctx, nil)
+		tools1 := testutils.NewMockTool("my-tool", "mock tool for offline config", "my-source", nil, false, false)
+		validCfg := server.ServerConfig{
+			Version: "0.0.0",
+			SourceConfigs: server.SourceConfigs{
+				"my-source": testutils.MockSourceConfig{Name: "my-source", Type: "mock-source"},
+			},
+			ToolConfigs: server.ToolConfigs{
+				"my-tool": tools1.ToConfig(),
+			},
+		}
+		sourcesMap, _, _, toolsMap, _, _, err := server.InitializeConfigs(ctx, validCfg)
+		if err != nil {
+			t.Fatalf("unexpected error during config initialization: %s", err)
+		}
+		wantSourcesMap := map[string]sources.Source{"my-source": source1}
+		wantToolsMap := map[string]tools.Tool{"my-tool": tools1}
+		if !reflect.DeepEqual(sourcesMap, wantSourcesMap) {
+			t.Fatalf("sources map mismatch: want %s, got %s", wantSourcesMap, sourcesMap)
+		}
+		if !reflect.DeepEqual(toolsMap, wantToolsMap) {
+			t.Fatalf("tools map mismatch: want %s, got %s", wantToolsMap, toolsMap)
+		}
+	})
+	t.Run("invalid initialization", func(t *testing.T) {
+		invalidCfg := server.ServerConfig{
+			Version: "0.0.0",
+			SourceConfigs: server.SourceConfigs{
+				"my-source": testutils.MockSourceConfig{Name: "my-source", Type: "invalid-type"},
+			},
+			ToolConfigs: server.ToolConfigs{
+				"my-invalid-tool": testutils.NewMockTool("my-tool", "mock tool for offline config", "my-source", nil, false, false).ToConfig(),
+			},
+		}
+		_, _, _, _, _, _, err := server.InitializeConfigs(ctx, invalidCfg)
+		if err == nil {
+			t.Fatalf("expected error but got nil")
+		}
+		wantErr := "invalid source for mock-tool tool: source my-source is not a compatible type"
+		if err.Error() != wantErr {
+			t.Fatalf("unexpected error: want %s, got %s", wantErr, err.Error())
+		}
+	})
 }
 
 func TestInitializeOfflineConfigs(t *testing.T) {
@@ -1833,14 +1868,13 @@ func TestInitializeOfflineConfigs(t *testing.T) {
 	}
 	ctx = util.WithInstrumentation(ctx, instrumentation)
 
-	sourceInitialized := false
 	cfg := server.ServerConfig{
 		Version: "0.0.0",
 		SourceConfigs: server.SourceConfigs{
-			"my-source": offlineSourceConfig{initialized: &sourceInitialized},
+			"my-source": testutils.MockSourceConfig{Name: "my-source"},
 		},
 		ToolConfigs: server.ToolConfigs{
-			"my-tool": offlineToolConfig{name: "my-tool"},
+			"my-tool": testutils.NewMockTool("my-tool", "mock tool for offline config", "non-existance-source", nil, false, false).ToConfig(),
 		},
 		SkipSourceValidation: true,
 	}
@@ -1848,9 +1882,6 @@ func TestInitializeOfflineConfigs(t *testing.T) {
 	toolsMap, groupsMap, err := server.InitializeOfflineConfigs(ctx, cfg)
 	if err != nil {
 		t.Fatalf("InitializeOfflineConfigs returned error: %s", err)
-	}
-	if sourceInitialized {
-		t.Error("source Initialize was called during offline init")
 	}
 	if _, ok := toolsMap["my-tool"]; !ok {
 		t.Errorf("expected tool %q in toolsMap, got %v", "my-tool", toolsMap)
@@ -1929,9 +1960,9 @@ func TestDefaultToolsetIsAlphabeticallySorted(t *testing.T) {
 	cfg := server.ServerConfig{
 		Version: "0.0.0",
 		ToolConfigs: server.ToolConfigs{
-			"zoo":    offlineToolConfig{name: "zoo"},
-			"apple":  offlineToolConfig{name: "apple"},
-			"banana": offlineToolConfig{name: "banana"},
+			"zoo":    testutils.NewMockTool("zoo", "", "", nil, false, false).ToConfig(),
+			"apple":  testutils.NewMockTool("apple", "", "", nil, false, false).ToConfig(),
+			"banana": testutils.NewMockTool("banana", "", "", nil, false, false).ToConfig(),
 		},
 		SkipSourceValidation: true,
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1876,7 +1876,6 @@ func TestInitializeOfflineConfigs(t *testing.T) {
 		ToolConfigs: server.ToolConfigs{
 			"my-tool": testutils.NewMockTool("my-tool", "mock tool for offline config", "non-existance-source", nil, false, false).ToConfig(),
 		},
-		SkipSourceValidation: true,
 	}
 
 	toolsMap, groupsMap, err := server.InitializeOfflineConfigs(ctx, cfg)
@@ -1964,7 +1963,6 @@ func TestDefaultToolsetIsAlphabeticallySorted(t *testing.T) {
 			"apple":  testutils.NewMockTool("apple", "", "", nil, false, false).ToConfig(),
 			"banana": testutils.NewMockTool("banana", "", "", nil, false, false).ToConfig(),
 		},
-		SkipSourceValidation: true,
 	}
 
 	_, toolsetsMap, err := server.InitializeOfflineConfigs(ctx, cfg)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1850,7 +1850,7 @@ func TestInitializeConfigs(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error but got nil")
 		}
-		wantErr := "invalid source for mock-tool tool: source my-source is not a compatible type"
+		wantErr := `invalid source for "mock-tool" tool: source "my-source" is not a compatible type`
 		if err.Error() != wantErr {
 			t.Fatalf("unexpected error: want %s, got %s", wantErr, err.Error())
 		}

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -69,7 +69,7 @@ func (m MockToolConfig) ToolConfigType() string {
 func (m MockToolConfig) Initialize(context.Context) (tools.Tool, error) {
 	return MockTool{
 		BaseTool: tools.NewBaseTool(
-			m, tools.GetAnnotationsOrDefault(nil, nil),
+			m, tools.GetAnnotationsOrDefault(&tools.ToolAnnotations{}, nil),
 			tools.Manifest{Description: m.Description, Parameters: m.Parameters.Manifest(), AuthRequired: m.AuthRequired},
 			m.Parameters,
 		),

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -18,47 +18,97 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// MockSourceConfig is used to mock source config in tests
+type MockSourceConfig struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
+	Foo  string `yaml:"foo"`
+}
+
+func (m MockSourceConfig) SourceConfigType() string {
+	return m.Type
+}
+
+func (m MockSourceConfig) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
+	return MockSource{MockSourceConfig: m}, nil
+}
+
+// MockSource is used to mock source in tests
+type MockSource struct {
+	MockSourceConfig
+}
+
+func (s MockSource) SourceType() string {
+	return s.Type
+}
+
+func (s MockSource) ToConfig() sources.SourceConfig {
+	return s.MockSourceConfig
+}
+
+// MockToolConfig is used to mock tool config in tests
+type MockToolConfig struct {
+	tools.ConfigBase `yaml:",inline"`
+	Source           string                `yaml:"source"`
+	Parameters       parameters.Parameters `yaml:"parameters"`
+	Type             string                `yaml:"type"`
+}
+
+func (m MockToolConfig) ToolConfigType() string {
+	return "mock-tool"
+}
+
+func (m MockToolConfig) Initialize(context.Context) (tools.Tool, error) {
+	return MockTool{
+		BaseTool: tools.NewBaseTool(
+			m, tools.GetAnnotationsOrDefault(nil, nil),
+			tools.Manifest{Description: m.Description, Parameters: m.Parameters.Manifest(), AuthRequired: m.AuthRequired},
+			m.Parameters,
+		),
+	}, nil
+}
+
+var _ tools.ToolConfig = MockToolConfig{}
 
 // MockTool is used to mock tools in tests
 type MockTool struct {
-	Name                       string
-	Description                string
-	Params                     []parameters.Parameter
-	manifest                   tools.Manifest
+	tools.BaseTool[MockToolConfig]
 	unauthorized               bool
 	requireClientAuthorization bool
-	authRequired               []string
 	ReturnParamsInInvoke       bool
 }
 
 var _ tools.Tool = MockTool{}
 
 // NewMockTool creates a new mock prompt for testing.
-func NewMockTool(name, desc string, params []parameters.Parameter, unauthorized, requireClientAuthorization bool) MockTool {
-	pMs := make([]parameters.ParameterManifest, 0, len(params))
-	for _, p := range params {
-		pMs = append(pMs, p.Manifest())
+func NewMockTool(name, desc, source string, params []parameters.Parameter, unauthorized, reqClientAutho bool) MockTool {
+	mockConfig := MockToolConfig{
+		ConfigBase: tools.ConfigBase{
+			Name:        name,
+			Description: desc,
+		},
+		Source:     source,
+		Type:       "mock-tool",
+		Parameters: params,
 	}
-	manifest := tools.Manifest{Description: desc, Parameters: pMs}
-	return MockTool{
-		Name:                       name,
-		Description:                desc,
-		Params:                     params,
-		manifest:                   manifest,
-		unauthorized:               unauthorized,
-		requireClientAuthorization: requireClientAuthorization,
-	}
+	ctx := context.Background()
+	t, _ := mockConfig.Initialize(ctx)
+	mt := t.(MockTool)
+	mt.unauthorized = unauthorized
+	mt.requireClientAuthorization = reqClientAutho
+	return mt
 }
 
 func (t MockTool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
-	mock := []any{t.Name}
+	mock := []any{t.Cfg.Name}
 	if t.ReturnParamsInInvoke && len(params) > 0 {
 		for _, p := range params {
 			mock = append(mock, p.Value)
@@ -68,69 +118,31 @@ func (t MockTool) Invoke(ctx context.Context, s sources.Source, params parameter
 }
 
 func (t MockTool) GetSourceName() string {
-	return ""
+	return t.Cfg.Source
 }
 
 func (t MockTool) ToConfig() tools.ToolConfig {
 	return nil
 }
 
-func (t MockTool) ValidateSource(sources.Source) error {
-	return nil
+func (t MockTool) Authorized(verifiedAuthServices []string) bool {
+	// default to true
+	return !t.unauthorized
+}
+
+func (t MockTool) ValidateSource(src sources.Source) error {
+	if src.SourceType() == "mock-source" {
+		return nil
+	}
+	return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 }
 
 // claims is a map of user info decoded from an auth token
 func (t MockTool) ParseParams(data map[string]any, claimsMap map[string]map[string]any) (parameters.ParamValues, error) {
-	return parameters.ParseParams(t.Params, data, claimsMap)
-}
-
-func (t MockTool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.Params, paramValues, embeddingModelsMap, nil)
-}
-
-func (t MockTool) Manifest(sources.Source) (tools.Manifest, error) {
-	return t.manifest, nil
-}
-
-func (t MockTool) StaticManifest() tools.Manifest {
-	return t.manifest
-}
-
-func (t MockTool) Authorized(verifiedAuthServices []string) bool {
-	// defaulted to true
-	return !t.unauthorized
-}
-
-func (t MockTool) RequiresClientAuthorization(sources.Source) (bool, error) {
-	// defaulted to false
-	return t.requireClientAuthorization, nil
-}
-
-func (t MockTool) GetParameters(sources.Source) (parameters.Parameters, error) {
-	return t.Params, nil
-}
-
-func (t MockTool) GetName() string {
-	return t.Name
-}
-
-func (t MockTool) GetDescription() string {
-	return t.Description
-}
-
-func (t MockTool) GetAuthRequired() []string {
-	return t.authRequired
+	return parameters.ParseParams(t.StaticParameters, data, claimsMap)
 }
 
 func (t MockTool) GetAnnotations() *tools.ToolAnnotations {
-	return nil
-}
-
-func (t MockTool) GetAuthTokenHeaderName(sources.Source) (string, error) {
-	return "Authorization", nil
-}
-
-func (t MockTool) GetScopesRequired() []string {
 	return nil
 }
 

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -107,6 +107,11 @@ func NewMockTool(name, desc, source string, params []parameters.Parameter, unaut
 	return mt
 }
 
+func (t MockTool) RequiresClientAuthorization(sources.Source) (bool, error) {
+	// defaulted to false
+	return t.requireClientAuthorization, nil
+}
+
 func (t MockTool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
 	mock := []any{t.Cfg.Name}
 	if t.ReturnParamsInInvoke && len(params) > 0 {
@@ -122,7 +127,7 @@ func (t MockTool) GetSourceName() string {
 }
 
 func (t MockTool) ToConfig() tools.ToolConfig {
-	return nil
+	return t.Cfg
 }
 
 func (t MockTool) Authorized(verifiedAuthServices []string) bool {
@@ -131,7 +136,7 @@ func (t MockTool) Authorized(verifiedAuthServices []string) bool {
 }
 
 func (t MockTool) ValidateSource(src sources.Source) error {
-	if src.SourceType() == "mock-source" {
+	if src == nil || src.SourceType() == "mock-source" {
 		return nil
 	}
 	return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -119,30 +119,30 @@ func WaitForString(ctx context.Context, re *regexp.Regexp, pr io.ReadCloser) (st
 	}
 }
 
-var MockTool1 = NewMockTool("no_params", "", []parameters.Parameter{}, false, false)
+var MockTool1 = NewMockTool("no_params", "", "", []parameters.Parameter{}, false, false)
 
 var MockTool2 = NewMockTool(
 	"some_params",
-	"",
+	"", "",
 	parameters.Parameters{
 		parameters.NewIntParameter("param1", "This is the first parameter."),
 		parameters.NewIntParameter("param2", "This is the second parameter."),
 	}, false, false)
 
 var MockTool3 = NewMockTool(
-	"array_param", "some description",
+	"array_param", "some description", "",
 	parameters.Parameters{
 		parameters.NewArrayParameter("my_array", "this param is an array of strings", parameters.NewStringParameter("my_string", "string item")),
 	}, false, false)
 
-var MockTool4 = NewMockTool("unauthorized_tool", "", []parameters.Parameter{}, true, false)
+var MockTool4 = NewMockTool("unauthorized_tool", "", "", []parameters.Parameter{}, true, false)
 
-var MockTool5 = NewMockTool("require_client_auth_tool", "", []parameters.Parameter{}, false, true)
+var MockTool5 = NewMockTool("require_client_auth_tool", "", "", []parameters.Parameter{}, false, true)
 
 var MockToolUrlBinding = func() MockTool {
 	t := NewMockTool(
 		"url_binding_tool",
-		"A tool for testing URL param binding",
+		"A tool for testing URL param binding", "",
 		parameters.Parameters{
 			parameters.NewStringParameter("param1", "A bound string param"),
 			parameters.NewIntParameter("param2", "A bound int param"),
@@ -169,8 +169,9 @@ func SetUpResources(t *testing.T, mockTools []MockTool, mockPrompts []MockPrompt
 	toolsMap := make(map[string]tools.Tool)
 	var allTools []string
 	for _, tool := range mockTools {
-		toolsMap[tool.Name] = tool
-		allTools = append(allTools, tool.Name)
+		toolName := tool.GetName()
+		toolsMap[toolName] = tool
+		allTools = append(allTools, toolName)
 	}
 
 	groupToolNames := make(map[string][]string)

--- a/internal/tools/toolsets_test.go
+++ b/internal/tools/toolsets_test.go
@@ -28,7 +28,7 @@ import (
 func TestToolsetConfig_Initialize(t *testing.T) {
 	t.Parallel()
 
-	var tool1 = testutils.NewMockTool("tool1", "some description", "", nil, false, false)
+	var tool1 = testutils.NewMockTool("tool1", "some description", "", []parameters.Parameter{}, false, false)
 	var tool2 = testutils.NewMockTool(
 		"tool2",
 		"some description", "",
@@ -167,7 +167,7 @@ func TestToolsetConfig_Initialize(t *testing.T) {
 					t.Errorf("Initialize() error mismatch:\n  want to contain: %q\n  got: %q", tc.wantErr, err.Error())
 				}
 				// Also check that the partially populated struct matches
-				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockTool{}), cmpopts.IgnoreUnexported(tools.Toolset{})); diff != "" {
+				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockTool{}), cmp.AllowUnexported(tools.BaseTool[testutils.MockToolConfig]{}), cmpopts.IgnoreUnexported(tools.Toolset{})); diff != "" {
 					t.Errorf("Initialize() partial result on error mismatch (-want +got):\n%s", diff)
 				}
 			} else {
@@ -175,7 +175,7 @@ func TestToolsetConfig_Initialize(t *testing.T) {
 					t.Fatalf("Initialize() returned unexpected error: %v", err)
 				}
 				// Using cmp.AllowUnexported because MockTool is unexported
-				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockTool{}), cmpopts.IgnoreUnexported(tools.Toolset{})); diff != "" {
+				if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(testutils.MockTool{}), cmp.AllowUnexported(tools.BaseTool[testutils.MockToolConfig]{}), cmpopts.IgnoreUnexported(tools.Toolset{})); diff != "" {
 					t.Errorf("Initialize() result mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/internal/tools/toolsets_test.go
+++ b/internal/tools/toolsets_test.go
@@ -28,10 +28,10 @@ import (
 func TestToolsetConfig_Initialize(t *testing.T) {
 	t.Parallel()
 
-	var tool1 = testutils.NewMockTool("tool1", "some description", []parameters.Parameter{}, false, false)
+	var tool1 = testutils.NewMockTool("tool1", "some description", "", nil, false, false)
 	var tool2 = testutils.NewMockTool(
 		"tool2",
-		"some description",
+		"some description", "",
 		parameters.Parameters{
 			parameters.NewIntParameter("param1", "This is the first parameter."),
 			parameters.NewIntParameter("param2", "This is the second parameter."),

--- a/tests/clickhouse/clickhouse_integration_test.go
+++ b/tests/clickhouse/clickhouse_integration_test.go
@@ -910,11 +910,6 @@ func TestClickHouseListDatabasesTool(t *testing.T) {
 				"source":      "my-instance",
 				"description": "Test listing databases",
 			},
-			"test-invalid-source": map[string]any{
-				"type":        "clickhouse-list-databases",
-				"source":      "non-existent-source",
-				"description": "Test with invalid source",
-			},
 		},
 	}
 
@@ -982,15 +977,6 @@ func TestClickHouseListDatabasesTool(t *testing.T) {
 		}
 
 		t.Logf("Successfully listed %d databases", len(databases))
-	})
-
-	t.Run("ListDatabasesWithInvalidSource", func(t *testing.T) {
-		api := "http://127.0.0.1:5000/api/tool/test-invalid-source/invoke"
-		resp, _ := tests.RunRequest(t, http.MethodPost, api, bytes.NewBuffer([]byte(`{}`)), nil)
-		if resp.StatusCode == http.StatusOK {
-			t.Fatalf("expected error for non-existent source, but got 200 OK")
-		}
-
 	})
 
 	t.Logf("✅ clickhouse-list-databases tool tests completed successfully")

--- a/tests/clickhouse/clickhouse_integration_test.go
+++ b/tests/clickhouse/clickhouse_integration_test.go
@@ -1039,11 +1039,6 @@ func TestClickHouseListTablesTool(t *testing.T) {
 				"source":      "my-instance",
 				"description": "Test listing tables",
 			},
-			"test-invalid-source": map[string]any{
-				"type":        "clickhouse-list-tables",
-				"source":      "non-existent-source",
-				"description": "Test with invalid source",
-			},
 		},
 	}
 
@@ -1125,14 +1120,6 @@ func TestClickHouseListTablesTool(t *testing.T) {
 		resp, _ := tests.RunRequest(t, http.MethodPost, api, bytes.NewBuffer([]byte(`{}`)), nil)
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("Expected 200 OK for missing database parameter, but got %d", resp.StatusCode)
-		}
-	})
-
-	t.Run("ListTablesWithInvalidSource", func(t *testing.T) {
-		api := "http://127.0.0.1:5000/api/tool/test-invalid-source/invoke"
-		resp, _ := tests.RunRequest(t, http.MethodPost, api, bytes.NewBuffer([]byte(`{}`)), nil)
-		if resp.StatusCode != http.StatusNotFound {
-			t.Errorf("Expected 404 NOT FOUND for non-existent source, but got %d", resp.StatusCode)
 		}
 	})
 


### PR DESCRIPTION
Tool validation is added during server startup, except for during skills generation.