### PR TITLE
docs: remove v1.1.0 from cloudflare docs

### DIFF
--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -107,10 +107,6 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
   version = "v1.2.0"
   url = "https://mcp-toolbox.dev/v1.2.0/"
 
-[[params.versions]]
-  version = "v1.1.0"
-  url = "https://mcp-toolbox.dev/v1.1.0/"
-
 [[menu.main]]
   name = "GitHub"
   weight = 50


### PR DESCRIPTION
cloudflare exceeding 20k files (which made the v1.8.0 docs deployment fail). 