### PR TITLE
feat(build): add support for linux/arm64 binary distribution

### DIFF
--- a/.ci/continuous.release.cloudbuild.yaml
+++ b/.ci/continuous.release.cloudbuild.yaml
@@ -114,6 +114,57 @@ steps:
         export VERSION=$(cat ./cmd/version.txt)
         go build -ldflags "-X github.com/googleapis/mcp-toolbox/cmd.commitSha=$(git rev-parse --short HEAD)" -o toolbox.geminicli.linux.amd64
 
+  - id: "build-linux-arm64"
+    name: golang:1
+    waitFor:
+      - "install-dependencies"
+      - "install-zig"
+    env:
+      - 'GOPATH=/gopath'
+      - 'CGO_ENABLED=1'
+      - 'GOOS=linux'
+      - 'GOARCH=arm64'
+      - 'CC=/zig-tools/zig cc -target aarch64-linux-gnu'
+      - 'CXX=/zig-tools/zig c++ -target aarch64-linux-gnu'
+    volumes:
+      - name: 'go'
+        path: '/gopath'
+      - name: 'zig'
+        path: '/zig-tools'
+    script: |
+        #!/usr/bin/env bash
+        go build -ldflags "-X github.com/googleapis/mcp-toolbox/cmd.commitSha=$(git rev-parse --short HEAD)" -o toolbox.linux.arm64
+
+  - id: "store-linux-arm64"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "build-linux-arm64"
+    script: |
+        #!/usr/bin/env bash
+        gcloud storage cp toolbox.linux.arm64 gs://$_BUCKET_NAME/$REF_NAME/linux/arm64/toolbox
+
+  - id: "build-linux-arm64-geminicli"
+    name: golang:1
+    waitFor:
+      - "install-dependencies"
+      - "install-zig"
+    env:
+      - 'GOPATH=/gopath'
+      - 'CGO_ENABLED=1'
+      - 'GOOS=linux'
+      - 'GOARCH=arm64'
+      - 'CC=/zig-tools/zig cc -target aarch64-linux-gnu'
+      - 'CXX=/zig-tools/zig c++ -target aarch64-linux-gnu'
+    volumes:
+      - name: 'go'
+        path: '/gopath'
+      - name: 'zig'
+        path: '/zig-tools'
+    script: |
+        #!/usr/bin/env bash
+        export VERSION=$(cat ./cmd/version.txt)
+        go build -ldflags "-X github.com/googleapis/mcp-toolbox/cmd.commitSha=$(git rev-parse --short HEAD)" -o toolbox.geminicli.linux.arm64
+
   - id: "build-darwin-arm64"
     name: golang:1
     waitFor:

--- a/.ci/generate_release_table.sh
+++ b/.ci/generate_release_table.sh
@@ -8,7 +8,7 @@ if [ -z "${VERSION}" ]; then
 fi
 
 
-FILES=("linux.amd64" "darwin.arm64" "darwin.amd64" "windows.amd64" "windows.arm64")
+FILES=("linux.amd64" "linux.arm64" "darwin.arm64" "darwin.amd64" "windows.amd64" "windows.arm64")
 
 echo "Waiting for Kokoro to sign and upload binaries to gs://mcp-toolbox-for-databases..."
 
@@ -30,13 +30,15 @@ for file_key in "${FILES[@]}"; do
     echo "Found signed binary: ${URL}!"
 done
 
-# Wait for the Linux GPG signature
-LINUX_SIG_URL="https://storage.googleapis.com/mcp-toolbox-for-databases/$VERSION/linux/amd64/toolbox.asc"
-until curl --fail --silent --head "${LINUX_SIG_URL}" > /dev/null 2>&1; do
-    echo "Waiting for Linux GPG signature: ${LINUX_SIG_URL}..."
-    sleep 30
+# Wait for the Linux GPG signatures
+for LINUX_ARCH in amd64 arm64; do
+    LINUX_SIG_URL="https://storage.googleapis.com/mcp-toolbox-for-databases/$VERSION/linux/$LINUX_ARCH/toolbox.asc"
+    until curl --fail --silent --head "${LINUX_SIG_URL}" > /dev/null 2>&1; do
+        echo "Waiting for Linux GPG signature: ${LINUX_SIG_URL}..."
+        sleep 30
+    done
+    echo "Found Linux GPG signature: ${LINUX_SIG_URL}!"
 done
-echo "Found Linux GPG signature: ${LINUX_SIG_URL}!"
 
 
 output_string=""
@@ -44,6 +46,7 @@ output_string=""
 # Define the descriptions - ensure this array's order matches FILES
 DESCRIPTIONS=(
     "For **Linux** systems running on **Intel/AMD 64-bit processors**."
+    "For **Linux** systems running on **ARM 64-bit processors**."
     "For **macOS** systems running on **Apple Silicon** (M1, M2, M3, etc.) processors."
     "For **macOS** systems running on **Intel processors**."
     "For **Windows** systems running on **Intel/AMD 64-bit processors**."
@@ -81,7 +84,7 @@ do
 
     # Write the table row
     if [ "$OS" = 'linux' ]; then
-        SIG_URL="https://storage.googleapis.com/mcp-toolbox-for-databases/$VERSION/linux/amd64/toolbox.asc"
+        SIG_URL="https://storage.googleapis.com/mcp-toolbox-for-databases/$VERSION/linux/$ARCH/toolbox.asc"
         output_string+=$(printf "$ROW_FMT" "[$OS/$ARCH]($URL) ([Signature]($SIG_URL))" "$description_text" "$SHA256")$'\n'
     else
         output_string+=$(printf "$ROW_FMT" "[$OS/$ARCH]($URL)" "$description_text" "$SHA256")$'\n'

--- a/.ci/publish_npm_to_ar.sh
+++ b/.ci/publish_npm_to_ar.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Publishes the six @toolbox-sdk npm packages (5 platform-specific + 1 wrapper)
+# Publishes the seven @toolbox-sdk npm packages (6 platform-specific + 1 wrapper)
 # to the OSS Exit Gate internal Artifact Registry. The Exit Gate then ships
 # them externally to npmjs.org once trigger_exit_gate.sh uploads the manifest.
 #
@@ -82,6 +82,7 @@ publish_platform() {
 }
 
 publish_platform "server-linux-x64"    "toolbox.linux.amd64"   "toolbox"
+publish_platform "server-linux-arm64"  "toolbox.linux.arm64"   "toolbox"
 publish_platform "server-darwin-arm64" "toolbox.darwin.arm64"  "toolbox"
 publish_platform "server-darwin-x64"   "toolbox.darwin.amd64"  "toolbox"
 publish_platform "server-win32-x64"    "toolbox.windows.amd64" "toolbox.exe"

--- a/.ci/publish_pypi_to_ar.sh
+++ b/.ci/publish_pypi_to_ar.sh
@@ -77,11 +77,12 @@ build_wheel() {
   (cd "${PYPI_DIR}" && TOOLBOX_PLATFORM="${plat}" python -m build --wheel)
 }
 
-build_wheel "toolbox.linux.amd64"   "manylinux2014_x86_64" "toolbox"
-build_wheel "toolbox.darwin.arm64"  "macosx_11_0_arm64"    "toolbox"
-build_wheel "toolbox.darwin.amd64"  "macosx_10_14_x86_64"  "toolbox"
-build_wheel "toolbox.windows.amd64" "win_amd64"            "toolbox.exe"
-build_wheel "toolbox.windows.arm64" "win_arm64"            "toolbox.exe"
+build_wheel "toolbox.linux.amd64"   "manylinux2014_x86_64"  "toolbox"
+build_wheel "toolbox.linux.arm64"   "manylinux2014_aarch64" "toolbox"
+build_wheel "toolbox.darwin.arm64"  "macosx_11_0_arm64"     "toolbox"
+build_wheel "toolbox.darwin.amd64"  "macosx_10_14_x86_64"   "toolbox"
+build_wheel "toolbox.windows.amd64" "win_amd64"             "toolbox.exe"
+build_wheel "toolbox.windows.arm64" "win_arm64"             "toolbox.exe"
 
 twine upload \
   --repository-url "${AR_URL}" \

--- a/.ci/pypi_retry.cloudbuild.yaml
+++ b/.ci/pypi_retry.cloudbuild.yaml
@@ -14,7 +14,7 @@
 #
 # Retry-only pipeline for the OSS Exit Gate PyPI publish steps. Use when the
 # PyPI portion of the versioned release fails after Go binaries are already in
-# GCS. The fetch-binaries step downloads the five platform binaries from GCS
+# GCS. The fetch-binaries step downloads the six platform binaries from GCS
 # by version into the workspace, then publish_pypi_to_ar.sh builds and
 # uploads the wheels (twine's --skip-existing makes uploads idempotent).
 #
@@ -36,6 +36,7 @@ steps:
       BUCKET="gs://mcp-toolbox-for-databases/${VERSION}"
 
       gcloud storage cp "${BUCKET}/linux/amd64/toolbox"       toolbox.linux.amd64
+      gcloud storage cp "${BUCKET}/linux/arm64/toolbox"       toolbox.linux.arm64
       gcloud storage cp "${BUCKET}/darwin/arm64/toolbox"      toolbox.darwin.arm64
       gcloud storage cp "${BUCKET}/darwin/amd64/toolbox"      toolbox.darwin.amd64
       gcloud storage cp "${BUCKET}/windows/amd64/toolbox.exe" toolbox.windows.amd64

--- a/.ci/versioned.release.cloudbuild.yaml
+++ b/.ci/versioned.release.cloudbuild.yaml
@@ -139,6 +139,66 @@ steps:
       export VERSION=v$(cat ./cmd/version.txt)
       gcloud storage cp toolbox.geminicli.linux.amd64 gs://$_BUCKET_NAME/geminicli/$VERSION/linux/amd64/toolbox
 
+  - id: "build-linux-arm64"
+    name: golang:1
+    waitFor:
+      - "install-dependencies"
+      - "install-zig"
+    env:
+      - "GOPATH=/gopath"
+      - "CGO_ENABLED=1"
+      - "GOOS=linux"
+      - "GOARCH=arm64"
+      - "CC=/zig-tools/zig cc -target aarch64-linux-gnu"
+      - "CXX=/zig-tools/zig c++ -target aarch64-linux-gnu"
+    volumes:
+      - name: "go"
+        path: "/gopath"
+      - name: "zig"
+        path: "/zig-tools"
+    script: |
+      #!/usr/bin/env bash
+      go build -ldflags "-X github.com/googleapis/mcp-toolbox/cmd.buildType=binary -X github.com/googleapis/mcp-toolbox/cmd.commitSha=$(git rev-parse --short HEAD)" -o toolbox.linux.arm64
+
+  - id: "store-linux-arm64"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "build-linux-arm64"
+    script: |
+      #!/usr/bin/env bash
+      export VERSION=v$(cat ./cmd/version.txt)
+      gcloud storage cp toolbox.linux.arm64 gs://$_UNSIGNED_BUCKET_NAME/$VERSION/linux/arm64/toolbox
+
+  - id: "build-linux-arm64-geminicli"
+    name: golang:1
+    waitFor:
+      - "install-dependencies"
+      - "install-zig"
+    env:
+      - "GOPATH=/gopath"
+      - "CGO_ENABLED=1"
+      - "GOOS=linux"
+      - "GOARCH=arm64"
+      - "CC=/zig-tools/zig cc -target aarch64-linux-gnu"
+      - "CXX=/zig-tools/zig c++ -target aarch64-linux-gnu"
+    volumes:
+      - name: "go"
+        path: "/gopath"
+      - name: "zig"
+        path: "/zig-tools"
+    script: |
+      #!/usr/bin/env bash
+      go build -ldflags "-X github.com/googleapis/mcp-toolbox/cmd.buildType=geminicli.binary -X github.com/googleapis/mcp-toolbox/cmd.commitSha=$(git rev-parse --short HEAD)" -o toolbox.geminicli.linux.arm64
+
+  - id: "store-linux-arm64-geminicli"
+    name: "gcr.io/cloud-builders/gcloud:latest"
+    waitFor:
+      - "build-linux-arm64-geminicli"
+    script: |
+      #!/usr/bin/env bash
+      export VERSION=v$(cat ./cmd/version.txt)
+      gcloud storage cp toolbox.geminicli.linux.arm64 gs://$_BUCKET_NAME/geminicli/$VERSION/linux/arm64/toolbox
+
   - id: "build-darwin-arm64"
     name: golang:1
     waitFor:
@@ -411,6 +471,7 @@ steps:
     name: node:20
     waitFor:
       - "build-linux-amd64"
+      - "build-linux-arm64"
       - "build-darwin-arm64"
       - "build-darwin-amd64"
       - "build-windows-amd64"
@@ -433,6 +494,7 @@ steps:
     name: python:3.12
     waitFor:
       - "build-linux-amd64"
+      - "build-linux-arm64"
       - "build-darwin-arm64"
       - "build-darwin-amd64"
       - "build-windows-amd64"

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -65,6 +65,11 @@ extraFiles:
     {
       "type": "json",
       "path": "npm/server/package.json",
+      "jsonpath": "$.optionalDependencies['@toolbox-sdk/server-linux-arm64']",
+    },
+    {
+      "type": "json",
+      "path": "npm/server/package.json",
       "jsonpath": "$.optionalDependencies['@toolbox-sdk/server-linux-x64']",
     },
     {
@@ -85,6 +90,11 @@ extraFiles:
     {
       "type": "json",
       "path": "npm/server-darwin-x64/package.json",
+      "jsonpath": "$.version",
+    },
+    {
+      "type": "json",
+      "path": "npm/server-linux-arm64/package.json",
       "jsonpath": "$.version",
     },
     {

--- a/README.md
+++ b/README.md
@@ -248,6 +248,19 @@ To install Toolbox as a binary:
 >
 > </details>
 > <details>
+> <summary>Linux (ARM64)</summary>
+>
+> To install Toolbox as a binary on Linux (ARM64):
+>
+> ```sh
+> # see releases page for other versions
+> export VERSION=1.8.0
+> curl -L -o toolbox https://storage.googleapis.com/mcp-toolbox-for-databases/v$VERSION/linux/arm64/toolbox
+> chmod +x toolbox
+> ```
+>
+> </details>
+> <details>
 > <summary>macOS (Apple Silicon)</summary>
 >
 > To install Toolbox as a binary on macOS (Apple Silicon):

--- a/docs/en/documentation/connect-to/ides/cloud_sql_mssql_admin_mcp.md
+++ b/docs/en/documentation/connect-to/ides/cloud_sql_mssql_admin_mcp.md
@@ -69,6 +69,10 @@ instance, database and users:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/cloud_sql_mysql_admin_mcp.md
+++ b/docs/en/documentation/connect-to/ides/cloud_sql_mysql_admin_mcp.md
@@ -69,6 +69,10 @@ database and users:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/cloud_sql_pg_admin_mcp.md
+++ b/docs/en/documentation/connect-to/ides/cloud_sql_pg_admin_mcp.md
@@ -69,6 +69,10 @@ instance, database and users:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.15.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/looker_mcp.md
+++ b/docs/en/documentation/connect-to/ides/looker_mcp.md
@@ -112,6 +112,10 @@ After you install Looker in the MCP Store, resources and tools from the server a
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/mssql_mcp.md
+++ b/docs/en/documentation/connect-to/ides/mssql_mcp.md
@@ -48,6 +48,10 @@ instance:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/mysql_mcp.md
+++ b/docs/en/documentation/connect-to/ides/mysql_mcp.md
@@ -46,6 +46,10 @@ expose your developer assistant tools to a MySQL instance:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/neo4j_mcp.md
+++ b/docs/en/documentation/connect-to/ides/neo4j_mcp.md
@@ -47,6 +47,10 @@ expose your developer assistant tools to a Neo4j instance:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/oracle_mcp.md
+++ b/docs/en/documentation/connect-to/ides/oracle_mcp.md
@@ -49,6 +49,10 @@ to expose your developer assistant tools to an Oracle instance:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/postgres_mcp.md
+++ b/docs/en/documentation/connect-to/ides/postgres_mcp.md
@@ -59,6 +59,10 @@ Omni](https://cloud.google.com/alloydb/omni/docs/overview).
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/connect-to/ides/sqlite_mcp.md
+++ b/docs/en/documentation/connect-to/ides/sqlite_mcp.md
@@ -46,6 +46,10 @@ to expose your developer assistant tools to a SQLite instance:
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/amd64/toolbox
 {{< /tab >}}
 
+{{< tab header="linux/arm64" lang="bash" >}}
+curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/linux/arm64/toolbox
+{{< /tab >}}
+
 {{< tab header="darwin/arm64" lang="bash" >}}
 curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/darwin/arm64/toolbox
 {{< /tab >}}

--- a/docs/en/documentation/getting-started/mcp_quickstart/_index.md
+++ b/docs/en/documentation/getting-started/mcp_quickstart/_index.md
@@ -106,7 +106,7 @@ In this section, we will download Toolbox, configure our tools in a
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/$OS/toolbox
     ```
     <!-- {x-release-please-end} -->

--- a/docs/en/documentation/getting-started/quickstart/shared/configure_toolbox.md
+++ b/docs/en/documentation/getting-started/quickstart/shared/configure_toolbox.md
@@ -14,7 +14,7 @@ In this section, we will download Toolbox, configure our tools in a
       <!-- {x-release-please-start-version} -->
 
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/$OS/toolbox
     ```
 

--- a/docs/en/documentation/introduction/_index.md
+++ b/docs/en/documentation/introduction/_index.md
@@ -116,6 +116,17 @@ chmod +x toolbox
 ```
 
 {{% /tab %}}
+{{% tab header="Linux (ARM64)" lang="en" %}}
+To install Toolbox as a binary on Linux (ARM64):
+
+```sh
+# see releases page for other versions
+export VERSION=1.8.0
+curl -L -o toolbox https://storage.googleapis.com/mcp-toolbox-for-databases/v$VERSION/linux/arm64/toolbox
+chmod +x toolbox
+```
+
+{{% /tab %}}
 {{% tab header="macOS (Apple Silicon)" lang="en" %}}
 To install Toolbox as a binary on macOS (Apple Silicon):
 

--- a/docs/en/integrations/alloydb/samples/mcp_quickstart.md
+++ b/docs/en/integrations/alloydb/samples/mcp_quickstart.md
@@ -124,7 +124,7 @@ In this section, we will download and install the Toolbox binary.
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     export VERSION="0.30.0"
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v$VERSION/$OS/toolbox
     ```

--- a/docs/en/integrations/bigquery/samples/local_quickstart.md
+++ b/docs/en/integrations/bigquery/samples/local_quickstart.md
@@ -180,7 +180,7 @@ to use BigQuery, and then run the Toolbox server.
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.30.0/$OS/toolbox
     ```
     <!-- {x-release-please-end} -->

--- a/docs/en/integrations/bigquery/samples/mcp_quickstart/_index.md
+++ b/docs/en/integrations/bigquery/samples/mcp_quickstart/_index.md
@@ -99,7 +99,7 @@ In this section, we will download Toolbox, configure our tools in a
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v0.30.0/$OS/toolbox
     ```
     <!-- {x-release-please-end} -->

--- a/docs/en/integrations/looker/samples/looker_gemini.md
+++ b/docs/en/integrations/looker/samples/looker_gemini.md
@@ -35,7 +35,7 @@ In this section, we will download Toolbox and run the Toolbox server.
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/$OS/toolbox
     ```
     <!-- {x-release-please-end} -->

--- a/docs/en/integrations/looker/samples/looker_gemini_oauth/_index.md
+++ b/docs/en/integrations/looker/samples/looker_gemini_oauth/_index.md
@@ -49,7 +49,7 @@ In this section, we will download Toolbox and run the Toolbox server.
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/$OS/toolbox
     ```
     <!-- {x-release-please-end} -->

--- a/docs/en/integrations/looker/samples/looker_mcp_inspector/_index.md
+++ b/docs/en/integrations/looker/samples/looker_mcp_inspector/_index.md
@@ -35,7 +35,7 @@ In this section, we will download Toolbox and run the Toolbox server.
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v1.8.0/$OS/toolbox
     ```
     <!-- {x-release-please-end} -->

--- a/docs/en/integrations/neo4j/samples/mcp_quickstart.md
+++ b/docs/en/integrations/neo4j/samples/mcp_quickstart.md
@@ -40,7 +40,7 @@ The simplest way to get started is to download the latest binary for your operat
 \+
 
 ```bash
-export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
 curl -O [https://storage.googleapis.com/mcp-toolbox-for-databases/v0.16.0/$OS/toolbox](https://storage.googleapis.com/mcp-toolbox-for-databases/v0.16.0/$OS/toolbox)
 ```
 

--- a/docs/en/integrations/snowflake/samples/sample.md
+++ b/docs/en/integrations/snowflake/samples/sample.md
@@ -54,7 +54,7 @@ In this section, we will download and install the Toolbox binary.
     {{< /notice >}}
     <!-- {x-release-please-start-version} -->
     ```bash
-    export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
+    export OS="linux/amd64" # one of linux/amd64, linux/arm64, darwin/arm64, darwin/amd64, windows/amd64, or windows/arm64
     export VERSION="0.10.0"
     curl -O https://storage.googleapis.com/mcp-toolbox-for-databases/v$VERSION/$OS/toolbox
     ```

--- a/maintainer-playbook.md
+++ b/maintainer-playbook.md
@@ -266,6 +266,7 @@ The following operating systems and architectures are supported for binary
 releases:
 
 * linux/amd64
+* linux/arm64
 * darwin/arm64
 * darwin/amd64
 * windows/amd64
@@ -299,7 +300,7 @@ MCP Toolbox is available as an npm package: [@toolbox-sdk/server](https://www.np
 >
 > **PyPI releases** are automated through the same Exit Gate via the
 > `publish-pypi-to-ar` and `trigger-exit-gate-pypi` steps. Each release
-> builds five platform-tagged wheels (one per OS/arch) via
+> builds six platform-tagged wheels (one per OS/arch) via
 > [pypi/setup.py](pypi/setup.py) with `TOOLBOX_PLATFORM` set per wheel,
 > uploads them all to `us-python.pkg.dev/oss-exit-gate-prod/mcp-toolbox--pypi`,
 > then drops a manifest at
@@ -324,13 +325,14 @@ To release a new version manually, follow these steps:
 - You will be publishing packages for the following OS/Architecture combinations:
   - `darwin/arm64` -> `server-darwin-arm64`
   - `darwin/x64` -> `server-darwin-x64`
+  - `linux/arm64` -> `server-linux-arm64`
   - `linux/x64` -> `server-linux-x64`
   - `win32/arm64` -> `server-win32-arm64`
   - `win32/x64` -> `server-win32-x64`
 
 **Phase A: Release Platform-Specific Packages**
 
-_Repeat the following steps for each of the 5 combinations listed above._
+_Repeat the following steps for each of the 6 combinations listed above._
 
 1. **Navigate to the package directory:**
    ```bash
@@ -364,8 +366,8 @@ Once all platform-specific packages are live, release the main wrapper package.
    ```
 2. **Verify Versioning:**
    - Open `package.json` and verify the `"version"` field reflects the target version.
-   - Verify that versions for dependencies in `"optionalDependencies"` match the new version for all 5 packages.
-3. **Sync Lockfile:** (Before this step, all 5 dep packages need to be published to npm)
+   - Verify that versions for dependencies in `"optionalDependencies"` match the new version for all 6 packages.
+3. **Sync Lockfile:** (Before this step, all 6 dep packages need to be published to npm)
    ```bash
    npm install --package-lock-only
    ```

--- a/npm/server-linux-arm64/README.md
+++ b/npm/server-linux-arm64/README.md
@@ -1,0 +1,6 @@
+# @toolbox-sdk/server-linux-arm64
+
+Platform-specific binary for the `toolbox` package on Linux arm64.
+This package is automatically installed by the main `@toolbox-sdk/server` package and is not intended to be installed directly.
+
+For more information, visit the [toolbox npm package](https://www.npmjs.com/package/@toolbox-sdk/server).

--- a/npm/server-linux-arm64/package-lock.json
+++ b/npm/server-linux-arm64/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "@toolbox-sdk/server-linux-arm64",
+  "version": "1.8.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@toolbox-sdk/server-linux-arm64",
+      "version": "1.8.0",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "os": [
+        "linux"
+      ]
+    }
+  }
+}

--- a/npm/server-linux-arm64/package.json
+++ b/npm/server-linux-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@toolbox-sdk/server-linux-arm64",
+  "version": "1.8.0",
+  "license": "Apache-2.0",
+  "author": "Google LLC",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "bin/toolbox",
+  "repository": "googleapis/mcp-toolbox",
+  "scripts": {
+    "prepack": "node scripts/downloadBinary.js linux arm64"
+  },
+  "files": [
+    "bin/toolbox"
+  ]
+}

--- a/npm/server-linux-arm64/scripts/downloadBinary.js
+++ b/npm/server-linux-arm64/scripts/downloadBinary.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { execSync } = require('child_process');
+
+// 1. Configuration
+const PLATFORM_MAP = {
+  'linux': 'linux',
+  'darwin': 'darwin',
+  'win32': 'windows'
+};
+
+const ARCH_MAP = {
+  'x64': 'amd64',
+  'arm64': 'arm64'
+};
+
+const args = process.argv.slice(2);
+if (args.length < 2) {
+  console.error("Usage: node download-binary.js <platform> <arch>");
+  process.exit(1);
+}
+
+const [targetPlatform, targetArch] = args;
+
+// 2. Determine Version
+const version = fs.readFileSync(path.join(__dirname, '..', '..', '..', 'cmd', 'version.txt'), 'utf8').trim();
+
+// 3. Construct URL
+const gcsPlatform = PLATFORM_MAP[targetPlatform];
+const gcsArch = ARCH_MAP[targetArch];
+
+if (!gcsPlatform || !gcsArch) {
+  console.error(`Unsupported platform/arch: ${targetPlatform}/${targetArch}`);
+  process.exit(1);
+}
+
+const extension = targetPlatform === 'win32' ? '.exe' : '';
+const binaryName = `toolbox${extension}`;
+const url = `https://storage.googleapis.com/mcp-toolbox-for-databases/v${version}/${gcsPlatform}/${gcsArch}/${binaryName}`;
+
+// 4. Prepare Output
+const binDir = path.join(process.cwd(), 'bin');
+if (!fs.existsSync(binDir)) {
+  fs.mkdirSync(binDir, { recursive: true });
+}
+const destPath = path.join(binDir, binaryName);
+
+if (fs.existsSync(destPath)) {
+  console.log(`[Skipped] Binary already exists at ${destPath}`);
+  process.exit(0);
+}
+
+console.log(`[Prepack] Downloading ${binaryName} for ${targetPlatform}/${targetArch}...`);
+console.log(`[Source]  ${url}`);
+
+// 5. Download Function
+const file = fs.createWriteStream(destPath);
+https.get(url, function(response) {
+  if (response.statusCode !== 200) {
+    console.error(`Failed to download. Status Code: ${response.statusCode}`);
+    fs.unlink(destPath, () => {}); // Delete partial file
+    process.exit(1);
+  }
+
+  response.pipe(file);
+
+  file.on('finish', () => {
+    file.close(() => {
+      // 6. Make executable (Unix only)
+      if (targetPlatform !== 'win32') {
+        try {
+          execSync(`chmod +x "${destPath}"`);
+        } catch (err) {
+          console.warn("Could not set executable permissions (chmod failed).");
+        }
+      }
+      console.log(`Success! Binary saved to ${destPath}`);
+    });
+  });
+}).on('error', function(err) {
+  fs.unlink(destPath, () => {});
+  console.error(`Download Error: ${err.message}`);
+  process.exit(1);
+});

--- a/npm/server/README.md
+++ b/npm/server/README.md
@@ -72,7 +72,7 @@ To learn more on how to configure your toolbox, visit the [official docsite](htt
 
 The toolbox automatically handles platform-specific binaries. Supported platforms include:
 - macOS (arm64, x64)
-- Linux (x64)
+- Linux (x64, arm64)
 - Windows (x64, arm64)
 
 ## Resources

--- a/npm/server/bin/run.js
+++ b/npm/server/bin/run.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const PLATFORMS = {
   'darwin-arm64': '@toolbox-sdk/server-darwin-arm64',
   'darwin-x64': '@toolbox-sdk/server-darwin-x64',
+  'linux-arm64': '@toolbox-sdk/server-linux-arm64',
   'linux-x64': '@toolbox-sdk/server-linux-x64',
   'win32-arm64': '@toolbox-sdk/server-win32-arm64',
   'win32-x64': '@toolbox-sdk/server-win32-x64'

--- a/npm/server/package-lock.json
+++ b/npm/server/package-lock.json
@@ -14,6 +14,7 @@
       "optionalDependencies": {
         "@toolbox-sdk/server-darwin-arm64": "1.4.0",
         "@toolbox-sdk/server-darwin-x64": "1.4.0",
+        "@toolbox-sdk/server-linux-arm64": "1.4.0",
         "@toolbox-sdk/server-linux-x64": "1.4.0",
         "@toolbox-sdk/server-win32-arm64": "1.4.0",
         "@toolbox-sdk/server-win32-x64": "1.4.0"

--- a/npm/server/package.json
+++ b/npm/server/package.json
@@ -13,6 +13,7 @@
   "optionalDependencies": {
     "@toolbox-sdk/server-darwin-arm64": "1.8.0",
     "@toolbox-sdk/server-darwin-x64": "1.8.0",
+    "@toolbox-sdk/server-linux-arm64": "1.8.0",
     "@toolbox-sdk/server-linux-x64": "1.8.0",
     "@toolbox-sdk/server-win32-arm64": "1.8.0",
     "@toolbox-sdk/server-win32-x64": "1.8.0"

--- a/pypi/setup.py
+++ b/pypi/setup.py
@@ -8,8 +8,8 @@ before running `python -m build`:
      toolbox.exe for Windows wheels). On Unix wheels it must be marked
      executable (chmod +x).
   2. Set TOOLBOX_PLATFORM to the PEP 425 platform tag for the wheel:
-     "manylinux2014_x86_64", "macosx_11_0_arm64", "macosx_10_14_x86_64",
-     "win_amd64", or "win_arm64".
+     "manylinux2014_x86_64", "manylinux2014_aarch64", "macosx_11_0_arm64",
+     "macosx_10_14_x86_64", "win_amd64", or "win_arm64".
 
 The wheel is always tagged py3 / none / <plat> since it ships no Python code
 that depends on a specific interpreter ABI.
@@ -41,7 +41,7 @@ class bdist_wheel(_bdist_wheel):
     def get_tag(self):
         # Override the default "infer the platform tag from the build
         # machine" behavior so one Linux Cloud Build VM can produce wheels
-        # for all 5 platforms by varying TOOLBOX_PLATFORM per invocation.
+        # for all 6 platforms by varying TOOLBOX_PLATFORM per invocation.
         plat = os.environ.get("TOOLBOX_PLATFORM")
         if not plat:
             raise SystemExit(


### PR DESCRIPTION
## Description

Add linux/arm64 to the binary release pipeline, mirroring the existing windows/arm64 support (#3231, #3232). The multi-arch container image already builds linux/arm64; this extends the standalone binary and everything downstream of it:

- Cloud Build (versioned + continuous): build and store linux/arm64 binary and geminicli flavors, cross-compiled with zig (aarch64-linux-gnu), and gate npm/pypi publishes on the new build.
- Release table: add the linux/arm64 row and wait for/link the GPG signature per Linux arch instead of hardcoding amd64.
- npm: new @toolbox-sdk/server-linux-arm64 platform package; register it in the wrapper package's optionalDependencies, lockfile, platform map (bin/run.js), and publish script.
- pypi: build and publish a manylinux2014_aarch64 wheel (including the retry pipeline).
- release-please: bump the new package's version and the wrapper's optionalDependency on release.
- docs: Linux (ARM64) install instructions in README, introduction, and IDE connect pages; include linux/arm64 in quickstart OS lists; update maintainer playbook platform lists and package counts.

## PR Checklist

> Thank you for opening a Pull Request! Before submitting your PR, there are a
> few things you can do to make sure it goes smoothly:

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #2754 
