### PR TITLE
docs(sdks): update MCP default protocol to 2026-07-28 and document URL query parameter preservation

### DIFF
--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
@@ -88,9 +88,13 @@ If you provide your own session, you are responsible for managing its lifecycle;
 Closing the `ToolboxClient` also closes the underlying network session shared by all tools loaded from that client. As a result, any tool instances you have loaded will cease to function and will raise an error if you attempt to invoke them after the client is closed.
 {{< /notice >}}
 
+{{< notice note >}}
+If your connection URL contains query parameters (e.g., `http://localhost:5000?foo=bar`), the client automatically preserves them across API requests for parameter binding.
+{{< /notice >}}
+
 ## Transport Protocols
 
-The SDK supports multiple transport protocols for communicating with the Toolbox server. By default, the client uses the `v2025-06-18` version of the **Model Context Protocol (MCP)**.
+The SDK supports multiple transport protocols for communicating with the Toolbox server. By default, the client uses the `2026-07-28` version of the **Model Context Protocol (MCP)**.
 
 You can explicitly select a protocol using the `core.WithProtocol` option during client initialization. This is useful if you need to pin the client to a specific legacy version of MCP.
 
@@ -104,9 +108,10 @@ We currently support different versions of the MCP protocol. For a complete and 
 
 | Constant | Description |
 | :--- | :--- |
-| `core.MCP` | **(Default)** Alias for the default MCP version (currently `v2025-11-25`). |
-| `core.MCPLatest` | Alias for the latest stable MCP version (currently `v2025-11-25`). |
-| `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `v2026-draft`). |
+| `core.MCP` | **(Default)** Alias for the default MCP version (currently `2026-07-28`). |
+| `core.MCPLatest` | Alias for the latest stable MCP version (currently `2026-07-28`). |
+| `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `2026-07-28`). |
+| `core.MCPv20260728` | MCP Protocol version 2026-07-28. |
 | `core.MCPv20251125` | MCP Protocol version 2025-11-25. |
 | `core.MCPv20250618` | MCP Protocol version 2025-06-18. |
 | `core.MCPv20250326` | MCP Protocol version 2025-03-26. |
@@ -114,7 +119,7 @@ We currently support different versions of the MCP protocol. For a complete and 
 
 ### Example
 
-// Initialize with the default MCP protocol (2025-11-25)
+// Initialize with the default MCP protocol (2026-07-28)
 
 ```go
 import "github.com/googleapis/mcp-toolbox-sdk-go/core"

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
@@ -85,9 +85,13 @@ during initialization (e.g., `tbadk.NewToolboxClient(URL, core.WithHTTPClient(my
 `ToolboxClient` *will not* close it.
 {{< /notice >}}
 
+{{< notice note >}}
+If your connection URL contains query parameters (e.g., `http://localhost:5000?foo=bar`), the client automatically preserves them across API requests for parameter binding.
+{{< /notice >}}
+
 ## Transport Protocols
 
-The SDK supports multiple transport protocols for communicating with the Toolbox server. By default, the client uses the `v2025-06-18` version of the **Model Context Protocol (MCP)**.
+The SDK supports multiple transport protocols for communicating with the Toolbox server. By default, the client uses the `2026-07-28` version of the **Model Context Protocol (MCP)**.
 
 You can explicitly select a protocol using the `core.WithProtocol` option during client initialization. This is useful if you need to pin the client to a specific legacy version of MCP.
 
@@ -101,9 +105,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `core.MCP` | **(Default)** Alias for the default MCP version (currently `v2025-11-25`). |
-| `core.MCPLatest` | Alias for the latest stable MCP version (currently `v2025-11-25`). |
-| `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `v2026-draft`). |
+| `core.MCP` | **(Default)** Alias for the default MCP version (currently `2026-07-28`). |
+| `core.MCPLatest` | Alias for the latest stable MCP version (currently `2026-07-28`). |
+| `core.MCPDraft` | Alias for the upcoming draft MCP version (currently `2026-07-28`). |
+| `core.MCPv20260728` | MCP Protocol version 2026-07-28. |
 | `core.MCPv20251125` | MCP Protocol version 2025-11-25. |
 | `core.MCPv20250618` | MCP Protocol version 2025-06-18. |
 | `core.MCPv20250326` | MCP Protocol version 2025-03-26. |
@@ -117,7 +122,7 @@ import (
     "github.com/googleapis/mcp-toolbox-sdk-go/tbadk"
 )
 
-// Initialize with the default MCP protocol (2025-06-18)
+// Initialize with the default MCP protocol (2026-07-28)
 client, err := tbadk.NewToolboxClient(
     "http://localhost:5000",
 )

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/adk/index.md
@@ -89,14 +89,14 @@ The SDK supports multiple transport protocols to communicate with the Toolbox se
 
 We currently support different versions of the MCP protocol.
 
-- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20251125`).
-- `Protocol.MCP_LATEST`: Alias for the latest stable MCP version (currently aliases to `MCP_v20251125`).
-- `Protocol.MCP_DRAFT`: Alias for the upcoming draft MCP version (currently aliases to `MCP_v2026_DRAFT`).
-- `Protocol.MCP_v2026_DRAFT`: Draft version 2026.
-- `Protocol.MCP_v20241105`: Use this for compatibility with older MCP servers (November 2024 version).
-- `Protocol.MCP_v20250326`: March 2025 version.
-- `Protocol.MCP_v20250618`: June 2025 version.
+- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20260728`).
+- `Protocol.MCP_LATEST`: Alias for the latest stable MCP version (currently aliases to `MCP_v20260728`).
+- `Protocol.MCP_DRAFT`: Alias for the upcoming draft MCP version (currently aliases to `MCP_v20260728`).
+- `Protocol.MCP_v20260728`: July 2026 version (2026-07-28).
 - `Protocol.MCP_v20251125`: November 2025 version.
+- `Protocol.MCP_v20250618`: June 2025 version.
+- `Protocol.MCP_v20250326`: March 2025 version.
+- `Protocol.MCP_v20241105`: Use this for compatibility with older MCP servers (November 2024 version).
 
 ### Specifying a Protocol
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
@@ -81,6 +81,10 @@ Closing the `ToolboxClient` also closes the underlying network session shared by
 For advanced use cases, you can provide an external `AxiosInstance` during initialization (e.g., `ToolboxClient(url, my_session)`).
 {{< /notice >}}
 
+{{< notice note >}}
+If your connection URL contains query parameters (e.g., `http://localhost:5000?foo=bar`), the client automatically preserves them across API requests for parameter binding.
+{{< /notice >}}
+
 ## Transport Protocols
 
 The SDK supports multiple transport protocols to communicate with the Toolbox server. You can specify the protocol version during client initialization.
@@ -90,14 +94,14 @@ The SDK supports multiple transport protocols to communicate with the Toolbox se
 We currently support different versions of the MCP protocol. For a complete and up-to-date list, see the [`Protocol` enum definition on GitHub](https://github.com/googleapis/mcp-toolbox-sdk-js/blob/main/packages/toolbox-core/src/toolbox_core/protocol.ts).
 
 
-- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20251125`).
-- `Protocol.MCP_LATEST`: Alias for the latest stable MCP version (currently aliases to `MCP_v20251125`).
-- `Protocol.MCP_DRAFT`: Alias for the upcoming draft MCP version (currently aliases to `MCP_v2026_DRAFT`).
-- `Protocol.MCP_v2026_DRAFT`: Draft version 2026.
-- `Protocol.MCP_v20241105`: Use this for compatibility with older MCP servers (November 2024 version).
-- `Protocol.MCP_v20250326`: March 2025 version.
-- `Protocol.MCP_v20250618`: June 2025 version.
+- `Protocol.MCP`: The default protocol version (currently aliases to `MCP_v20260728`).
+- `Protocol.MCP_LATEST`: Alias for the latest stable MCP version (currently aliases to `MCP_v20260728`).
+- `Protocol.MCP_DRAFT`: Alias for the upcoming draft MCP version (currently aliases to `MCP_v20260728`).
+- `Protocol.MCP_v20260728`: July 2026 version (2026-07-28).
 - `Protocol.MCP_v20251125`: November 2025 version.
+- `Protocol.MCP_v20250618`: June 2025 version.
+- `Protocol.MCP_v20250326`: March 2025 version.
+- `Protocol.MCP_v20241105`: Use this for compatibility with older MCP servers (November 2024 version).
 
 ### Specifying a Protocol
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
@@ -53,10 +53,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
-| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_v20260728` | MCP Protocol version 2026-07-28. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
 | `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
@@ -87,6 +87,10 @@ For advanced use cases, you can provide an external `aiohttp.ClientSession` duri
 Closing the `ToolboxClient` also closes the underlying network session shared by all tools loaded from that client. As a result, any tool instances you have loaded will cease to function and will raise an error if you attempt to invoke them after the client is closed.
 {{< /notice >}}
 
+{{< notice note >}}
+If your connection URL contains query parameters (e.g., `http://localhost:5000?foo=bar`), the client automatically preserves them across API requests for parameter binding.
+{{< /notice >}}
+
 ## Transport Protocols
 
 The SDK supports multiple transport protocols for communicating with the Toolbox server. By default, the client uses the latest supported version of the **Model Context Protocol (MCP)**.
@@ -103,10 +107,10 @@ We currently support different versions of the MCP protocol. For a complete and 
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
-| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_v20260728` | MCP Protocol version 2026-07-28. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
 | `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/langchain/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/langchain/index.md
@@ -71,10 +71,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
-| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_v20260728` | MCP Protocol version 2026-07-28. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
 | `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/llamaindex/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/llamaindex/index.md
@@ -79,10 +79,10 @@ We currently support different versions of the MCP protocol.
 
 | Constant | Description |
 | :--- | :--- |
-| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2025-11-25`). |
-| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `DRAFT-2026-v1`). |
-| `Protocol.MCP_v2026_DRAFT` | MCP Protocol draft version DRAFT-2026-v1. |
+| `Protocol.MCP` | **(Default)** Alias for the default MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_LATEST` | Alias for the latest stable MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_DRAFT` | Alias for the upcoming draft MCP version (currently `2026-07-28`). |
+| `Protocol.MCP_v20260728` | MCP Protocol version 2026-07-28. |
 | `Protocol.MCP_v20251125` | MCP Protocol version 2025-11-25. |
 | `Protocol.MCP_v20250618` | MCP Protocol version 2025-06-18. |
 | `Protocol.MCP_v20250326` | MCP Protocol version 2025-03-26. |


### PR DESCRIPTION
## Overview

This PR updates the documentation across all Toolbox SDKs (Go, JavaScript, and Python) to reflect the new `2026-07-28` default MCP protocol version and adds documentation for URL Query Parameter Preservation.

## Changes

- Updated `Protocol.MCP`, `Protocol.MCP_LATEST`, and `Protocol.MCP_DRAFT` (along with Go equivalents `core.MCP`, `core.MCPLatest`, `core.MCPDraft`) across all SDK documentation to target the `2026-07-28` (`MCP_v20260728` / `core.MCPv20260728`) release.
- Synchronized protocol enumeration tables and code initialization comments across Python, JavaScript, and Go SDK documentation pages.
- Added tip notice blocks in core SDK documentation (JS Core, Python Core, Go TBADK) clarifying that connection URLs with query parameters (e.g., `http://localhost:5000?toolset=my_group`) automatically retain those parameters across API calls for toolset and group binding.
