### PR TITLE
docs(embedding): add description field to vector ingestion sample tool

### DIFF
--- a/docs/en/documentation/configuration/embedding-models/_index.md
+++ b/docs/en/documentation/configuration/embedding-models/_index.md
@@ -83,6 +83,7 @@ parameters:
     description: The raw text content to be stored in the database.
   - name: vector_string
     type: string
+    description: A hidden parameter holding a copy of 'content' to be embedded as a vector.
     # This parameter is hidden from the LLM.
     # It automatically copies the value from 'content' and embeds it.
     valueFromParam: content


### PR DESCRIPTION
## Description

Adds a description field to the `vector_string` parameter in the sample vector ingestion tool (`insert_embedding`). 

Previously, using this sample tool without the description field causes Toolbox to crash with an "unable to parse config file" error. Even though `vector_string` is a hidden parameter, the current Toolbox YAML parser seems to require a description field for all CommonParameters. 