### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # MCP Toolbox for Databases
 
+[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fgenai-toolbox.svg)](https://mcptoplist.com/server/pulsemcp%2Fgenai-toolbox)
+
 <a href="https://trendshift.io/repositories/25495" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25495" alt="googleapis%2Fmcp-toolbox | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/googleapis/mcp-toolbox)](https://goreportcard.com/report/github.com/googleapis/mcp-toolbox)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 77,308 MCP servers across the major
registries, and **Toolbox for Databases** is currently ranked **#8**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fgenai-toolbox.svg)](https://mcptoplist.com/server/pulsemcp%2Fgenai-toolbox)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Toolbox for Databases!
