### PR TITLE
refactor: remove GetEmbeddingModelMap

### DIFF
--- a/cmd/internal/invoke/command.go
+++ b/cmd/internal/invoke/command.go
@@ -128,7 +128,7 @@ func runInvoke(cmd *cobra.Command, args []string, opts *internal.ToolboxOptions)
 		return errMsg
 	}
 
-	parsedParams, err = tool.EmbedParams(ctx, parsedParams, primitiveMgr.GetEmbeddingModelMap())
+	parsedParams, err = tool.EmbedParams(ctx, parsedParams, primitiveMgr)
 	if err != nil {
 		errMsg := fmt.Errorf("error embedding parameters: %w", err)
 		opts.Logger.ErrorContext(ctx, errMsg.Error())

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -299,7 +299,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	}
 	s.logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
 
-	params, err = tool.EmbedParams(ctx, params, s.PrimitiveMgr.GetEmbeddingModelMap())
+	params, err = tool.EmbedParams(ctx, params, s.PrimitiveMgr)
 	if err != nil {
 		err = fmt.Errorf("error embedding parameters: %w", err)
 		s.logger.DebugContext(ctx, err.Error())

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -313,8 +313,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, g group.Group, 
 	}
 	logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
 
-	embeddingModels := primitiveMgr.GetEmbeddingModelMap()
-	params, err = tool.EmbedParams(ctx, params, embeddingModels)
+	params, err = tool.EmbedParams(ctx, params, primitiveMgr)
 	if err != nil {
 		err = fmt.Errorf("error embedding parameters: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -313,8 +313,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, g group.Group, 
 	}
 	logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
 
-	embeddingModels := primitiveMgr.GetEmbeddingModelMap()
-	params, err = tool.EmbedParams(ctx, params, embeddingModels)
+	params, err = tool.EmbedParams(ctx, params, primitiveMgr)
 	if err != nil {
 		err = fmt.Errorf("error embedding parameters: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -312,8 +312,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, g group.Group, 
 	}
 	logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
 
-	embeddingModels := primitiveMgr.GetEmbeddingModelMap()
-	params, err = tool.EmbedParams(ctx, params, embeddingModels)
+	params, err = tool.EmbedParams(ctx, params, primitiveMgr)
 	if err != nil {
 		err = fmt.Errorf("error embedding parameters: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -312,8 +312,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, g group.Group, 
 	}
 	logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
 
-	embeddingModels := primitiveMgr.GetEmbeddingModelMap()
-	params, err = tool.EmbedParams(ctx, params, embeddingModels)
+	params, err = tool.EmbedParams(ctx, params, primitiveMgr)
 	if err != nil {
 		err = fmt.Errorf("error embedding parameters: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err

--- a/internal/server/mcp/v20260728/method.go
+++ b/internal/server/mcp/v20260728/method.go
@@ -432,8 +432,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, g group.Group, 
 	}
 	logger.DebugContext(ctx, fmt.Sprintf("invocation params: %s", params))
 
-	embeddingModels := primitiveMgr.GetEmbeddingModelMap()
-	params, err = tool.EmbedParams(ctx, params, embeddingModels)
+	params, err = tool.EmbedParams(ctx, params, primitiveMgr)
 	if err != nil {
 		err = fmt.Errorf("error embedding parameters: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err

--- a/internal/server/primitives/primitives.go
+++ b/internal/server/primitives/primitives.go
@@ -126,16 +126,6 @@ func (r *PrimitiveManager) GetAuthServiceMap() map[string]auth.AuthService {
 	return copiedMap
 }
 
-func (r *PrimitiveManager) GetEmbeddingModelMap() map[string]embeddingmodels.EmbeddingModel {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	copiedMap := make(map[string]embeddingmodels.EmbeddingModel, len(r.embeddingModels))
-	for k, v := range r.embeddingModels {
-		copiedMap[k] = v
-	}
-	return copiedMap
-}
-
 // GroupsList returns a copy of the groups list sorted alphabetically by name
 func (r *PrimitiveManager) GroupsList() []group.Group {
 	r.mu.RLock()

--- a/internal/tools/arcadedb/arcadedbexecutecypher/arcadedbexecutecypher.go
+++ b/internal/tools/arcadedb/arcadedbexecutecypher/arcadedbexecutecypher.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -135,8 +134,8 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	return resp, nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, nil)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, nil)
 }
 
 func (t Tool) GetSourceName() string {

--- a/internal/tools/arcadedb/arcadedbexecutesql/arcadedbexecutesql.go
+++ b/internal/tools/arcadedb/arcadedbexecutesql/arcadedbexecutesql.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -138,8 +137,8 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	return resp, nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, nil)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, nil)
 }
 
 func (t Tool) GetSourceName() string {

--- a/internal/tools/bigquery/bigquerysql/bigquerysql.go
+++ b/internal/tools/bigquery/bigquerysql/bigquerysql.go
@@ -24,7 +24,6 @@ import (
 
 	bigqueryapi "cloud.google.com/go/bigquery"
 	yaml "github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	bigqueryds "github.com/googleapis/mcp-toolbox/internal/sources/bigquery"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -318,8 +317,8 @@ func formatVectorForBigQuery(vectorFloats []float32) any {
 	return res
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, formatVectorForBigQuery)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, formatVectorForBigQuery)
 }
 
 func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {

--- a/internal/tools/clickhouse/clickhousesql/clickhousesql.go
+++ b/internal/tools/clickhouse/clickhousesql/clickhousesql.go
@@ -128,6 +128,6 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	return resp, nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForClickHouse)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, embeddingmodels.FormatVectorForClickHouse)
 }

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -143,6 +142,6 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	return nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
 	return paramValues, nil
 }

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -131,6 +130,6 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	return nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
 	return paramValues, nil
 }

--- a/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	cla "github.com/googleapis/mcp-toolbox/internal/sources/cloudloggingadmin"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -201,6 +200,6 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	return nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
 	return paramValues, nil
 }

--- a/internal/tools/looker/lookergetconnections/lookergetconnections.go
+++ b/internal/tools/looker/lookergetconnections/lookergetconnections.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -154,7 +153,7 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	return data, nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
 	return parameters.ParamValues{}, nil
 }
 

--- a/internal/tools/looker/lookergetmodels/lookergetmodels.go
+++ b/internal/tools/looker/lookergetmodels/lookergetmodels.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -109,7 +108,7 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	return nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
 	return parameters.ParamValues{}, nil
 }
 

--- a/internal/tools/looker/lookergetprojects/lookergetprojects.go
+++ b/internal/tools/looker/lookergetprojects/lookergetprojects.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -108,7 +107,7 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	return nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
 	return parameters.ParamValues{}, nil
 }
 

--- a/internal/tools/postgres/postgressql/postgressql.go
+++ b/internal/tools/postgres/postgressql/postgressql.go
@@ -113,8 +113,8 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	return resp, nil
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForPgvector)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, embeddingmodels.FormatVectorForPgvector)
 }
 
 func (t Tool) GetSourceName() string {

--- a/internal/tools/serverlessspark/createbatch/tool.go
+++ b/internal/tools/serverlessspark/createbatch/tool.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	dataprocpb "cloud.google.com/go/dataproc/v2/apiv1/dataprocpb"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -112,8 +111,8 @@ func (t *Tool) ToConfig() tools.ToolConfig {
 	return t.originalConfig
 }
 
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	newParamValues, err := parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, nil)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	newParamValues, err := parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, nil)
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error embedding parameters: %v", err), http.StatusInternalServerError, err)
 	}

--- a/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
+++ b/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
@@ -119,8 +119,8 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 }
 
 // EmbedParams overrides BaseTool to apply the pgvector formatter.
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForPgvector)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, embeddingmodels.FormatVectorForPgvector)
 }
 
 func (t Tool) GetSourceName() string {

--- a/internal/tools/singlestore/singlestoresql/singlestoresql.go
+++ b/internal/tools/singlestore/singlestoresql/singlestoresql.go
@@ -138,8 +138,8 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 }
 
 // EmbedParams overrides BaseTool to apply the pgvector formatter.
-func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForPgvector)
+func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr tools.PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, pMgr, embeddingmodels.FormatVectorForPgvector)
 }
 
 func (t Tool) GetSourceName() string {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -129,7 +129,7 @@ type Tool interface {
 	GetAuthRequired() []string
 	GetAnnotations() *ToolAnnotations
 	Invoke(context.Context, sources.Source, parameters.ParamValues, AccessToken) (any, util.ToolboxError)
-	EmbedParams(context.Context, parameters.ParamValues, map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error)
+	EmbedParams(context.Context, parameters.ParamValues, PrimitiveManagerI) (parameters.ParamValues, error)
 	Manifest(sources.Source) (Manifest, error)
 	StaticManifest() Manifest
 	Authorized([]string) bool
@@ -141,11 +141,12 @@ type Tool interface {
 	ValidateSource(sources.Source) error
 }
 
-// SourceManager defines the minimal view of the primitives.PrimitiveManager
+// PrimitiveManagerI defines the minimal view of the primitives.PrimitiveManager
 // that the Tool package needs.
 // This is implemented to prevent import cycles.
-type SourceManager interface {
-	GetSource(sourceName string) (sources.Source, bool)
+type PrimitiveManagerI interface {
+	GetSource(string) (sources.Source, bool)
+	GetEmbeddingModel(string) (embeddingmodels.EmbeddingModel, bool)
 }
 
 // Manifest is the representation of tools sent to Client SDKs.
@@ -254,6 +255,6 @@ func (b BaseTool[T]) GetAuthTokenHeaderName(_ sources.Source) (string, error) {
 	return "Authorization", nil
 }
 
-func (b BaseTool[T]) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
-	return parameters.EmbedParams(ctx, b.StaticParameters, paramValues, embeddingModelsMap, nil)
+func (b BaseTool[T]) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr PrimitiveManagerI) (parameters.ParamValues, error) {
+	return parameters.EmbedParams(ctx, b.StaticParameters, paramValues, pMgr, nil)
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
@@ -134,8 +134,9 @@ func TestBaseToolEmbedParamsPassthrough(t *testing.T) {
 		tools.Manifest{},
 		parameters.Parameters{parameters.NewStringParameter("p1", "first")},
 	)
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, nil, nil)
 	values := parameters.ParamValues{{Name: "p1", Value: "hello"}}
-	got, err := b.EmbedParams(context.Background(), values, map[string]embeddingmodels.EmbeddingModel{})
+	got, err := b.EmbedParams(context.Background(), values, pMgr)
 	if err != nil {
 		t.Fatalf("EmbedParams() error = %v", err)
 	}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
@@ -134,9 +133,8 @@ func TestBaseToolEmbedParamsPassthrough(t *testing.T) {
 		tools.Manifest{},
 		parameters.Parameters{parameters.NewStringParameter("p1", "first")},
 	)
-	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, nil, nil)
 	values := parameters.ParamValues{{Name: "p1", Value: "hello"}}
-	got, err := b.EmbedParams(context.Background(), values, pMgr)
+	got, err := b.EmbedParams(context.Background(), values, nil)
 	if err != nil {
 		t.Fatalf("EmbedParams() error = %v", err)
 	}

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -60,14 +60,14 @@ type ToolsetManifest struct {
 
 // BuildManifest resolves the manifest for every tool in the toolset against the
 // provided sources, returning an error if any tool's manifest cannot be built.
-func (t Toolset) BuildManifest(srcMgr SourceManager) (ToolsetManifest, error) {
+func (t Toolset) BuildManifest(pMgr PrimitiveManagerI) (ToolsetManifest, error) {
 	toolsManifest := make(map[string]Manifest, len(t.Tools))
 	for _, tool := range t.Tools {
 		srcName := (*tool).GetSourceName()
 		var src sources.Source
 		var ok bool
 		if srcName != "" {
-			src, ok = srcMgr.GetSource(srcName)
+			src, ok = pMgr.GetSource(srcName)
 			if !ok {
 				return ToolsetManifest{}, fmt.Errorf("unable to retrieve %s source for tool %q", srcName, (*tool).GetName())
 			}

--- a/internal/util/parameters/parameters.go
+++ b/internal/util/parameters/parameters.go
@@ -169,7 +169,12 @@ func ParseParams(ps Parameters, data map[string]any, claimsMap map[string]map[st
 	return params, nil
 }
 
-func EmbedParams(ctx context.Context, ps Parameters, paramValues ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel, formatter embeddingmodels.VectorFormatter) (ParamValues, error) {
+// PrimitiveManagerI defines the minimal view of the primitive manager needed by parameters.
+type PrimitiveManagerI interface {
+	GetEmbeddingModel(string) (embeddingmodels.EmbeddingModel, bool)
+}
+
+func EmbedParams(ctx context.Context, ps Parameters, paramValues ParamValues, pMgr PrimitiveManagerI, formatter embeddingmodels.VectorFormatter) (ParamValues, error) {
 
 	type ParamToEmbed struct {
 		OriginalValue string
@@ -199,7 +204,7 @@ func EmbedParams(ctx context.Context, ps Parameters, paramValues ParamValues, em
 
 	// Batch embedding request sent to each model
 	for modelName, params := range parametersToEmbed {
-		model, ok := embeddingModelsMap[modelName]
+		model, ok := pMgr.GetEmbeddingModel(modelName)
 		if !ok {
 			return nil, fmt.Errorf("embedding model does not exist: %s", modelName)
 		}


### PR DESCRIPTION
This PR removes the `GetEmbeddingModelMap`. With this, we parse the primitiveManager to EmbedParams and call the specified embedding model when needed.